### PR TITLE
cr3qt: changing to page view mode always scrolls to the last page fix

### DIFF
--- a/cr3qt/src/cr3widget.cpp
+++ b/cr3qt/src/cr3widget.cpp
@@ -662,6 +662,10 @@ void CR3View::updateScroll()
         // TODO: set scroll range
         const LVScrollInfo * si = _docview->getScrollInfo();
         //bool changed = false;
+
+        // change value before max scroll to avoid a ValueChange event
+        if ( _scroll->value() > si->maxpos )
+            _scroll->setValue( si->pos );
         if ( si->maxpos != _scroll->maximum() ) {
             _scroll->setMaximum( si->maxpos );
             _scroll->setMinimum(0);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3140,6 +3140,7 @@ void LVDocView::setViewMode(LVDocViewMode view_mode, int visiblePageCount) {
 		m_pagesVisible = visiblePageCount;
         m_props->setInt(PROP_LANDSCAPE_PAGES, m_pagesVisible);
     }
+    updateLayout();
     REQUEST_RENDER("setViewMode")
     _posIsSet = false;
 


### PR DESCRIPTION
when going from scroll view to page view, it always jumps to the last page,
that's caused by a ValueChange event generated by qt when setting a new maximum
scroll value that is smaller than the scrollbar's current value.