### PR TITLE
сr3.2.31 fixes

### DIFF
--- a/android/.idea/codeStyles/Project.xml
+++ b/android/.idea/codeStyles/Project.xml
@@ -1,0 +1,10 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="JAVA">
+      <indentOptions>
+        <option name="USE_TAB_CHARACTER" value="true" />
+        <option name="LABEL_INDENT_ABSOLUTE" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/android/jni/cr3engine.cpp
+++ b/android/jni/cr3engine.cpp
@@ -233,7 +233,7 @@ static bool GetBookProperties(const char *name,  BookProperties * pBookProps)
     #endif
     lString16 authors = extractDocAuthors( &doc, lString16("|"), false );
     lString16 title = extractDocTitle( &doc );
-    lString16 language = extractDocLanguage( &doc ).lowercase();
+    lString16 language = extractDocLanguage( &doc );
     lString16 series = extractDocSeries( &doc, &pBookProps->seriesNumber );
 #if SERIES_IN_AUTHORS==1
     if ( !series.empty() )

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -591,7 +591,7 @@
     <string name="options_app_ui_theme_hicontrast2">Контрастная черная</string>
     <string name="error_while_opening">Ошибка открытия документа \"%s\"</string>
     <string name="datadir_is_removed">Каталог с данными приложения \"%s\" был удален другой программой!\nВозможно какой-то оптимизатор дискового пространства?\nК сожалению, все настройки утеряны.</string>
-    <string name="font_not_compat_with_language">"Предупреждение: шрифт \"%s\" не совместим с языком \"%s\". Вместо него будет задействован дополнительный шрифт."</string>
+    <string name="font_not_compat_with_language">Предупреждение: шрифт \"%s\" не содержит полный набор символов языка \"%s\". Недостающие символы будут взяты из дополнительного шрифта.</string>
     <string name="fontconfig_language_orthography_database">Набор символов различных писменностей от Fontconfig:
         https://www.fontconfig.org/
     </string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -617,7 +617,7 @@
     <string name="pages_per_full_swipe_20">"20 pages (track)"</string>
     <string name="error_while_opening">Error while opening document \"%s\"</string>
     <string name="datadir_is_removed">Application data directory \"%s\" has been removed by other app.\nPossibly it was some kind of disc space optimizer.\nUnfortunately all the settings were lost.</string>
-    <string name="font_not_compat_with_language">"Notice: font \"%s\" isn't compatible with language \"%s\". Instead will be used fallback font."</string>
+    <string name="font_not_compat_with_language">Warning: font \"%s\" does not contain the full character set of the language \"%s\". Missing characters will be taken from the additional font.</string>
     <string name="fontconfig_language_orthography_database">"Languages character set database by Fontconfig:
         https://www.fontconfig.org/ "
     </string>

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -674,7 +674,7 @@ public class CoolReader extends BaseActivity
 
 	@Override
 	public void onSettingsChanged(Properties props, Properties oldProps) {
-		Properties changedProps = oldProps!=null ? props.diff(oldProps) : props;
+		Properties changedProps = oldProps != null ? props.diff(oldProps) : props;
 		if (mHomeFrame != null) {
 			mHomeFrame.refreshOnlineCatalogs();
 		}
@@ -683,13 +683,13 @@ public class CoolReader extends BaseActivity
 			if (mReaderView != null)
 				mReaderView.updateSettings(props);
 		}
-        for ( Map.Entry<Object, Object> entry : changedProps.entrySet() ) {
-    		String key = (String)entry.getKey();
-    		String value = (String)entry.getValue();
-    		applyAppSetting( key, value );
-        }
+		for (Map.Entry<Object, Object> entry : changedProps.entrySet()) {
+			String key = (String) entry.getKey();
+			String value = (String) entry.getValue();
+			applyAppSetting(key, value);
+		}
 		// Show/Hide soft navbar after OptionDialog is closed.
-		setSystemUiVisibility();
+		applyFullscreen(getWindow());
 	}
 
     protected boolean allowLowBrightness() {

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -5387,17 +5387,18 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		public void OnFormatStart() {
 	    	log.d("readerCallback.OnFormatStart");
 		}
+
 		public void OnLoadFileEnd() {
-	    	log.d("readerCallback.OnLoadFileEnd");
+			log.d("readerCallback.OnLoadFileEnd");
 			if (internalDX == 0 && internalDY == 0) {
 				internalDX = requestedWidth;
 				internalDY = requestedHeight;
 				log.d("OnLoadFileEnd: resizeInternal(" + internalDX + "," + internalDY + ")");
 				doc.resize(internalDX, internalDY);
-				hideProgress();
 			}
-	    	
+			hideProgress();
 		}
+
 		public void OnLoadFileError(String message) {
 	    	log.d("readerCallback.OnLoadFileError(" + message + ")");
 		}
@@ -5446,10 +5447,14 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 //			});
 			return true;
 		}
+
 		public void OnLoadFileStart(String filename) {
 			cancelSwapTask();
 			BackgroundThread.ensureBackground();
-	    	log.d("readerCallback.OnLoadFileStart " + filename);
+			log.d("readerCallback.OnLoadFileStart " + filename);
+			if (enable_progress_callback) {
+				showProgress(1000, R.string.progress_loading);
+			}
 		}
 	    /// Override to handle external links
 	    public void OnImageCacheClear() {

--- a/android/src/org/coolreader/db/MainDB.java
+++ b/android/src/org/coolreader/db/MainDB.java
@@ -1400,7 +1400,7 @@ public class MainDB extends BaseDB {
 		fileInfo.createTime = rs.getInt(i++);
 		fileInfo.lastAccessTime = rs.getInt(i++);
 		fileInfo.flags = rs.getInt(i++);
-	    fileInfo.language = rs.getString(i++).toLowerCase();
+	    fileInfo.language = rs.getString(i++);
 		fileInfo.isArchive = fileInfo.arcname!=null; 
 	}
 

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -1216,7 +1216,7 @@ bool ImportCHMDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallbac
     if ( !title.empty() )
         doc->getProps()->setString(DOC_PROP_TITLE, title);
     if ( !language.empty() )
-        doc->getProps()->setString(DOC_PROP_LANGUAGE, language.lowercase());
+        doc->getProps()->setString(DOC_PROP_LANGUAGE, language);
 
     fragmentCount = tocReader.appendFragments( progressCallback );
     writer.OnTagClose(L"", L"body");

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -724,7 +724,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         lString16 title = doc->textFromXPath( cs16("package/metadata/title"));
         lString16 language = doc->textFromXPath( cs16("package/metadata/language"));
         m_doc_props->setString(DOC_PROP_TITLE, title);
-        m_doc_props->setString(DOC_PROP_LANGUAGE, language.lowercase());
+        m_doc_props->setString(DOC_PROP_LANGUAGE, language);
         m_doc_props->setString(DOC_PROP_AUTHORS, author );
 
         for ( int i=1; i<50; i++ ) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4397,9 +4397,9 @@ bool LVDocView::ParseDocument() {
 			m_doc_props->setString(DOC_PROP_AUTHORS, extractDocAuthors(m_doc));
 			m_doc_props->setString(DOC_PROP_TITLE, extractDocTitle(m_doc));
 			if (txt_autodet_lang.length() > 0)
-				m_doc_props->setString(DOC_PROP_LANGUAGE, txt_autodet_lang);        // already in lowercase
+				m_doc_props->setString(DOC_PROP_LANGUAGE, txt_autodet_lang);
 			else
-				m_doc_props->setString(DOC_PROP_LANGUAGE, extractDocLanguage(m_doc).lowercase());
+				m_doc_props->setString(DOC_PROP_LANGUAGE, extractDocLanguage(m_doc));
             int seriesNumber = -1;
             lString16 seriesName = extractDocSeries(m_doc, &seriesNumber);
             m_doc_props->setString(DOC_PROP_SERIES_NAME, seriesName);


### PR DESCRIPTION
1. Fix a BUG(regression) that prevents loadind data from the database if the book does not contain language information, which leads to a loss of the reading position. Revert commit d0976a6.
2. Hide the load document progress in rare cases when it is not hidden. Otherwise, it will not be hidded at all. This fixes "endless" document loading.
3. Fixed bug/regression on devices with Android API >= 14 and < 19 with enabled fullscreen options: after software navbar is hidded and the user taps on the screen, navbar appears again without any other interactions. This behavior forced to make double taps for page turn. So hiding software navbar on devices with Android < 19 is disabled again.
4. A more cleaner explanation about font compatibility.
5. Setting up Code Style in Android Studio: Indentation for Java - tabs, for cpp & other - spaces.