### PR TITLE
Zip entryname UTF-8 encoding support, language code in lowercase

### DIFF
--- a/android/jni/cr3engine.cpp
+++ b/android/jni/cr3engine.cpp
@@ -231,7 +231,7 @@ static bool GetBookProperties(const char *name,  BookProperties * pBookProps)
     #endif
     lString16 authors = extractDocAuthors( &doc, lString16("|"), false );
     lString16 title = extractDocTitle( &doc );
-    lString16 language = extractDocLanguage( &doc );
+    lString16 language = extractDocLanguage( &doc ).lowercase();
     lString16 series = extractDocSeries( &doc, &pBookProps->seriesNumber );
 #if SERIES_IN_AUTHORS==1
     if ( !series.empty() )

--- a/android/src/org/coolreader/db/MainDB.java
+++ b/android/src/org/coolreader/db/MainDB.java
@@ -1400,7 +1400,7 @@ public class MainDB extends BaseDB {
 		fileInfo.createTime = rs.getInt(i++);
 		fileInfo.lastAccessTime = rs.getInt(i++);
 		fileInfo.flags = rs.getInt(i++);
-	    fileInfo.language = rs.getString(i++);
+	    fileInfo.language = rs.getString(i++).toLowerCase();
 		fileInfo.isArchive = fileInfo.arcname!=null; 
 	}
 

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -1216,7 +1216,7 @@ bool ImportCHMDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallbac
     if ( !title.empty() )
         doc->getProps()->setString(DOC_PROP_TITLE, title);
     if ( !language.empty() )
-        doc->getProps()->setString(DOC_PROP_LANGUAGE, language);
+        doc->getProps()->setString(DOC_PROP_LANGUAGE, language.lowercase());
 
     fragmentCount = tocReader.appendFragments( progressCallback );
     writer.OnTagClose(L"", L"body");

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -724,7 +724,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         lString16 title = doc->textFromXPath( cs16("package/metadata/title"));
         lString16 language = doc->textFromXPath( cs16("package/metadata/language"));
         m_doc_props->setString(DOC_PROP_TITLE, title);
-        m_doc_props->setString(DOC_PROP_LANGUAGE, language);
+        m_doc_props->setString(DOC_PROP_LANGUAGE, language.lowercase());
         m_doc_props->setString(DOC_PROP_AUTHORS, author );
 
         for ( int i=1; i<50; i++ ) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4382,9 +4382,9 @@ bool LVDocView::ParseDocument() {
 			m_doc_props->setString(DOC_PROP_AUTHORS, extractDocAuthors(m_doc));
 			m_doc_props->setString(DOC_PROP_TITLE, extractDocTitle(m_doc));
 			if (txt_autodet_lang.length() > 0)
-				m_doc_props->setString(DOC_PROP_LANGUAGE, txt_autodet_lang);
+				m_doc_props->setString(DOC_PROP_LANGUAGE, txt_autodet_lang);        // already in lowercase
 			else
-				m_doc_props->setString(DOC_PROP_LANGUAGE, extractDocLanguage(m_doc));
+				m_doc_props->setString(DOC_PROP_LANGUAGE, extractDocLanguage(m_doc).lowercase());
             int seriesNumber = -1;
             lString16 seriesName = extractDocSeries(m_doc, &seriesNumber);
             m_doc_props->setString(DOC_PROP_SERIES_NAME, seriesName);


### PR DESCRIPTION
1. Added support of unicode file names in zip archives firstly introduced in InfoZip 6.3.
2. Convert the book language code to lower case for proper comparision with the font language.

Test file that can't ne opened by previous versions and with language code in upper case: 
[1Sobranie_stihotvorenii_(Brodskii+I.).fb2.zip](https://github.com/buggins/coolreader/files/2825538/1Sobranie_stihotvorenii_.Brodskii%2BI.fb2.zip)
