### PR TITLE
multiple APKs for ABIs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,8 @@ android {
         applicationId "org.coolreader"
         minSdkVersion 3
         targetSdkVersion 21
+        // When new version released, version code must be incremented at least by 8
+        // for compatibility with ABI versioning of split apk (see below).
         versionCode 2001
         versionName "3.2.2-1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -63,6 +65,37 @@ android {
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
             options.compilerArgs << "-Xlint:unchecked"
+        }
+    }
+    // https://developer.android.com/studio/build/configure-apk-splits
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a' //select ABIs to build APKs for
+            universalApk true //generate an additional APK that contains all the ABIs
+        }
+    }
+     // map for the version code
+    project.ext.abiCodes = [
+            'armeabi': 1,
+            'armeabi-v7a': 2,
+            'arm64-v8a': 6,
+            'mips': 3,
+            'mips64': 7,
+            'x86': 4,
+            'x86_64': 5
+    ]
+    android.applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // Stores the value of ext.abiCodes that is associated with the ABI for this variant.
+            def baseAbiVersionCode = project.ext.abiCodes.get(output.getFilter(com.android.build.OutputFile.ABI))
+            if (baseAbiVersionCode != null) {
+                // Variant 1: small version code increment for various ABI (old behaviour)
+                output.versionCodeOverride = variant.versionCode + baseAbiVersionCode
+                // Variant 2: big version code increment for various ABI
+                //output.versionCodeOverride = variant.versionCode + 1000000*baseAbiVersionCode
+            }
         }
     }
     externalNativeBuild {


### PR DESCRIPTION
[GRADLE] cr3android/app/build.gradle: Add split section to shrink apks.
https://developer.android.com/studio/build/configure-apk-splits
Modified by virxkane to use in new project structure.
Thanks to @S-trace.