### PR TITLE
"Solve bug in applying screen/margin setting:"

### DIFF
--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -43,7 +43,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 
 	public static final Logger log = L.create("rv", Log.VERBOSE);
 	public static final Logger alog = L.create("ra", Log.WARN);
-	
+
 	private final SurfaceView surface;
 	private final BookView bookView;
 	public SurfaceView getSurface() { return surface; }
@@ -4597,7 +4597,6 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		int profileNumber;
 		boolean disableInternalStyles;
 		boolean disableTextAutoformat;
-		Properties props;
 		LoadDocumentTask(BookInfo bookInfo, Runnable errorHandler)
 		{
 			BackgroundThread.ensureGUI();
@@ -4622,7 +4621,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			disableInternalStyles = mBookInfo.getFileInfo().getFlag(FileInfo.DONT_USE_DOCUMENT_STYLES_FLAG);
 			disableTextAutoformat = mBookInfo.getFileInfo().getFlag(FileInfo.DONT_REFLOW_TXT_FILES_FLAG);
 			profileNumber = mBookInfo.getFileInfo().getProfileId();
-			Properties oldSettings = new Properties(mSettings);
+			//Properties oldSettings = new Properties(mSettings);
 			// TODO: enable storing of profile per book
 			mActivity.setCurrentProfile(profileNumber);
 	    	if ( mBookInfo!=null && mBookInfo.getLastPosition()!=null )
@@ -4644,17 +4643,17 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	        // close existing document
 			log.v("LoadDocumentTask : closing current book");
 	        close();
-	        if (props != null) {
-		        setAppSettings(props, oldSettings);
-	    		BackgroundThread.instance().postBackground(new Runnable() {
-	    			@Override
-	    			public void run() {
-	    				log.v("LoadDocumentTask : switching current profile");
-	    				applySettings(props);
-	    				log.i("Switching done");
-	    			}
-	    		});
-	        }
+			final Properties currSettings = new Properties(mSettings);
+			//setAppSettings(props, oldSettings);
+			BackgroundThread.instance().postBackground(new Runnable() {
+				@Override
+				public void run() {
+					log.v("LoadDocumentTask : switching current profile");
+					applySettings(currSettings); //enforce settings reload
+					log.i("Switching done");
+				}
+			});
+
 		}
 
 		@Override


### PR DESCRIPTION
On both my devices, Tolino E-Ink but also Samsung S7 mobile, I noticed following behavior with cr3.2.1:
1. I setup custom margins, especially bottom margin larger than standard value
2. Exit coolreader
3. Start cr again and open any book - custom margins are not reflected (def. margins are used)
4. I have to go to options and then back to book, the book gets reloaded with proper margins

I saw that below in LoadDocumentTask  there is a background  thread which would call applySettings,
but this was never called ... I did minor modifications so that applySettings would be always called,
and this solved the problem on both of my devices

Please judge my solution and should you find it ok, merge it 
