### PR TITLE
[CRENGINE] Engine.java: Fix conflict with Magisk

### DIFF
--- a/android/src/org/coolreader/crengine/Engine.java
+++ b/android/src/org/coolreader/crengine/Engine.java
@@ -1104,7 +1104,16 @@ public class Engine {
 		    try {
 		        final Process process = new ProcessBuilder().command("mount")
 		                .redirectErrorStream(true).start();
-		        process.waitFor();
+		        ProcessWithTimeout processWithTimeout = new ProcessWithTimeout(process);
+		        int exitCode = processWithTimeout.waitForProcess(100);
+		        if (exitCode == Integer.MIN_VALUE)
+		        {
+		            // Timeout
+		            log.e("Timed out waiting for mount command output, " +
+		                  "please add CoolReader to MagiskHide list!");
+                            process.destroy();
+                            return out;
+		        }
 		        final InputStream is = process.getInputStream();
 		        final byte[] buffer = new byte[1024];
 		        while (is.read(buffer) != -1) {

--- a/android/src/org/coolreader/crengine/ProcessWithTimeout.java
+++ b/android/src/org/coolreader/crengine/ProcessWithTimeout.java
@@ -1,0 +1,48 @@
+package org.coolreader.crengine;
+
+// By Muzikant@stackoverflow.com
+// See https://stackoverflow.com/a/19272315 for details
+
+public class ProcessWithTimeout extends Thread
+{
+    private Process m_process;
+    private int m_exitCode = Integer.MIN_VALUE;
+
+    public ProcessWithTimeout(Process p_process)
+    {
+        m_process = p_process;
+    }
+
+    public int waitForProcess(int p_timeoutMilliseconds)
+    {
+        this.start();
+
+        try
+        {
+            this.join(p_timeoutMilliseconds);
+        }
+        catch (InterruptedException e)
+        {
+            this.interrupt();
+        }
+
+        return m_exitCode;
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            m_exitCode = m_process.waitFor();
+        }
+        catch (InterruptedException ignore)
+        {
+            // Do nothing
+        }
+        catch (Exception ex)
+        {
+            // Unexpected exception
+        }
+    }
+}


### PR DESCRIPTION
The "mount" command may hang and hang CoolReader in getExternalMounts()
(process.waitFor() will wait forever)