### PR TITLE
LVBlockWriteStream: workaround to exclude fatal error in ldomTextStor…

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -809,7 +809,7 @@ bool CacheFile::read( lUInt16 type, lUInt16 dataIndex, lUInt8 * &buf, int &size 
     lvsize_t bytesRead = 0;
     _stream->Read(buf, size, &bytesRead );
     if ( (int)bytesRead!=size ) {
-        CRLog::error("CacheFile::read: Cannot read block %d:%d of size %d", type, dataIndex, (int)size);
+        CRLog::error("CacheFile::read: Cannot read block %d:%d of size %d, bytesRead=%d", type, dataIndex, (int)size, (int)bytesRead);
         free(buf);
         buf = NULL;
         size = 0;
@@ -1549,20 +1549,20 @@ bool tinyNodeCollection::openCacheFile()
         return false;
     }
 
-    CRLog::info("ldomDocument::openCacheFile() - looking for cache file", UnicodeToUtf8(fname).c_str() );
+    CRLog::info("ldomDocument::openCacheFile() - looking for cache file %s", UnicodeToUtf8(fname).c_str() );
 
     LVStreamRef map = ldomDocCache::openExisting( fname, crc, getPersistenceFlags() );
     if ( map.isNull() ) {
         delete f;
         return false;
     }
-    CRLog::info("ldomDocument::openCacheFile() - cache file found, trying to read index", UnicodeToUtf8(fname).c_str() );
+    CRLog::info("ldomDocument::openCacheFile() - cache file found, trying to read index %s", UnicodeToUtf8(fname).c_str() );
 
     if ( !f->open( map ) ) {
         delete f;
         return false;
     }
-    CRLog::info("ldomDocument::openCacheFile() - index read successfully", UnicodeToUtf8(fname).c_str() );
+    CRLog::info("ldomDocument::openCacheFile() - index read successfully %s", UnicodeToUtf8(fname).c_str() );
     _cacheFile = f;
     _textStorage.setCache( f );
     _elemStorage.setCache( f );


### PR DESCRIPTION
LVBlockWriteStream: workaround to exclude fatal error in ldomTextStorageChunk::ensureUnpacked()
Write the cached data to the file stream before reading if the required read block is larger than the rest of the file.
This is a very rare case, only Android is affected.

Problem file on the forum: https://4pda.ru/forum/index.php?showtopic=191747&view=findpost&p=84334549