### PR TITLE
Fixed invalid text rendering when using font without block of main bo…

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -281,6 +281,8 @@ lUInt32 calcGlobalSettingsHash(int documentId)
     lUInt32 hash = FORMATTING_VERSION_ID;
     if ( fontMan->getKerning() )
         hash += 127365;
+    if ( fontMan->getLigatures() )
+        hash += 254655;
     hash = hash * 31 + fontMan->GetFontListHash(documentId);
     hash = hash * 31 + (int)fontMan->GetHintingMode();
     if ( LVRendGetFontEmbolden() )


### PR DESCRIPTION
Fixed invalid text rendering when using font without block of main book's language. For example, font 'Dancing Script' with russian (cirillic) text.
![screenshot_20190108_202052](https://user-images.githubusercontent.com/36960933/50844019-53dac300-1383-11e9-96cc-57254775d707.png)
Fixed:
![screenshot_20190108_202220](https://user-images.githubusercontent.com/36960933/50844059-68b75680-1383-11e9-9e6e-7c46f48ba642.png)
Also fixed function calculating settings hash calcGlobalSettingsHash() to force book's reformat when ligature option changed.
P.S. This is fixes for b537ffbe869fce0904a9fa8edcb550dc2aeb8997.