### PR TITLE
Android: detect old Onyx BOOX readers as eink devices, fix issue #55.

### DIFF
--- a/android/src/org/coolreader/crengine/DeviceInfo.java
+++ b/android/src/org/coolreader/crengine/DeviceInfo.java
@@ -112,8 +112,8 @@ public class DeviceInfo {
 		EINK_NOOK_120 = EINK_NOOK && (MODEL.contentEquals("BNRV350") || MODEL.contentEquals("BNRV300") || MODEL.contentEquals("BNRV500"));
 		EINK_SONY = MANUFACTURER.toLowerCase().contentEquals("sony") && MODEL.startsWith("PRS-T");
 		//MANUFACTURER=Onyx, MODEL=*; All ONYX BOOX Readers have e-ink screen
-		EINK_ONYX = MANUFACTURER.toLowerCase().contentEquals("onyx") &&
-				(BRAND.toLowerCase().contentEquals("onyx") || BRAND.toLowerCase().contentEquals("maccentre")) &&
+		EINK_ONYX = (MANUFACTURER.toLowerCase().contentEquals("onyx") || MANUFACTURER.toLowerCase().contentEquals("onyx-intl")) &&
+				(BRAND.toLowerCase().contentEquals("onyx") || BRAND.toLowerCase().contentEquals("maccentre") || BRAND.toLowerCase().contentEquals("maccenter")) &&
 				MODEL.length() > 0;
 		//MANUFACTURER -DNS, DEVICE -BK6004C, MODEL - DNS Airbook EGH602, PRODUCT - BK6004C
 		EINK_DNS = MANUFACTURER.toLowerCase().contentEquals("dns") && MODEL.startsWith("DNS Airbook EGH");


### PR DESCRIPTION
Note: ONYX I63ML Newton should detecting as eink device, but this device based on Android 2.3.1 and officially not supported by latest Android SDK & NDK, so resulting apk may not work...