### PR TITLE
Fixed bug: when opened book in external file manager it can send inte…

### DIFF
--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -533,7 +533,7 @@
     <string name="btn_toolbar_more">Еще...</string>
     <string name="black_list_enforced">Нельзя добавлять этот адрес, так как по запросу LitRes.ru он добавлен в черный список каталогов, нарушающих авторские права.</string>
     <string name="black_list_warning">Внимание! этот адрес по запросу LitRes.ru был добавлен в черный список каталогов, нарушающих авторские права. Вы действительно хотите использовать этот каталог?</string>
-    <string name="cant_open_file">Невозможно открыть файл!</string>
+    <string name="cant_open_file">Невозможно открыть файл \"%s\"!</string>
     <string name="error">Ошибка</string>
     <string name="options_app_tts_stop_motion_timeout">Остановить чтение вслух при бездействии датчика движения</string>
     <string name="motion_timeout_off">"Выключено"</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -562,7 +562,7 @@
     <string name="black_list_enforced">Cannot add this URL since it is added to black list of catalogs which may violate DMCA by request of LitRes.ru</string>
     <string name="black_list_warning">WARNING: this URL is added to black list of catalogs which may violate DMCA by request of LitRes.ru Do you really want to add this catalog?</string>
     <string name="error">Error</string>
-    <string name="cant_open_file">Can\'t open file!</string>
+    <string name="cant_open_file">Can\'t open file \"%s\"!</string>
     <string name="options_app_tts_stop_motion_timeout">Stop reading aloud on motion sensor timeout</string>
     <string name="motion_timeout_off">"Off"</string>
     <string name="motion_timeout_1min">"1 minute"</string>

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -311,6 +311,7 @@ public class CoolReader extends BaseActivity
 				fileToOpen = fileToOpen.replace("%2F", "/");
 			}
 			log.d("FILE_TO_OPEN = " + fileToOpen);
+			final String finalFileToOpen = fileToOpen;
 			loadDocument(fileToOpen, new Runnable() {
 				@Override
 				public void run() {
@@ -318,7 +319,7 @@ public class CoolReader extends BaseActivity
 						@Override
 						public void run() {
 							// if document not loaded show error & then root window
-							ErrorDialog errDialog = new ErrorDialog(CoolReader.this, CoolReader.this.getString(R.string.error), CoolReader.this.getString(R.string.cant_open_file));
+							ErrorDialog errDialog = new ErrorDialog(CoolReader.this, CoolReader.this.getString(R.string.error), CoolReader.this.getString(R.string.cant_open_file, finalFileToOpen));
 							errDialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
 								@Override
 								public void onDismiss(DialogInterface dialog) {

--- a/android/src/org/coolreader/crengine/FileInfo.java
+++ b/android/src/org/coolreader/crengine/FileInfo.java
@@ -435,7 +435,18 @@ public class FileInfo {
 	{
 		return pathname!=null && pathname.startsWith(SERIES_PREFIX);
 	}
-	
+
+	public boolean isOnSDCard() {
+		if (null == parent)
+			return false;
+		if ( ( (filename.compareTo("SD") == 0 && title.compareTo("SD") == 0) ||
+				(filename.compareTo("EXT SD") == 0 && title.compareTo("EXT SD") == 0) ) &&
+				isDirectory && !isArchive && 0 == size && 0 == arcsize &&
+				parent.pathname.compareTo("@root") == 0)
+			return true;
+		return parent.isOnSDCard();
+	}
+
 	public long getAuthorId()
 	{
 		if (!isBooksByAuthorDir())
@@ -584,13 +595,13 @@ public class FileInfo {
 	{
 		if ( dirs!=null )
 			for ( FileInfo dir : dirs )
-				if ( pathName.equals(dir.getPathName() ))
+				if ( isOnSDCard() && pathName.compareToIgnoreCase(dir.getPathName()) == 0 || pathName.equals(dir.getPathName()) )
 					return dir;
 		if ( files!=null )
 			for ( FileInfo file : files ) {
-				if ( pathName.equals(file.getPathName() ))
+				if ( isOnSDCard() && pathName.compareToIgnoreCase(file.getPathName()) == 0 || pathName.equals(file.getPathName()) )
 					return file;
-				if ( file.getPathName().startsWith(pathName+"@/" ))
+				if ( isOnSDCard() && file.getPathName().toLowerCase().startsWith(pathName.toLowerCase()+"@/") || file.getPathName().startsWith(pathName+"@/" ))
 					return file;
 			}
 		return null;

--- a/android/src/org/coolreader/crengine/Scanner.java
+++ b/android/src/org/coolreader/crengine/Scanner.java
@@ -629,7 +629,9 @@ public class Scanner extends FileInfoChangeSource {
 	private FileInfo findParentInternal(FileInfo file, FileInfo root)	{
 		if ( root==null || file==null || root.isRecentDir() )
 			return null;
-		if ( !root.isRootDir() && !file.getPathName().startsWith( root.getPathName() ) )
+		if (!root.isRootDir() &&
+				!(file.getPathName().startsWith(root.getPathName()) ||
+						root.isOnSDCard() && file.getPathName().toLowerCase().startsWith( root.getPathName().toLowerCase() ) ) )
 			return null;
 		// to list all directories starting root dir
 		if ( root.isDirectory && !root.isSpecialDir() )
@@ -640,9 +642,11 @@ public class Scanner extends FileInfoChangeSource {
 				return found;
 		}
 		for ( int i=0; i<root.fileCount(); i++ ) {
-			if ( root.getFile(i).getPathName().equals(file.getPathName()) )
+			if ( root.getFile(i).getPathName().equals(file.getPathName()) ||
+					root.isOnSDCard() && root.getFile(i).getPathName().compareToIgnoreCase(file.getPathName()) == 0 )
 				return root;
-			if ( root.getFile(i).getPathName().startsWith(file.getPathName() + "@/") )
+			if ( root.getFile(i).getPathName().startsWith(file.getPathName() + "@/") ||
+					root.isOnSDCard() && root.getFile(i).getPathName().toLowerCase().startsWith(file.getPathName().toLowerCase() + "@/") )
 				return root;
 		}
 		return null;


### PR DESCRIPTION
Fixed bug: when opened book in external file manager on internal storage or on sd-card it can send intent with wrong letter case in file name.

For example, instead of "/storage/emulated/0/Download" received "/storage/emulated/0/download" and as result CoolReader can't find received file path on mount roots.

> NB1:/storage/emulated/0 $ ls -l
total 320
drwxrwx--x  2 root sdcard_rw  4096 1971-03-16 03:25 Alarms
drwxrwx--x  5 root sdcard_rw  4096 2018-12-21 23:16 Android
drwxrwx--x  2 root sdcard_rw  4096 2019-01-09 21:58 AppProjects
drwxrwx--x 87 root sdcard_rw  4096 2019-01-07 16:34 Books
drwxrwx--x  4 root sdcard_rw  4096 2018-12-21 21:40 DCIM
drwxrwx--x  7 root sdcard_rw  4096 2019-01-15 00:46 Download
drwxrwx--x  3 root sdcard_rw  4096 2018-12-22 01:02 ExaGear
drwxrwx--x  2 root sdcard_rw  4096 1971-03-16 03:25 Movies
drwxrwx--x  2 root sdcard_rw  4096 1971-03-16 03:25 Music
drwxrwx--x  2 root sdcard_rw  4096 1971-03-16 03:25 Notifications
drwxrwx--x  8 root sdcard_rw  4096 2018-12-22 00:27 Pictures
drwxrwx--x  2 root sdcard_rw  4096 1971-03-16 03:25 Playlists
drwxrwx--x  2 root sdcard_rw  4096 1971-03-16 03:25 Podcasts
drwxrwx--x  2 root sdcard_rw  4096 2018-12-22 00:55 Ringtones
drwxrwx--x  2 root sdcard_rw  4096 2019-01-06 00:39 SMSBackupRestore
drwxrwx--x  2 root sdcard_rw  4096 2018-12-22 00:27 Snapseed
drwxrwx--x  2 root sdcard_rw  4096 2018-12-23 02:16 Subtitles
drwxrwx--x  2 root sdcard_rw  4096 2018-12-22 00:17 bluetooth
drwxrwx--x  2 root sdcard_rw  4096 2018-12-22 00:13 fonts

> NB1:/storage/emulated/0 $ cd dOwnloAd
NB1:/storage/emulated/0/dOwnloAd $ pwd
/storage/emulated/0/dOwnloAd

> NB1:/storage/emulated/0/dOwnloAd $ stat .
  File: `.'
  Size: 4096     Blocks: 16      IO Blocks: 512 directory
Device: 1ah/26d  Inode: 1180150  Links: 7
Access: (771/drwxrwx--x)        Uid: (    0/    root)   Gid: ( 1015/sdcard_rw)
Access: 1971-03-16 03:25:48.049999951
Modify: 2019-01-15 00:46:36.201266924
Change: 2019-01-15 00:46:36.201266924


logcat:

>2019-01-15 00:54:00.172 26638-26638/org.coolreader D/cr3: Scanner.initRoots({/storage/emulated/0=SD, /storage/C5DE-0801=EXT SD})
2019-01-15 00:54:00.173 26638-26638/org.coolreader I/cr3: G|sc| Checking FS root /storage/emulated/0
2019-01-15 00:54:00.177 26638-26638/org.coolreader I/cr3: G|sc| Adding FS root: /storage/emulated/0  SD
2019-01-15 00:54:00.178 26638-26638/org.coolreader I/cr3: G|sc| Checking FS root /storage/C5DE-0801
2019-01-15 00:54:00.181 26638-26773/org.coolreader I/cr3: Entering background thread
2019-01-15 00:54:00.182 26638-26638/org.coolreader I/cr3: G|sc| Adding FS root: /storage/C5DE-0801  EXT SD
......................................................................................................................
2019-01-15 00:54:00.286 26638-26638/org.coolreader D/cr3: G|cr| intent=Intent { act=android.intent.action.VIEW dat=file:///storage/emulated/0/download/1/rationality.epub typ=application/epub+zip flg=0x13000000 cmp=org.coolreader/.CoolReader }
2019-01-15 00:54:00.286 26638-26638/org.coolreader D/cr3: G|cr| FILE_TO_OPEN = /storage/emulated/0/download/1/rationality.epub
......................................................................................................................
2019-01-15 00:54:00.614 26638-26638/org.coolreader I/cr3: G|rv| loadDocument(/storage/emulated/0/download/1/rationality.epub)
2019-01-15 00:54:00.616 26638-26638/org.coolreader V/cr3: G|rv| loadDocument() : book not found in history, looking for location directory
2019-01-15 00:54:00.619 26638-26638/org.coolreader I/cr3: G|Found possible mount point /storage
2019-01-15 00:54:00.620 26638-26638/org.coolreader I/cr3: G|sc| Checking FS root /storage
2019-01-15 00:54:00.620 26638-26638/org.coolreader I/cr3: G|sc| Adding FS root: /storage  /storage
2019-01-15 00:54:00.623 26638-26638/org.coolreader E/cr3: G|Cannot find root directory for file /storage/emulated/0/download/1/rationality.epub
2019-01-15 00:54:00.623 26638-26638/org.coolreader V/cr3: G|rv| loadDocument() : no file item /storage/emulated/0/download/1/rationality.epub found inside null
2019-01-15 00:54:00.624 26638-26638/org.coolreader I/cr3: G|cr| New current frame: class org.coolreader.crengine.ReaderViewLayout