### PR TITLE
Fix various bugs and errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ wxbuild
 qtbuild
 qt-build
 qtcreator-build
+CMakeLists.txt.user
 *~

--- a/cr3qt/src/settings.cpp
+++ b/cr3qt/src/settings.cpp
@@ -114,14 +114,14 @@ SettingsDlg::SettingsDlg(QWidget *parent, CR3View * docView ) :
         lString16 fn = bgFiles[i];
         QString f = cr2qt(fn);
         if ( f==bgFile )
-            bgIndex = i;
+            bgIndex = i + 1;
         m_backgroundFiles.append(f);
         fn = LVExtractFilenameWithoutExtension(fn);
         bgFileLabels.append(cr2qt(fn));
     }
     m_ui->cbPageSkin->clear();
     m_ui->cbPageSkin->addItems( bgFileLabels );
-    m_ui->cbPageSkin->setCurrentIndex(bgIndex+1);
+    m_ui->cbPageSkin->setCurrentIndex( bgIndex );
 
     optionToUi( PROP_WINDOW_FULLSCREEN, m_ui->cbWindowFullscreen );
     optionToUi( PROP_WINDOW_SHOW_MENU, m_ui->cbWindowShowMenu );

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -605,7 +605,7 @@ public:
     /// set list of icons to display at left side of header
     void setHeaderIcons( LVRefVec<LVImageSource> icons );
     /// set list of battery icons to display battery state
-    void setBatteryIcons( LVRefVec<LVImageSource> & icons );
+    void setBatteryIcons( const LVRefVec<LVImageSource> & icons );
     /// sets page margins
     void setPageMargins(lvRect rc);
     /// update page margins based on current settings

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1569,7 +1569,7 @@ bool LVDocView::setBatteryState(int newState) {
 }
 
 /// set list of battery icons to display battery state
-void LVDocView::setBatteryIcons(LVRefVec<LVImageSource> & icons) {
+void LVDocView::setBatteryIcons(const LVRefVec<LVImageSource> & icons) {
 	m_batteryIcons = icons;
 }
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -967,6 +967,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
             for (;;)
             {
                 node = node->getParentNode();
+                if (!node) return false;
                 if (node->isNull())
                     return false;
                 if (node->getNodeId() == _id)


### PR DESCRIPTION
1. Fix bug with wrong value in the "Page Skin" combo box ("Settings => Style" dialog).
Steps to reproduce:
1.1. Run new and clear instance of the Cool Reader, go to the "Settings => Style => Page Skin".
1.2. It shows bg_paperX (instead of [NONE]).
1.3. Choose second (after [NONE]) page skin, click "OK".
1.4. Nothing will change.

2. Fix compilation error on the new GCC versions:
```
/home/exl/Projects/GIT/coolreader/cr3qt/src/cr3widget.cpp: In constructor ‘CR3View::CR3View(QWidget*)’:
/home/exl/Projects/GIT/coolreader/cr3qt/src/cr3widget.cpp:325:47: error: cannot bind non-const lvalue reference of type ‘LVRefVec<LVImageSource>&’ to an rvalue of type ‘LVRefVec<LVImageSource>’
     _docview->setBatteryIcons( getBatteryIcons(0x000000) );
                                ~~~~~~~~~~~~~~~^~~~~~~~~~
In file included from /home/exl/Projects/GIT/coolreader/cr3qt/src/cr3widget.cpp:1:0:
/home/exl/Projects/GIT/coolreader/tinydict/../crengine/include/lvdocview.h:608:10: note:   initializing argument 1 of ‘void LVDocView::setBatteryIcons(LVRefVec<LVImageSource>&)’
     void setBatteryIcons( LVRefVec<LVImageSource> & icons );
          ^~~~~~~~~~~~~~~
```

3. Fix Segmentation fault in the Release build:
```
$ gdb ./cr3 
GNU gdb (GDB) 8.1
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./cr3...(no debugging symbols found)...done.
(gdb) r
Starting program: /home/exl/Projects/GIT/coolreader/qtbuild/cr3qt/cr3 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
2018/05/03 11:32:41.5931 WARN Changing log level from 3 to 1
642 fonts loaded.
2018/05/03 11:32:41.8991 ERROR Canot load translation file cr3_en_US from dir /usr/share/cr3/i18n/
2018/05/03 11:32:41.9328 ERROR Loading settings from file /home/exl/.cr3/cr3.ini

Program received signal SIGSEGV, Segmentation fault.
0x000055555567bc28 in LVStyleSheet::apply(ldomNode const*, css_style_rec_tag*) ()
(gdb) bt full
#0  0x000055555567bc28 in LVStyleSheet::apply(ldomNode const*, css_style_rec_tag*) ()
#1  0x00005555556d2d23 in setNodeStyle(ldomNode*, LVFastRef<css_style_rec_tag>, LVProtectedFastRef<LVFont>) ()
#2  0x0000555555640954 in ldomNode::initNodeStyle() ()
#3  0x0000555555640e50 in updateStyleDataRecursive(ldomNode*) ()
#4  0x0000555555640ef0 in updateStyleDataRecursive(ldomNode*) ()
#5  0x0000555555640ef0 in updateStyleDataRecursive(ldomNode*) ()
#6  0x0000555555640ef0 in updateStyleDataRecursive(ldomNode*) ()
#7  0x0000555555646771 in ldomDocument::render(LVRendPageList*, LVDocViewCallback*, int, int, bool, int, LVProtectedFastRef<LVFont>, int, LVFastRef<CRPropAccessor>) ()
#8  0x00005555556ae862 in LVDocView::Render(int, int, LVRendPageList*) ()
#9  0x00005555556aea50 in LVDocView::checkRender() ()
#10 0x00005555556b2fa6 in LVDocView::updateBookMarksRanges() ()
#11 0x00005555556c7815 in LVDocView::propsApply(LVFastRef<CRPropAccessor>) ()
#12 0x00005555555ce64e in CR3View::loadSettings(QString) ()
#13 0x00005555555da585 in MainWindow::MainWindow(QWidget*) ()
#14 0x00005555555b928c in main ()
```