### PR TITLE
Fix create user local cr3.ini

### DIFF
--- a/cr3qt/src/mainwindow.cpp
+++ b/cr3qt/src/mainwindow.cpp
@@ -100,8 +100,13 @@ MainWindow::MainWindow(QWidget *parent)
 
     ldomDocCache::init( qt2cr( cacheDir ), DOC_CACHE_SIZE );
     ui->view->setPropsChangeCallback( this );
+    bool settingsExists = false;
     if ( !ui->view->loadSettings( iniFile ) )
-        ui->view->loadSettings( iniFile2 );
+        settingsExists = ui->view->loadSettings( iniFile2 );
+    //Detect even place for future save settings
+    if(!settingsExists)
+        if ( !ui->view->saveSettings( iniFile2) )
+            ui->view->saveSettings( iniFile );
     if ( !ui->view->loadHistory( histFile ) )
         ui->view->loadHistory( histFile2 );
     if ( !ui->view->loadCSS( cssFile ) )


### PR DESCRIPTION
On the Linux OS after install app cr3.ini does not exist. App trying to read user local ini (/home/<user>/.cr3/cr3.ini) then system level ini (/usr/share/cr3/cr3.ini). The last one cached and on save settings used cached value. When system level ini is not writable the app lost settings at the exit.
Fix store in the cache only writable ini name