### PR TITLE
[GRADLE] Allow android project to be imported and built in Android Studio 3.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,53 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.1.1'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+        google()
+    }
+}
+
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 22
+    buildToolsVersion "27.0.3"
+
+    defaultConfig {
+        applicationId "org.coolreader"
+        minSdkVersion 3
+        targetSdkVersion 17
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+        }
+    }
+    externalNativeBuild {
+        ndkBuild {
+            path 'jni/Android.mk'
+        }
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['res']
+            aidl.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+    }
+}

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -30,6 +30,8 @@ LOCAL_CFLAGS += $(CRFLAGS) $(CRENGINE_INCLUDES) -Wno-psabi -Wno-unused-variable 
 
 LOCAL_CFLAGS += -funwind-tables -Wl,--no-merge-exidx-entries
 
+# Necessary for building cr3engine.cpp in Android Studio 3.1.1
+LOCAL_CFLAGS += -fexceptions
 
 CRENGINE_SRC_FILES := \
     ../../crengine/src/cp_stats.cpp \


### PR DESCRIPTION
Add  android/build.gradle
Add -fexceptions to LOCAL_CFLAGS in android/jni/Android.mk to fix JNI build failure in Android Studio 3.1.1