### PR TITLE
Added possibility to hide system navigation keys

### DIFF
--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -43,6 +43,7 @@ import org.coolreader.donations.CRDonationService;
 import org.koekak.android.ebookdownloader.SonyBookSelector;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -288,6 +289,8 @@ public class CoolReader extends BaseActivity
 		return null;
 	}
 
+
+
 	@Override
 	protected void onNewIntent(Intent intent) {
 		log.i("onNewIntent : " + intent);
@@ -506,7 +509,19 @@ public class CoolReader extends BaseActivity
 
 		log.i("CoolReader.onStart() exiting");
 	}
-	
+
+	@TargetApi(11)
+	@Override
+	public void onWindowFocusChanged(boolean hasFocus) {
+		super.onWindowFocusChanged(hasFocus);
+		if (hasFocus) {
+			getWindow().getDecorView().setSystemUiVisibility(
+					View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+							| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+							| View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+							| View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+		}
+	}
  
 
 	private boolean stopped = false;


### PR DESCRIPTION
On my android device, there is no need to show any Soft Navigations keys (Back, Home, Apps), which take useful place for reedeing