### PR TITLE
Recognition of Tolino Vision as E-Ink device and suppress PageUp event for its backlight btn

### DIFF
--- a/android/src/org/coolreader/crengine/BaseActivity.java
+++ b/android/src/org/coolreader/crengine/BaseActivity.java
@@ -1357,7 +1357,9 @@ public class BaseActivity extends Activity implements Settings {
 			
 			new DefKeyAction(ReaderView.NOOK_KEY_NEXT_RIGHT, ReaderAction.NORMAL, ReaderAction.PAGE_DOWN),
 			new DefKeyAction(ReaderView.NOOK_KEY_SHIFT_DOWN, ReaderAction.NORMAL, ReaderAction.PAGE_DOWN),
-			new DefKeyAction(ReaderView.NOOK_KEY_PREV_LEFT, ReaderAction.NORMAL, ReaderAction.PAGE_UP),
+
+			new DefKeyAction(ReaderView.NOOK_KEY_PREV_LEFT, ReaderAction.NORMAL, (!DeviceInfo.EINK_TOLINO ? ReaderAction.PAGE_UP : ReaderAction.NONE)), // TOLINO backlight button  !
+
 			new DefKeyAction(ReaderView.NOOK_KEY_PREV_RIGHT, ReaderAction.NORMAL, ReaderAction.PAGE_UP),
 			new DefKeyAction(ReaderView.NOOK_KEY_SHIFT_UP, ReaderAction.NORMAL, ReaderAction.PAGE_UP),
 
@@ -1385,7 +1387,7 @@ public class BaseActivity extends Activity implements Settings {
 			
 			new DefKeyAction(ReaderView.KEYCODE_ESCAPE, ReaderAction.NORMAL, ReaderAction.PAGE_DOWN),
 			new DefKeyAction(ReaderView.KEYCODE_ESCAPE, ReaderAction.LONG, ReaderAction.REPEAT),
-			
+
 //		    public static final int KEYCODE_PAGE_BOTTOMLEFT = 0x5d; // fwd
 //		    public static final int KEYCODE_PAGE_BOTTOMRIGHT = 0x5f; // fwd
 //		    public static final int KEYCODE_PAGE_TOPLEFT = 0x5c; // back

--- a/android/src/org/coolreader/crengine/DeviceInfo.java
+++ b/android/src/org/coolreader/crengine/DeviceInfo.java
@@ -116,9 +116,11 @@ public class DeviceInfo {
 				|| MODEL.startsWith("I63MLP");
 		//MANUFACTURER -DNS, DEVICE -BK6004C, MODEL - DNS Airbook EGH602, PRODUCT - BK6004C
 		EINK_DNS = MANUFACTURER.toLowerCase().contentEquals("dns") && MODEL.startsWith("DNS Airbook EGH");
-		EINK_TOLINO = BRAND.toLowerCase().contentEquals("tolino") && (
-					MODEL.toLowerCase().contentEquals("imx50_rdp") // SHINE
-				);
+
+		EINK_TOLINO = (BRAND.toLowerCase().contentEquals("tolino") && (MODEL.toLowerCase().contentEquals("imx50_rdp")) ) || 		// SHINE
+						DEVICE.toLowerCase().contentEquals("tolino_vision2"); //Tolino Vision HD4 doesn't show any Brand, and DEVICE=tolino_vision2)
+
+
 		EINK_SCREEN = EINK_SONY || EINK_NOOK || EINK_ONYX || EINK_DNS || EINK_TOLINO; // TODO: set to true for eink devices like Nook Touch
 
 		POCKETBOOK = MODEL.toLowerCase().startsWith("pocketbook") || MODEL.toLowerCase().startsWith("obreey");

--- a/android/src/org/coolreader/crengine/DeviceInfo.java
+++ b/android/src/org/coolreader/crengine/DeviceInfo.java
@@ -118,7 +118,7 @@ public class DeviceInfo {
 		EINK_DNS = MANUFACTURER.toLowerCase().contentEquals("dns") && MODEL.startsWith("DNS Airbook EGH");
 
 		EINK_TOLINO = (BRAND.toLowerCase().contentEquals("tolino") && (MODEL.toLowerCase().contentEquals("imx50_rdp")) ) || 		// SHINE
-						DEVICE.toLowerCase().contentEquals("tolino_vision2"); //Tolino Vision HD4 doesn't show any Brand, and DEVICE=tolino_vision2)
+				(MODEL.toLowerCase().contentEquals("tolino") && DEVICE.toLowerCase().contentEquals("tolino_vision2")); //Tolino Vision HD4 doesn't show any Brand, only Model=tolino and  DEVICE=tolino_vision2)
 
 
 		EINK_SCREEN = EINK_SONY || EINK_NOOK || EINK_ONYX || EINK_DNS || EINK_TOLINO; // TODO: set to true for eink devices like Nook Touch

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -43,7 +43,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 
 	public static final Logger log = L.create("rv", Log.VERBOSE);
 	public static final Logger alog = L.create("ra", Log.WARN);
-	
+
 	private final SurfaceView surface;
 	private final BookView bookView;
 	public SurfaceView getSurface() { return surface; }
@@ -4597,7 +4597,6 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		int profileNumber;
 		boolean disableInternalStyles;
 		boolean disableTextAutoformat;
-		Properties props;
 		LoadDocumentTask(BookInfo bookInfo, Runnable errorHandler)
 		{
 			BackgroundThread.ensureGUI();
@@ -4644,17 +4643,16 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	        // close existing document
 			log.v("LoadDocumentTask : closing current book");
 	        close();
-	        if (props != null) {
-		        setAppSettings(props, oldSettings);
-	    		BackgroundThread.instance().postBackground(new Runnable() {
-	    			@Override
-	    			public void run() {
-	    				log.v("LoadDocumentTask : switching current profile");
-	    				applySettings(props);
-	    				log.i("Switching done");
-	    			}
-	    		});
-	        }
+			final Properties currSettings = new Properties(mSettings);
+			BackgroundThread.instance().postBackground(new Runnable() {
+				@Override
+				public void run() {
+					log.v("LoadDocumentTask : switching current profile");
+					applySettings(currSettings); //enforce reloading of the settings
+					log.i("Switching done");
+				}
+			});
+
 		}
 
 		@Override

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -43,7 +43,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 
 	public static final Logger log = L.create("rv", Log.VERBOSE);
 	public static final Logger alog = L.create("ra", Log.WARN);
-
+	
 	private final SurfaceView surface;
 	private final BookView bookView;
 	public SurfaceView getSurface() { return surface; }
@@ -4597,6 +4597,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		int profileNumber;
 		boolean disableInternalStyles;
 		boolean disableTextAutoformat;
+		Properties props;
 		LoadDocumentTask(BookInfo bookInfo, Runnable errorHandler)
 		{
 			BackgroundThread.ensureGUI();
@@ -4643,16 +4644,17 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	        // close existing document
 			log.v("LoadDocumentTask : closing current book");
 	        close();
-			final Properties currSettings = new Properties(mSettings);
-			BackgroundThread.instance().postBackground(new Runnable() {
-				@Override
-				public void run() {
-					log.v("LoadDocumentTask : switching current profile");
-					applySettings(currSettings); //enforce reloading of the settings
-					log.i("Switching done");
-				}
-			});
-
+	        if (props != null) {
+		        setAppSettings(props, oldSettings);
+	    		BackgroundThread.instance().postBackground(new Runnable() {
+	    			@Override
+	    			public void run() {
+	    				log.v("LoadDocumentTask : switching current profile");
+	    				applySettings(props);
+	    				log.i("Switching done");
+	    			}
+	    		});
+	        }
 		}
 
 		@Override


### PR DESCRIPTION
1. Tolino Vision (HD4 in my case) was not recognized as E-Ink device as it returns BRAND=generic:
     I/cr3: DeviceInfo: MANUFACTURER=Telekom, MODEL=tolino, DEVICE=tolino_vision2, 
       PRODUCT=tolino_vision2, BRAND=generic
   I changed the recognition to test only MODEL=tolino && DEVICE=tolinio_vision2
   and now finally I can configure Screen update mode & Full screen update internal 
   (these options were not visible prior to my changes)
2. Tolino Vision's backlight button generates keycode=96, and there was a collition with 
    NOOK_KEY_PREV_LEFT ...  I added a condition !DeviceInfo.EINK_TOLINO for this 
   as clicking backlight button on Tolino vision was going 1 page back 