### PR TITLE
Replace deprecated qt5_use_modules macro

### DIFF
--- a/cr3qt/CMakeLists.txt
+++ b/cr3qt/CMakeLists.txt
@@ -151,7 +151,7 @@ ADD_EXECUTABLE(cr3 ${CR3_MAN_PAGES} ${CR3_CHANGELOG} ${CR3_SOURCES} ${CR3_RCS} $
 endif (WIN32)
 
 if( NOT ${GUI} STREQUAL QT )
-  qt5_use_modules(cr3 Widgets)
+  target_link_libraries(cr3 Qt5::Widgets)
   SET(QTVER ${Qt5Widgets_VERSION})
 else()
   SET(QTVER "${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.${QT_VERSION_PATCH}")


### PR DESCRIPTION
Replace deprecated qt5_use_modules() with target_link_libraries().

> qt5_use_modules(target [LINK_PUBLIC|LINK_PRIVATE] module ... )
> ...
> This macro is obsolete. Use target_link_libraries with IMPORTED targets instead.

References: 
[1] https://doc.qt.io/qt-5.6/cmake-manual.html
[2] https://doc.qt.io/qt-5.10/cmake-manual.html