### PR TITLE
Hb light features

### DIFF
--- a/cr3qt/src/settings.cpp
+++ b/cr3qt/src/settings.cpp
@@ -139,7 +139,11 @@ SettingsDlg::SettingsDlg(QWidget *parent, CR3View * docView ) :
     m_ui->cbEnableEmbeddedFonts->setEnabled(m_props->getBoolDef(PROP_EMBEDDED_STYLES, true));
     optionToUi( PROP_TXT_OPTION_PREFORMATTED, m_ui->cbTxtPreFormatted );
     optionToUi( PROP_FONT_KERNING_ENABLED, m_ui->cbFontKerning );
+#if USE_HARFBUZZ==1
     optionToUi( PROP_FONT_LIGATURES_ENABLED, m_ui->cbLigatures );
+#else
+    m_ui->cbLigatures->setEnabled(false);
+#endif
     optionToUi( PROP_FLOATING_PUNCTUATION, m_ui->cbFloatingPunctuation );
     optionToUiIndex( PROP_IMG_SCALING_ZOOMIN_INLINE_MODE, m_ui->cbImageInlineZoominMode );
     optionToUiIndex( PROP_IMG_SCALING_ZOOMIN_INLINE_SCALE, m_ui->cbImageInlineZoominScale );

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1555,6 +1555,7 @@ public:
                     else {
                         posInfo.offset = 0;
                         posInfo.width = prev_width;
+                        lastFitChar = i + 1;
                         continue;  /* ignore errors */
                     }
                 }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -14,6 +14,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 
 
@@ -824,6 +825,7 @@ struct LVCharPosInfo
     int width;
 };
 
+#if USE_HARFBUZZ==1
 inline lUInt32 getHash( const struct LVCharTriplet& triplet )
 {
     //return (triplet.prevChar * 1975317 + 164521) ^ (triplet.Char * 1975317 + 164521) ^ (triplet.nextChar * 1975317 + 164521);
@@ -831,6 +833,7 @@ inline lUInt32 getHash( const struct LVCharTriplet& triplet )
                     + (((lUInt64)triplet.prevChar) << 16)
                     + (((lUInt64)triplet.nextChar) << 32) );
 }
+#endif
 
 class LVFreeTypeFace : public LVFont
 {
@@ -1609,6 +1612,7 @@ public:
                     _wcache.put(ch, w);
                 } else {
                     widths[i] = prev_width;
+                    lastFitChar = i + 1;
                     continue;  /* ignore errors */
                 }
                 if ( ch_glyph_index==(FT_UInt)-1 )
@@ -1626,7 +1630,7 @@ public:
             if ( !isHyphen ) // avoid soft hyphens inside text string
                 prev_width = widths[i];
             if ( prev_width > max_width ) {
-                if ( lastFitChar < i + 7)
+                if ( lastFitChar < (uint32_t)(i + 7))
                     break;
             } else {
                 lastFitChar = i + 1;
@@ -1857,13 +1861,13 @@ public:
         if ( y + _height < clip.top || y >= clip.bottom )
             return;
 
-        unsigned int i;
         //lUInt16 prev_width = 0;
         lChar16 ch;
         // measure character widths
         bool isHyphen = false;
         int x0 = x;
 #if USE_HARFBUZZ==1
+        unsigned int i;
         hb_glyph_info_t *glyph_info = 0;
         hb_glyph_position_t *glyph_pos = 0;
         unsigned int glyph_count;
@@ -1978,6 +1982,7 @@ public:
         }
 #else
         FT_UInt previous = 0;
+        int i;
         int error;
 #if (ALLOW_KERNING==1)
         int use_kerning = _allowKerning && FT_HAS_KERNING( _face );

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -809,6 +809,7 @@ static lUInt16 char_flags[] = {
         (ch==UNICODE_NO_BREAK_SPACE?LCHAR_DEPRECATED_WRAP_AFTER|LCHAR_IS_SPACE: \
         (ch==UNICODE_HYPHEN?LCHAR_DEPRECATED_WRAP_AFTER:0))))
 
+#if USE_HARFBUZZ==1
 struct LVCharTriplet
 {
     lChar16 prevChar;
@@ -825,7 +826,6 @@ struct LVCharPosInfo
     int width;
 };
 
-#if USE_HARFBUZZ==1
 inline lUInt32 getHash( const struct LVCharTriplet& triplet )
 {
     //return (triplet.prevChar * 1975317 + 164521) ^ (triplet.Char * 1975317 + 164521) ^ (triplet.nextChar * 1975317 + 164521);

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -864,7 +864,7 @@ protected:
     LVHashTable<lUInt32, LVFontGlyphIndexCacheItem*> _glyph_cache2;
     LVHashTable<struct LVCharTriplet, struct LVCharPosInfo> _width_cache2;
     hb_buffer_t* _hb_opt_kern_buffer;
-    hb_feature_t _hb_opt_kern_features[2];
+    hb_feature_t _hb_opt_kern_features[22];
 #endif
 public:
 
@@ -916,9 +916,38 @@ public:
         // HarfBuzz features for full text shaping
         hb_feature_from_string("-kern", -1, &_hb_features[0]);      // font kerning
         hb_feature_from_string("-liga", -1, &_hb_features[1]);      // ligatures
+
         // HarfBuzz features for lighweight characters width calculating with caching
-        hb_feature_from_string("-kern", -1, &_hb_opt_kern_features[0]);      // font kerning
-        hb_feature_from_string("-liga", -1, &_hb_opt_kern_features[1]);      // ligatures
+        hb_feature_from_string("-kern", -1, &_hb_opt_kern_features[0]);  // Kerning: Fine horizontal positioning of one glyph to the next, based on the shapes of the glyphs
+        // We can enable these ones:
+        hb_feature_from_string("+mark", -1, &_hb_opt_kern_features[1]);  // Mark Positioning: Fine positioning of a mark glyph to a base character
+        hb_feature_from_string("+mkmk", -1, &_hb_opt_kern_features[2]);  // Mark-to-mark Positioning: Fine positioning of a mark glyph to another mark character
+        hb_feature_from_string("+curs", -1, &_hb_opt_kern_features[3]);  // Cursive Positioning: Precise positioning of a letter's connection to an adjacent one
+        hb_feature_from_string("+locl", -1, &_hb_opt_kern_features[4]);  // Substitutes character with the preferred form based on script language
+
+        // We should disable these ones:
+        hb_feature_from_string("-liga", -1, &_hb_opt_kern_features[5]);  // Standard Ligatures: replaces (by default) sequence of characters with a single ligature glyph
+        hb_feature_from_string("-rlig", -1, &_hb_opt_kern_features[6]);  // Ligatures required for correct text display (any script, but in cursive) - Arabic, semitic
+        hb_feature_from_string("-clig", -1, &_hb_opt_kern_features[7]);  // Applies a second ligature feature based on a match of a character pattern within a context of surrounding patterns
+        hb_feature_from_string("-ccmp", -1, &_hb_opt_kern_features[8]);  // Glyph composition/decomposition: either calls a ligature replacement on a sequence of characters or replaces a character with a sequence of glyphs
+                                                                      // Provides logic that can for example effectively alter the order of input characters
+        hb_feature_from_string("-calt", -1, &_hb_opt_kern_features[9]);  // Contextual Alternates: Applies a second substitution feature based on a match of a character pattern within a context of surrounding patterns
+        hb_feature_from_string("-rclt", -1, &_hb_opt_kern_features[10]); // Required Contextual Alternates: Contextual alternates required for correct text display which differs from the default join for other letters, required especially important by Arabic
+        hb_feature_from_string("-rvrn", -1, &_hb_opt_kern_features[11]); // Required Variation Alternates: Special variants of a single character, which need apply to specific font variation, required by variable fonts
+        hb_feature_from_string("-ltra", -1, &_hb_opt_kern_features[12]); // Left-to-right glyph alternates: Replaces characters with forms befitting left-to-right presentation
+        hb_feature_from_string("-ltrm", -1, &_hb_opt_kern_features[13]); // Left-to-right mirrored forms: Replaces characters with possibly mirrored forms befitting left-to-right presentation
+        hb_feature_from_string("-rtla", -1, &_hb_opt_kern_features[14]); // Right-to-left glyph alternates: Replaces characters with forms befitting right-to-left presentation
+        hb_feature_from_string("-rtlm", -1, &_hb_opt_kern_features[15]); // Right-to-left mirrored forms: Replaces characters with possibly mirrored forms befitting right-to-left presentation
+        hb_feature_from_string("-frac", -1, &_hb_opt_kern_features[16]); // Fractions: Converts figures separated by slash with diagonal fraction
+        hb_feature_from_string("-numr", -1, &_hb_opt_kern_features[17]); // Numerator: Converts to appropriate fraction numerator form, invoked by frac
+        hb_feature_from_string("-dnom", -1, &_hb_opt_kern_features[18]); // Denominator: Converts to appropriate fraction denominator form, invoked by frac
+        hb_feature_from_string("-rand", -1, &_hb_opt_kern_features[19]); // Replaces character with random forms (meant to simulate handwriting)
+        hb_feature_from_string("-trak", -1, &_hb_opt_kern_features[20]); // Tracking (?)
+        hb_feature_from_string("-vert", -1, &_hb_opt_kern_features[21]); // Vertical (?)
+        // Especially needed with FreeSerif and french texts: -ccmp
+        // Especially needed with Fedra Serif and "The", "Thuringe": -calt
+        // These tweaks seem fragile (adding here +smcp to experiment with small caps would break FreeSerif again).
+        // So, when tuning these, please check it still behave well with FreeSerif.
 #endif
     }
 
@@ -1203,7 +1232,7 @@ public:
         }
         hb_buffer_set_content_type(_hb_opt_kern_buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
         hb_buffer_guess_segment_properties(_hb_opt_kern_buffer);
-        hb_shape(_hb_font, _hb_opt_kern_buffer, _hb_opt_kern_features, 2);
+        hb_shape(_hb_font, _hb_opt_kern_buffer, _hb_opt_kern_features, 22);
         unsigned int glyph_count = hb_buffer_get_length(_hb_opt_kern_buffer);
         if (segLen == glyph_count) {
             hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(_hb_opt_kern_buffer, &glyph_count);
@@ -2482,6 +2511,11 @@ public:
             if ( !item )
                 face.clear();
             _fallbackFontFace = face;
+            // Somehow, with Fedra Serif (only!), changing the fallback font does
+            // not prevent glyphs from previous fallback font to be re-used...
+            // So let's clear glyphs caches too.
+            gc();
+            clearGlyphCache();
         }
         return !_fallbackFontFace.empty();
     }


### PR DESCRIPTION
Fixed bug with text rendering without ligatures on some fonts. Thanks to koreader project members:
https://github.com/koreader/koreader/pull/4744
https://github.com/koreader/crengine/pull/271
The essence of the bug: some characters, such as the “è” symbol, are divided into two glyphs, which are prohibited when ligatures are turned off.
![before](https://user-images.githubusercontent.com/36960933/54512830-eb095b80-496e-11e9-8599-6811af4a3bf4.png)

Affected font - 'FreeSerif.ttf' in https://github.com/koreader/koreader-fonts/tree/master/freefont
Test file: [Da.Vinci.Code.FR.epub.zip](https://github.com/buggins/coolreader/files/2976730/Da.Vinci.Code.FR.epub.zip)

