### PR TITLE
Fix compare this

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(MSVC)
   endif()
 elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
   # Update if necessary
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -std=c++11 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -std=c++11 -fPIC -Wno-misleading-indentation")
 endif()
 
 if (NOT DEFINED GUI)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To build debian package, copy one of package descriptions from packages director
 Android Build Instructions
 --------------------------
 
-Use Android Studio - open android/app as Android Studio project
+Use Android Studio - open subdirectory "android" as Android Studio project
 
 Ensure that you have Android SDK and NDK installed
 

--- a/android/app/CMakeLists.txt
+++ b/android/app/CMakeLists.txt
@@ -106,7 +106,7 @@ add_subdirectory(thirdparty_libs)
 # Gradle automatically packages shared libraries with your APK.
 
 add_library( # Sets the name of the library.
-             cr3engine-3-1-2
+             cr3engine-3-2-X
 
              # Sets the library as a shared library.
              SHARED
@@ -132,7 +132,7 @@ find_library( # Sets the name of the path variable.
 # build script, prebuilt third-party libraries, or system libraries.
 
 target_link_libraries( # Specifies the target library.
-                       cr3engine-3-1-2
+                       cr3engine-3-2-X
 
                        # thirdparty static libs
                        png

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -30,7 +30,7 @@ LOCAL_C_INCLUDES := \
 
 LOCAL_CFLAGS += $(CRFLAGS)
 
-LOCAL_CFLAGS += -Wno-psabi -Wno-unused-variable -Wno-sign-compare -Wno-write-strings -Wno-main -Wno-unused-but-set-variable -Wno-unused-function -Wall
+LOCAL_CFLAGS += -Wall -Wno-unused-variable -Wno-sign-compare -Wno-write-strings -Wno-main -Wno-unused-function
 
 LOCAL_CFLAGS += -funwind-tables -Wl,--no-merge-exidx-entries
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -3,7 +3,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE    := cr3engine-3-1-2
+LOCAL_MODULE    := cr3engine-3-2-X
 
 # Generate CREngine blob with statically linked libjpeg, libpng, freetype, harfbuzz, chmlib
 

--- a/android/src/org/coolreader/crengine/Engine.java
+++ b/android/src/org/coolreader/crengine/Engine.java
@@ -36,7 +36,7 @@ public class Engine {
 	public static final Object lock = new Object();
 
 	
-	static final private String LIBRARY_NAME = "cr3engine-3-1-2";
+	static final private String LIBRARY_NAME = "cr3engine-3-2-X";
 
 	private BaseActivity mActivity;
 	

--- a/cr3qt/CMakeLists.txt
+++ b/cr3qt/CMakeLists.txt
@@ -140,6 +140,12 @@ else()
 ADD_EXECUTABLE(cr3 ${CR3_MAN_PAGES} ${CR3_CHANGELOG} ${CR3_SOURCES} ${CR3_RCS} ${CR3_UI_HDRS} ${CR3_MOC_SRCS} ${QM_FILES} ${RES_FILES})
 endif (WIN32)
 
+if(${CMAKE_BUILD_TYPE} STREQUAL Debug)
+  if (CMAKE_HOST_UNIX)
+    configure_file(valgrind_check.sh.cmake ${CMAKE_CURRENT_BINARY_DIR}/valgrind_check.sh)
+  endif(CMAKE_HOST_UNIX)
+endif(${CMAKE_BUILD_TYPE} STREQUAL Debug)
+
 if(WIN32)
 if(CMAKE_GENERATOR MATCHES "Visual Studio.*")
   message("Visual Studio generator detected")

--- a/cr3qt/src/settings.cpp
+++ b/cr3qt/src/settings.cpp
@@ -136,7 +136,7 @@ SettingsDlg::SettingsDlg(QWidget *parent, CR3View * docView ) :
     optionToUi( PROP_TXT_OPTION_PREFORMATTED, m_ui->cbTxtPreFormatted );
     optionToUi( PROP_EMBEDDED_STYLES, m_ui->cbEnableDocumentStyles );
     optionToUi( PROP_EMBEDDED_FONTS, m_ui->cbEnableEmbeddedFonts );
-    m_ui->cbEnableEmbeddedFonts->setCheckState(m_props->getBoolDef(PROP_EMBEDDED_STYLES, true) ? Qt::Checked : Qt::Unchecked);
+    m_ui->cbEnableEmbeddedFonts->setEnabled(m_props->getBoolDef(PROP_EMBEDDED_STYLES, true));
     optionToUi( PROP_TXT_OPTION_PREFORMATTED, m_ui->cbTxtPreFormatted );
     optionToUi( PROP_FONT_KERNING_ENABLED, m_ui->cbFontKerning );
     optionToUi( PROP_FLOATING_PUNCTUATION, m_ui->cbFloatingPunctuation );

--- a/cr3qt/src/settings.cpp
+++ b/cr3qt/src/settings.cpp
@@ -136,7 +136,7 @@ SettingsDlg::SettingsDlg(QWidget *parent, CR3View * docView ) :
     optionToUi( PROP_TXT_OPTION_PREFORMATTED, m_ui->cbTxtPreFormatted );
     optionToUi( PROP_EMBEDDED_STYLES, m_ui->cbEnableDocumentStyles );
     optionToUi( PROP_EMBEDDED_FONTS, m_ui->cbEnableEmbeddedFonts );
-    m_ui->cbEnableEmbeddedFonts->setEnabled(m_props->getBoolDef(PROP_EMBEDDED_STYLES, true) ? Qt::Checked : Qt::Unchecked);
+    m_ui->cbEnableEmbeddedFonts->setCheckState(m_props->getBoolDef(PROP_EMBEDDED_STYLES, true) ? Qt::Checked : Qt::Unchecked);
     optionToUi( PROP_TXT_OPTION_PREFORMATTED, m_ui->cbTxtPreFormatted );
     optionToUi( PROP_FONT_KERNING_ENABLED, m_ui->cbFontKerning );
     optionToUi( PROP_FLOATING_PUNCTUATION, m_ui->cbFloatingPunctuation );

--- a/cr3qt/valgrind_check.sh.cmake
+++ b/cr3qt/valgrind_check.sh.cmake
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+valgrind --tool=memcheck -v --leak-check=full --show-reachable=yes --track-origins=yes \
+	${CMAKE_CURRENT_BINARY_DIR}/cr3 \
+	$* 2>&1 | tee ${CMAKE_CURRENT_BINARY_DIR}/valgrind_check.log

--- a/crengine/src/crgui.cpp
+++ b/crengine/src/crgui.cpp
@@ -471,7 +471,7 @@ void CRGUIWindowManager::showWaitIcon( lString16 filename, int progressPercent )
 /// draws icon at center of screen, with optional progress gauge
 void CRGUIWindowManager::showProgress( lString16 filename, int progressPercent )
 {
-    time_t t = (time_t)time((time_t)0);
+    time_t t = (time_t)time((time_t*)0);
     if ( t<_lastProgressUpdate+PROGRESS_UPDATE_INTERVAL || progressPercent==_lastProgressPercent )
         return;
     showWaitIcon( filename, progressPercent );

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -932,7 +932,10 @@ LVStreamRef LVDocView::getCoverPageImageStream() {
 	lUInt16 path[] = { el_FictionBook, el_description, el_title_info,
 			el_coverpage, 0 };
 	//lUInt16 path[] = { el_FictionBook, el_description, el_title_info, el_coverpage, el_image, 0 };
-	ldomNode * cover_el = m_doc->getRootNode()->findChildElement(path);
+	ldomNode * rootNode = m_doc->getRootNode();
+	ldomNode * cover_el = 0;
+	if (rootNode)
+		cover_el = rootNode->findChildElement(path);
 	//ldomNode * cover_img_el = m_doc->getRootNode()->findChildElement( path );
 
 	if (cover_el) {
@@ -956,7 +959,10 @@ LVImageSourceRef LVDocView::getCoverPageImage() {
 	lUInt16 path[] = { el_FictionBook, el_description, el_title_info,
 			el_coverpage, 0 };
 	//lUInt16 path[] = { el_FictionBook, el_description, el_title_info, el_coverpage, el_image, 0 };
-	ldomNode * cover_el = m_doc->getRootNode()->findChildElement(path);
+	ldomNode * cover_el = 0;
+	ldomNode * rootNode = m_doc->getRootNode();
+	if (rootNode)
+		cover_el = rootNode->findChildElement(path);
 	//ldomNode * cover_img_el = m_doc->getRootNode()->findChildElement( path );
 
 	if (cover_el) {
@@ -2370,7 +2376,9 @@ LVImageSourceRef LVDocView::getImageByPoint(lvPoint pt) {
     if (ptr.isNull())
         return res;
     //CRLog::debug("node: %s", LCSTR(ptr.toString()));
-    res = ptr.getNode()->getObjectImageSource();
+    ldomNode* node = ptr.getNode();
+    if (node)
+        res = node->getObjectImageSource();
     if (!res.isNull())
         CRLog::debug("getImageByPoint(%d, %d) : found image %d x %d", pt.x, pt.y, res->GetWidth(), res->GetHeight());
     return res;
@@ -4334,7 +4342,10 @@ bool LVDocView::ParseDocument() {
 
 		if (m_doc_format == doc_format_html) {
 			static lUInt16 path[] = { el_html, el_head, el_title, 0 };
-			ldomNode * el = m_doc->getRootNode()->findChildElement(path);
+			ldomNode * el = NULL;
+			ldomNode * rootNode = m_doc->getRootNode();
+			if (rootNode)
+				el = rootNode->findChildElement(path);
 			if (el != NULL) {
                 lString16 s = el->getText(L' ', 1024);
 				if (!s.empty()) {

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -733,6 +733,8 @@ lUInt32 LVGrayDrawBuf::GetPixel( int x, int y )
 
 void LVGrayDrawBuf::Clear( lUInt32 color )
 {
+    if (!_data)
+        return;
     color = rgbToGrayMask( color, _bpp );
 #if (GRAY_INVERSE==1)
     color ^= 0xFF;

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -2936,7 +2936,7 @@ public:
 	}
 	virtual lverror_t Write( const void * buf, lvsize_t count, lvsize_t * nBytesWritten )
 	{
-		if (!m_pBuffer || m_mode==LVOM_READ )
+		if (!m_pBuffer || !buf || m_mode==LVOM_READ )
 			return LVERR_FAIL;
 		SetBufSize( m_pos+count ); // check buf size
 		int bytes_avail = (int)(m_bufsize-m_pos);

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -948,7 +948,7 @@ static bool parse_ident( const char * &str, char * ident )
 
 bool LVCssSelectorRule::check( const ldomNode * & node )
 {
-    if (node->isNull() || node->isRoot())
+    if (!node || node->isNull() || node->isRoot())
         return false;
     switch (_type)
     {
@@ -956,7 +956,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         //
         {
             node = node->getParentNode();
-            if (node->isNull())
+            if (!node || node->isNull())
                 return false;
             return node->getNodeId() == _id;
         }
@@ -967,8 +967,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
             for (;;)
             {
                 node = node->getParentNode();
-                if (!node) return false;
-                if (node->isNull())
+                if (!node || node->isNull())
                     return false;
                 if (node->getNodeId() == _id)
                     return true;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -254,14 +254,18 @@ void LFormattedText::AddSourceObject(
      )
 {
     ldomNode * node = (ldomNode*)object;
-    LVImageSourceRef img = node->getObjectImageSource();
-    if ( img.isNull() )
-        img = LVCreateDummyImageSource( node, DUMMY_IMAGE_SIZE, DUMMY_IMAGE_SIZE );
-    lUInt16 width = (lUInt16)img->GetWidth();
-    lUInt16 height = (lUInt16)img->GetHeight();
-    lvtextAddSourceObject(m_pbuffer,
-        width, height,
-        flags, interval, margin, object, letter_spacing );
+    if (node) {
+        LVImageSourceRef img = node->getObjectImageSource();
+        if ( img.isNull() )
+            img = LVCreateDummyImageSource( node, DUMMY_IMAGE_SIZE, DUMMY_IMAGE_SIZE );
+        lUInt16 width = (lUInt16)img->GetWidth();
+        lUInt16 height = (lUInt16)img->GetHeight();
+        lvtextAddSourceObject(m_pbuffer,
+            width, height,
+            flags, interval, margin, object, letter_spacing );
+    }
+    else
+        TR("LFormattedText::AddSourceObject(): node is NULL!");
 }
 
 class LVFormatter {
@@ -1370,13 +1374,15 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 {
                     srcline = &m_pbuffer->srctext[word->src_text_index];
                     ldomNode * node = (ldomNode *) srcline->object;
-                    LVImageSourceRef img = node->getObjectImageSource();
-                    if ( img.isNull() )
-                        img = LVCreateDummyImageSource( node, word->width, word->o.height );
-                    int xx = x + frmline->x + word->x;
-                    int yy = line_y + frmline->baseline - word->o.height + word->y;
-                    buf->Draw( img, xx, yy, word->width, word->o.height );
-                    //buf->FillRect( xx, yy, xx+word->width, yy+word->height, 1 );
+                    if (node) {
+                        LVImageSourceRef img = node->getObjectImageSource();
+                        if ( img.isNull() )
+                            img = LVCreateDummyImageSource( node, word->width, word->o.height );
+                        int xx = x + frmline->x + word->x;
+                        int yy = line_y + frmline->baseline - word->o.height + word->y;
+                        buf->Draw( img, xx, yy, word->width, word->o.height );
+                        //buf->FillRect( xx, yy, xx+word->width, yy+word->height, 1 );
+                    }
                 }
                 else
                 {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2560,7 +2560,7 @@ void ldomTextStorageChunk::modified()
 void ldomTextStorageChunk::freeNode( int offset )
 {
     offset <<= 4;
-    if ( offset>=0 && offset<(int)_bufpos ) {
+    if ( _buf && offset>=0 && offset<(int)_bufpos ) {
         TextDataStorageItem * item = (TextDataStorageItem *)(_buf+offset);
         if ( (item->type==LXML_TEXT_NODE || item->type==LXML_ELEMENT_NODE) && item->dataIndex ) {
             item->type = LXML_NO_DATA;
@@ -2574,7 +2574,7 @@ void ldomTextStorageChunk::freeNode( int offset )
 lString8 ldomTextStorageChunk::getText( int offset )
 {
     offset <<= 4;
-    if ( offset>=0 && offset<(int)_bufpos ) {
+    if ( _buf && offset>=0 && offset<(int)_bufpos ) {
         TextDataStorageItem * item = (TextDataStorageItem *)(_buf+offset);
         return item->getText8();
     }
@@ -5160,7 +5160,7 @@ bool ldomXPointer::getRect(lvRect & rect) const
 ldomXPointer ldomDocument::createXPointer( ldomNode * baseNode, const lString16 & xPointerStr )
 {
     //CRLog::trace( "ldomDocument::createXPointer(%s)", UnicodeToUtf8(xPointerStr).c_str() );
-    if ( xPointerStr.empty() )
+    if ( xPointerStr.empty() || !baseNode )
         return ldomXPointer();
     const lChar16 * str = xPointerStr.c_str();
     int index = -1;
@@ -10828,7 +10828,7 @@ ldomNode * ldomNode::findChildElement( lUInt16 nsid, lUInt16 id, int index )
 ldomNode * ldomNode::findChildElement( lUInt16 idPath[] )
 {
     ASSERT_NODE_NOT_NULL;
-    if ( !this || !isElement() )
+    if ( !isElement() )
         return NULL;
     ldomNode * elem = this;
     for ( int i=0; idPath[i]; i++ ) {
@@ -11035,7 +11035,7 @@ public:
 /// returns object image ref name
 lString16 ldomNode::getObjectImageRefName()
 {
-    if ( !this || !isElement() )
+    if (!isElement())
         return lString16::empty_str;
     //printf("ldomElement::getObjectImageSource() ... ");
     const css_elem_def_props_t * et = getDocument()->getElementTypePtr(getNodeId());

--- a/thirdparty/antiword/fail.c
+++ b/thirdparty/antiword/fail.c
@@ -11,7 +11,7 @@
 
 #if !defined(NDEBUG)
 void
-__fail(char *szExpression, char *szFilename, int iLineNumber)
+__fail(const char *szExpression, const char *szFilename, int iLineNumber)
 {
 	if (szExpression == NULL || szFilename == NULL) {
 		werr(1, "Internal error: no expression");

--- a/thirdparty/antiword/fail.h
+++ b/thirdparty/antiword/fail.h
@@ -17,6 +17,6 @@
 #define fail(e)	((e) ? __fail(#e, __FILE__, __LINE__) : (void)0)
 #endif /* NDEBUG */
 
-extern void	__fail(char *, char *, int);
+extern void	__fail(const char *, const char *, int);
 
 #endif /* __fail_h */


### PR DESCRIPTION
1. Removed last dangerous compile warning "nonnull argument «this» compared to NULL  [-Wnonnull-compare]": such checks deleted and inserted analogous checks at upper level of call stack. (cpp)
See
 https://habr.com/company/abbyy/blog/205070/
 https://www.viva64.com/en/b/0226/
1.1 Also removed statements like "delete this" (cpp).
2. Other small fixes to suppress various compile warnings (cpp).
3. "warning: this «if» clause does not guard... [-Wmisleading-indentation]":
Misleading indentation saved as is, just added compile flag "-Wno-misleading-indentation".
4. Fixed README.md about Android Studio project.
5. Android: changed suffix of so-library from "3-1-2" to "3-2-X".
6. Qt: added autogenerated in build directory shell script "valgrind_check.sh" to test in valgrind (only Linux). Of course, valgrind must be installed.