### PR TITLE
FB3 format basic support (for QT only)

### DIFF
--- a/cr3gui/CMakeLists.txt
+++ b/cr3gui/CMakeLists.txt
@@ -97,6 +97,7 @@ elseif ( ${GUI} STREQUAL CRGUI_QT )
     
     SET(CR3_SOURCES ${CR3_SOURCES} src/cr3qt.cpp)
     SET (EXTRA_LIBS ${QT_LIBRARIES} ${STD_LIBS} )
+    SET(CR3_STYLES ${CR3_STYLES} data/fb3.css)
 
     INSTALL( FILES ${CR3_STYLES} DESTINATION root/crengine)
     INSTALL( DIRECTORY data/hyph/ DESTINATION root/crengine/hyph

--- a/cr3qt/data/fb3.css
+++ b/cr3qt/data/fb3.css
@@ -1,0 +1,131 @@
+body { text-align: left; margin: 0; text-indent: 0px }
+
+p { $def.all } 
+
+empty-line { height: 1em }
+
+hr { height: 1px; background-color: #808080; margin-top: 0.5em; margin-bottom: 0.5em; /* 2px */ }
+
+a { display: inline; $link.all }
+a[type="note"] { $footnote-link.all }
+
+image { text-align: center; text-indent: 0px; display: block }
+p image { display: inline }
+li image { display: inline }
+
+li { display: list-item; text-indent: 0em;  }
+ul { display: block; list-style-type: disc; margin-left: 1em }
+ol { display: block; list-style-type: decimal; margin-left: 1em }
+
+v { text-align: left; text-align-last: right; text-indent: 1em hanging }
+
+stanza { $poem.all }
+stanza + stanza { margin-top: 1em; }
+poem { margin-top: 1em; margin-bottom: 1em; text-indent: 0px }
+text-author { $text-author.all }
+
+epigraph, epigraph p { $epigraph.all }
+cite, cite p { $cite.all }
+
+title p, h1 p, h2 p { 
+    $title.all
+}
+
+subtitle, subtitle p, h3 p, h4 p, h5 p, h6 p { 
+    $subtitle.all
+}
+
+title, h1, h2, h3, h4, h5, h6, subtitle { 
+	hyphenate: none; 
+}
+
+h1, h2, h3, h4, h5, h6 {    
+	display: block; 
+   	margin-top: 0.5em; 
+   	margin-bottom: 0.3em; 
+     	padding: 10px ; 
+     	margin-top: 0.5em; 
+     	margin-bottom: 0.5em; 
+}
+title, h1, h2 { 
+	page-break-before: always; 
+	page-break-inside: avoid; 
+	page-break-after: avoid; 
+}
+subtitle, h3, h4, h5, h6 { 
+	page-break-inside: avoid; 
+	page-break-after: avoid; 
+}
+h1 { font-size: 150% }
+h2 { font-size: 140% }
+h3 { font-size: 130% }
+h4 { font-size: 120% }
+h5 { font-size: 110% }
+
+table { font-size: 80% }
+td, th { text-indent: 0px; padding: 3px }
+th {  font-weight: bold; text-align: center; background-color: #DDD  } 
+/* #808080; */
+table caption { text-indent: 0px; padding: 4px; background-color: #EEE }
+
+tt, samp, kbd, code, pre { font-family: "Courier New", "Courier", monospace; } 
+code, pre { 
+    display: block; 
+    white-space: pre; 
+    $pre.all
+}
+
+body[name="notes"] { $footnote.all }
+body[name="notes"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; }
+body[name="notes"] section title p { display: inline }
+
+body[name="comments"] { $footnote.all }
+body[name="comments"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; }
+body[name="comments"] section title p { display: inline }
+
+description { display: block; }
+title-info { display: block; }
+annotation { $annotation.all }
+date { display: block; font-size: 80%; font-style: italic; text-align: center }
+genre { display: none; }
+author { display: none; }
+book-title { display: none; }
+keywords { display: none; }
+lang { display: none; }
+src-lang { display: none; }
+translator { display: none; }
+document-info { display: none; }
+publish-info { display: none; }
+custom-info { display: none; }
+coverpage { display: none }
+
+head, form, script { display: none; } 
+
+b,strong,i,em,dfn,var,q,u,del,s,strike,small,big,sub,sup,acronym,tt,sa mp,kbd,code { 
+   display: inline; 
+} 
+
+sub { vertical-align: sub; font-size: 70% }
+sup { vertical-align: super; font-size: 70% }
+
+strong, b { font-weight: bold }
+emphasis, i, em, dfn, var { font-style: italic }
+u { text-decoration: underline; } 
+del, s, strike, strikethrough { text-decoration: line-through; } 
+
+small { font-size: 80%; } 
+big { font-size: 130%; } 
+
+nobr { display: inline; hyphenate: none; white-space: nowrap; } 
+
+dl { margin-left: 0em; } 
+dt { display: block; margin-left: 0em; margin-top:0.3em; font-weight: bold; } 
+dd { display: block; margin-left: 1.3em; } 
+
+img { 
+   margin: 0.5em; 
+   text-align: center; 
+   text-indent: 0em; 
+   border-style: solid; 
+   border-width: medium; 
+} 

--- a/cr3qt/data/fb3.css
+++ b/cr3qt/data/fb3.css
@@ -52,6 +52,9 @@ title, h1, h2 {
 	page-break-inside: avoid; 
 	page-break-after: avoid; 
 }
+ol title, ul title {
+    page-break-before: auto; 
+}
 subtitle, h3, h4, h5, h6 { 
 	page-break-inside: avoid; 
 	page-break-after: avoid; 

--- a/cr3qt/data/fb3.css
+++ b/cr3qt/data/fb3.css
@@ -101,16 +101,18 @@ coverpage { display: none }
 
 head, form, script { display: none; } 
 
-b,strong,i,em,dfn,var,q,u,del,s,strike,small,big,sub,sup,acronym,tt,sa mp,kbd,code { 
+b,strong,i,em,dfn,var,q,u,underline,del,s,strike,small,big,sub,sup,acronym,tt,sa mp,kbd,code { 
    display: inline; 
 } 
+
+spacing { display: inline; letter-spacing: 5px }
 
 sub { vertical-align: sub; font-size: 70% }
 sup { vertical-align: super; font-size: 70% }
 
 strong, b { font-weight: bold }
 emphasis, i, em, dfn, var { font-style: italic }
-u { text-decoration: underline; } 
+u,underline { text-decoration: underline; } 
 del, s, strike, strikethrough { text-decoration: line-through; } 
 
 small { font-size: 80%; } 

--- a/cr3qt/src/cr3widget.cpp
+++ b/cr3qt/src/cr3widget.cpp
@@ -1226,6 +1226,9 @@ void CR3View::OnLoadFileFormatDetected( doc_format_t fileFormat )
         case doc_format_txt:
             filename = "txt.css";
             break;
+        case doc_format_fb3:
+            filename = "fb3.css";
+            break;
         case doc_format_rtf:
             filename = "rtf.css";
             break;

--- a/cr3qt/src/mainwindow.cpp
+++ b/cr3qt/src/mainwindow.cpp
@@ -231,8 +231,9 @@ void MainWindow::on_actionOpen_triggered()
     }
     QString fileName = QFileDialog::getOpenFileName(this, tr("Open book file"),
          lastPath,
-         QString(tr("All supported formats")) + QString(" (*.fb2 *.txt *.tcr *.rtf *.doc *.epub *.html *.shtml *.htm *.chm *.zip *.pdb *.pml *.prc *.pml *.mobi);;")
+         QString(tr("All supported formats")) + QString(" (*.fb2 *.fb3 *.txt *.tcr *.rtf *.doc *.epub *.html *.shtml *.htm *.chm *.zip *.pdb *.pml *.prc *.pml *.mobi);;")
                 + QString(tr("FB2 books")) + QString(" (*.fb2 *.fb2.zip);;")
+                + QString(tr("FB3 books")) + QString(" (*.fb3);;")
                 + QString(tr("Text files")) + QString(" (*.txt);;")
                 + QString(tr("Rich text")) + QString(" (*.rtf);;")
                 + QString(tr("MS Word document")) + QString(" (*.doc);;")

--- a/crengine/CMakeLists.txt
+++ b/crengine/CMakeLists.txt
@@ -43,6 +43,7 @@ if ( NOT ${GUI} STREQUAL FB2PROPS )
     src/epubfmt.cpp     
     src/pdbfmt.cpp     
     src/wordfmt.cpp     
+    src/fb3fmt.cpp
     src/crconcurrent.cpp
     #src/xutils.cpp
     )

--- a/crengine/include/bookformats.h
+++ b/crengine/include/bookformats.h
@@ -7,6 +7,7 @@
 typedef enum {
     doc_format_none,
     doc_format_fb2,
+    doc_format_fb3,
     doc_format_txt,
     doc_format_rtf,
     doc_format_epub,

--- a/crengine/include/fb3fmt.h
+++ b/crengine/include/fb3fmt.h
@@ -1,0 +1,10 @@
+#ifndef FB3FMT_H
+#define FB3FMT_H
+
+#include "../include/crsetup.h"
+#include "../include/lvtinydom.h"
+
+bool DetectFb3Format( LVStreamRef stream );
+bool ImportFb3Document( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback );
+
+#endif // FB3FMT_H

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -851,7 +851,7 @@ public:
     /// returns object image source
     LVImageSourceRef getObjectImageSource();
     /// returns object image ref name
-    lString16 getObjectImageRefName();
+    lString16 getObjectImageRefName(bool percentDecode = true);
     /// returns object image stream
     LVStreamRef getObjectImageStream();
     /// formats final block

--- a/crengine/src/fb3fmt.cpp
+++ b/crengine/src/fb3fmt.cpp
@@ -1,0 +1,376 @@
+#include "../include/fb3fmt.h"
+#include "../include/lvtinydom.h"
+#include "../include/fb2def.h"
+
+const lChar16 * const fb3_BodyContentType = L"application/fb3-body+xml";
+const lChar16 * const fb3_PropertiesContentType = L"application/vnd.openxmlformats-package.core-properties+xml";
+const lChar16 * const fb3_CoverRelationship = L"http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail";
+const lChar16 * const fb3_ImageRelationship = L"http://www.fictionbook.org/FictionBook3/relationships/image";
+
+class fb3ImportContext
+{
+private:
+    LVHashTable<lString16, lString16> m_relationships;
+    LVHashTable<lString16, lString16> m_contentTypes;
+    LVContainerRef m_arc;
+    lString16 getTargetPath(const lString16 src, const lString16 targetMode, lString16 target);
+public:
+    fb3ImportContext(LVContainerRef arc);
+    virtual ~fb3ImportContext();
+
+    bool readRelations(const lString16 path);
+    lString16 readRelationByType(const lString16 path, const lString16 type);
+    lString16 geImageTarget(const lString16 relationId) {
+        return m_relationships.get( relationId );
+    }
+    lString16 getContentPath(const lString16 typeId) {
+        return m_contentTypes.get( typeId );
+    }
+    void clearRelations() {
+        m_relationships.clear();
+    }
+    bool readContentTypes();
+public:
+    lString16 m_coverImage;
+};
+
+bool DetectFb3Format( LVStreamRef stream )
+{
+    LVContainerRef m_arc = LVOpenArchieve( stream );
+    bool ret = false;
+    if ( m_arc.isNull() )
+        return false; // not a ZIP archive
+
+    LVStreamRef mtStream = m_arc->OpenStream(L"[Content_Types].xml", LVOM_READ );
+    if ( !mtStream.isNull() ) {
+        ldomDocument * doc = LVParseXMLStream( mtStream );
+        if( doc ) {
+            lUInt16 id = doc->findAttrValueIndex(fb3_BodyContentType);
+            if ( id != (lUInt16)-1 )
+                ret = true;
+            delete doc;
+        }
+    }
+    return ret;
+}
+
+class fb3DomWriter : public LVXMLParserCallback
+{
+private:
+    fb3ImportContext *m_context;
+    ldomDocumentWriter *m_parent;
+    ldomNode *m_footnotesBody;
+    bool m_checkRole;
+protected:
+    void writeDescription();
+public:
+    /// constructor
+    fb3DomWriter(ldomDocumentWriter * parent, fb3ImportContext *importContext ) :
+        m_parent(parent), m_context(importContext), m_footnotesBody(NULL), m_checkRole(false)
+    {
+    }
+    // LVXMLParserCallback interface
+public:
+    ldomNode *OnTagOpen(const lChar16 *nsname, const lChar16 *tagname);
+    /// called on closing tag
+    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void OnTagBody();
+    void OnAttribute(const lChar16 *nsname, const lChar16 *attrname, const lChar16 *attrvalue);
+
+    lUInt32 getFlags() { return m_parent->getFlags(); }
+    void setFlags(lUInt32 flags) { m_parent->setFlags(flags); }
+    void OnEncoding(const lChar16 *name, const lChar16 *table) { m_parent->OnEncoding(name, table); }
+    void OnStart(LVFileFormatParser *parser) { m_parent->OnStart(parser); }
+    void OnStop() { m_parent->OnStop(); }
+    void OnText(const lChar16 *text, int len, lUInt32 flags) {  m_parent->OnText(text, len, flags); }
+    bool OnBlob(lString16 name, const lUInt8 *data, int size) { return m_parent->OnBlob(name, data, size); }
+    void OnDocProperty(const char *name, lString8 value)  { m_parent->OnDocProperty(name, value);  }
+};
+
+bool ImportFb3Document( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback )
+{
+    LVContainerRef arc = LVOpenArchieve( stream );
+    if ( arc.isNull() )
+        return false; // not a ZIP archive
+
+    fb3ImportContext context(arc);
+
+    if( !context.readContentTypes( )) {
+        CRLog::error("Couldn't read content types");
+        return false;
+    }
+
+    if ( !context.readRelations(context.getContentPath(fb3_BodyContentType)) ) {
+        CRLog::error("Couldn't read relations");
+        return false;
+    }
+    doc->setContainer(arc);
+
+#if BUILD_LITE!=1
+    if ( doc->openFromCache(formatCallback) ) {
+        if ( progressCallback ) {
+            progressCallback->OnLoadFileEnd( );
+        }
+        return true;
+    }
+#endif
+
+    CRPropRef doc_props = doc->getProps();
+    LVStreamRef propStream = arc->OpenStream(context.getContentPath(fb3_PropertiesContentType).c_str(), LVOM_READ );
+    if ( propStream.isNull() ) {
+        CRLog::error("Couldn't read properties");
+        return false;
+    }
+
+    ldomDocument * propertiesDoc = LVParseXMLStream( propStream );
+    if ( !propertiesDoc ) {
+        CRLog::error("Couldn't parse properties doc");
+        return false;
+    }
+
+    lString16 author = propertiesDoc->textFromXPath( cs16("coreProperties/creator") );
+    lString16 title = doc->textFromXPath( cs16("coreProperties/title") );
+    doc_props->setString(DOC_PROP_TITLE, title);
+    doc_props->setString(DOC_PROP_AUTHORS, author );
+    CRLog::info("Author: %s Title: %s", author.c_str(), title.c_str());
+    delete propertiesDoc;
+
+    LVStreamRef bookStream = arc->OpenStream(context.getContentPath(fb3_BodyContentType).c_str(), LVOM_READ );
+    if ( bookStream.isNull() ) {
+        CRLog::error("Couldn't read a book");
+        return false;
+    }
+
+    ldomDocumentWriter writer(doc);
+    fb3DomWriter fb3Writer(&writer, &context);
+    LVFileFormatParser * parser = new LVXMLParser(bookStream, &fb3Writer);
+
+    bool ret = parser->Parse();
+    delete parser;
+
+    if ( !ret ) {
+        CRLog::error("Couldn't parse a book");
+    } else {
+#if 1
+    // save compound XML document, for testing:
+    doc->saveToStream(LVOpenFileStream("C:/Temp/fb3_dump.xml", LVOM_WRITE), NULL, true);
+#endif
+
+    }
+
+    if ( progressCallback ) {
+        progressCallback->OnLoadFileEnd( );
+        doc->compact();
+        doc->dumpStatistics();
+    }
+
+    return ret;
+}
+
+lString16 fb3ImportContext::getTargetPath(const lString16 srcPath, const lString16 targetMode, lString16 target)
+{
+    if( !target.empty() ) {
+        if ( targetMode == L"External" || target.pos(L":") != -1 )
+            return target;
+
+        if( !LVIsAbsolutePath(target) ) {
+            target = LVCombinePaths(srcPath, target);
+        }
+        if( LVIsAbsolutePath(target) ) {
+            return target.substr(1);
+        }
+    }
+    return target;
+}
+
+fb3ImportContext::fb3ImportContext(LVContainerRef arc) :
+    m_relationships(64), m_contentTypes(16), m_arc(arc)
+{
+    m_contentTypes.set(cs16(fb3_BodyContentType), lString16(L"/fb3/body.xml"));
+    m_contentTypes.set(cs16(fb3_PropertiesContentType), lString16(L"/meta/core.xml"));
+}
+
+fb3ImportContext::~fb3ImportContext()
+{
+}
+
+bool fb3ImportContext::readRelations(const lString16 path)
+{
+    lString16 srcPath = LVExtractPath(path);
+    lString16 relsPath = srcPath + "_rels/" + LVExtractFilename(path) + ".rels";
+
+    CRLog::info("rels path = %s", LCSTR(relsPath));
+
+    LVStreamRef container_stream = m_arc->OpenStream(relsPath.c_str(), LVOM_READ);
+
+    if ( !container_stream.isNull() ) {
+        ldomDocument * doc = LVParseXMLStream( container_stream );
+        if ( doc ) {
+            ldomNode *root = doc->nodeFromXPath(cs16("Relationships"));
+            if( root ) {
+                for(int i = 0; i < root->getChildCount(); i++) {
+                    ldomNode * relationshipNode = root->getChildNode(i);
+                    const lString16 relType = relationshipNode->getAttributeValue(L"Type");
+                    if( relType != fb3_ImageRelationship)
+                        continue;
+                    const lString16 id = relationshipNode->getAttributeValue(L"Id");
+                    if( !id.empty() ) {
+                        m_relationships.set( id,
+                                             getTargetPath(srcPath, relationshipNode->getAttributeValue(L"TargetMode"),
+                                                           relationshipNode->getAttributeValue(L"Target")) );
+                    }
+                }
+            }
+            delete doc;
+            m_coverImage = readRelationByType(L"/", fb3_CoverRelationship);
+            return true;
+        }
+    }
+    return false;
+}
+
+lString16 fb3ImportContext::readRelationByType(const lString16 path, const lString16 type)
+{
+    lString16 srcPath = LVExtractPath(path);
+    lString16 relsPath = srcPath + cs16("_rels/") + LVExtractFilename(path) + cs16(".rels");
+    lString16 targetPath;
+
+    LVStreamRef container_stream = m_arc->OpenStream(relsPath.c_str(), LVOM_READ);
+    if ( !container_stream.isNull() ) {
+        ldomDocument * doc = LVParseXMLStream( container_stream );
+        if ( doc ) {
+            ldomNode *root = doc->nodeFromXPath(cs16("Relationships"));
+            if( root ) {
+                for(int i = 0; i < root->getChildCount(); i++) {
+                    ldomNode * relationshipNode = root->getChildNode(i);
+                    const lString16 relType = relationshipNode->getAttributeValue(L"Type");
+                    if( relType == type ) {
+                        targetPath = getTargetPath(srcPath, relationshipNode->getAttributeValue(L"TargetMode"),
+                                                   relationshipNode->getAttributeValue(L"Target"));
+                        // return first found
+                        break;
+                    }
+                }
+            }
+            delete doc;
+        }
+    }
+    return targetPath;
+}
+
+bool fb3ImportContext::readContentTypes()
+{
+    bool ret = false;
+
+    LVStreamRef mtStream = m_arc->OpenStream(L"[Content_Types].xml", LVOM_READ );
+    if ( !mtStream.isNull() ) {
+        ldomDocument * doc = LVParseXMLStream( mtStream );
+        if( doc ) {
+            ldomNode *root = doc->nodeFromXPath(cs16("Types"));
+            if(root) {
+                for(int i = 0; i < root->getChildCount(); i++) {
+                    ldomNode * typeNode = root->getChildNode(i);
+                    if(typeNode->getNodeName() == cs16("Override")) {
+                        const lString16 contentType = typeNode->getAttributeValue(L"ContentType");
+                        const lString16 partName = typeNode->getAttributeValue(L"PartName");
+                        if( !contentType.empty() && !partName.empty() ) {
+                            m_contentTypes.set( contentType, partName );
+                        }
+                    }
+                }
+            }
+            delete doc;
+            ret = true;
+        }
+    }
+    return ret;
+}
+
+void fb3DomWriter::writeDescription()
+{
+    //TODO extended FB3 description
+    m_parent->OnTagOpenNoAttr( NULL, L"description" );
+    m_parent->OnTagOpenNoAttr( NULL, L"title-info" );
+    m_parent->OnTagOpenNoAttr( NULL, L"book-title" );
+    m_parent->OnTagClose( NULL, L"book-title" );
+    if ( !m_context->m_coverImage.empty() ) {
+        m_parent->OnTagOpenNoAttr( NULL, L"coverpage" );
+        m_parent->OnTagOpen(NULL, L"image");
+        m_parent->OnAttribute(L"l", L"href", m_context->m_coverImage.c_str());
+        m_parent->OnTagClose( NULL, L"image" );
+        m_parent->OnTagClose( NULL, L"coverpage" );
+    }
+    m_parent->OnTagClose( NULL, L"title-info" );
+    m_parent->OnTagClose( NULL, L"description" );
+}
+
+ldomNode *fb3DomWriter::OnTagOpen(const lChar16 *nsname, const lChar16 *tagname)
+{
+    if( !lStr_cmp(tagname, "fb3-body") ) {
+        m_parent->OnTagOpenNoAttr(NULL, L"FictionBook");
+        writeDescription();
+        tagname = L"body";
+    } else if ( !lStr_cmp(tagname, "notes" )) {
+        if ( m_footnotesBody == NULL ) {
+            m_parent->OnTagClose(NULL, L"body");
+            m_footnotesBody = m_parent->OnTagOpen(NULL,L"body");
+            m_parent->OnAttribute(NULL, L"name", L"notes");
+            m_parent->OnTagBody();
+            return m_footnotesBody;
+        }
+    } else if( !lStr_cmp(tagname, "notebody") ) {
+        tagname = L"section";
+    } else if( !lStr_cmp(tagname, "note") ) {
+        m_checkRole = true;
+        return m_parent->OnTagOpen(nsname, L"a");
+    }
+    return m_parent->OnTagOpen(nsname, tagname);
+}
+
+void fb3DomWriter::OnTagClose(const lChar16 *nsname, const lChar16 *tagname)
+{
+    if ( !lStr_cmp(tagname, "fb3-body") ) {
+        m_parent->OnTagClose(NULL, L"body");
+        tagname = L"FictionBook";
+    } else if ( !lStr_cmp(tagname, "notebody") ) {
+        tagname = L"section";
+    } else if( !lStr_cmp(tagname, "note") ) {
+        tagname = L"a";
+    }
+    m_parent->OnTagClose(nsname, tagname);
+}
+
+void fb3DomWriter::OnTagBody()
+{
+    m_checkRole = false;
+    m_parent->OnTagBody();
+}
+
+void fb3DomWriter::OnAttribute(const lChar16 *nsname, const lChar16 *attrname, const lChar16 *attrvalue)
+{
+    bool pass = true;
+
+    if( !lStr_cmp(attrname, "href") ) {
+        lString16 href(attrvalue);
+
+        if ( href.pos(":") == -1 && href[0] != '#') {
+            href = cs16("#") + href;
+            m_parent->OnAttribute(nsname, attrname, href.c_str());
+            pass = false;
+        }
+    } else if ( m_checkRole && !lStr_cmp(attrname, "role") ) {
+        if( !lStr_cmp(attrvalue, "footnote") )
+            m_parent->OnAttribute(NULL, L"type", L"note");
+        else
+            m_parent->OnAttribute(NULL, L"type", L"comment");
+    } else if ( !lStr_cmp(attrname, "src") ) {
+        lString16 target = m_context->geImageTarget(attrvalue);
+        if( !target.empty() ) {
+            m_parent->OnAttribute(nsname, attrname, target.c_str());
+            pass = false;
+        }
+    }
+    if ( pass) {
+        m_parent->OnAttribute(nsname, attrname, attrvalue);
+    }
+}

--- a/crengine/src/fb3fmt.cpp
+++ b/crengine/src/fb3fmt.cpp
@@ -107,15 +107,6 @@ bool ImportFb3Document( LVStreamRef stream, ldomDocument * doc, LVDocViewCallbac
     }
     doc->setContainer(arc);
 
-#if BUILD_LITE!=1
-    if ( doc->openFromCache(formatCallback) ) {
-        if ( progressCallback ) {
-            progressCallback->OnLoadFileEnd( );
-        }
-        return true;
-    }
-#endif
-
     CRPropRef doc_props = doc->getProps();
     LVStreamRef propStream = arc->OpenStream(context.getContentPath(fb3_PropertiesContentType).c_str(), LVOM_READ );
     if ( propStream.isNull() ) {
@@ -150,6 +141,15 @@ bool ImportFb3Document( LVStreamRef stream, ldomDocument * doc, LVDocViewCallbac
     CRLog::info("Author: %s Title: %s", author.c_str(), title.c_str());
     delete propertiesDoc;
     delete descDoc;
+
+#if BUILD_LITE!=1
+    if ( doc->openFromCache(formatCallback) ) {
+        if ( progressCallback ) {
+            progressCallback->OnLoadFileEnd( );
+        }
+        return true;
+    }
+#endif
 
     LVStreamRef bookStream = arc->OpenStream(context.getContentPath(fb3_BodyContentType).c_str(), LVOM_READ );
     if ( bookStream.isNull() ) {

--- a/crengine/src/fb3fmt.cpp
+++ b/crengine/src/fb3fmt.cpp
@@ -60,14 +60,13 @@ class fb3DomWriter : public LVXMLParserCallback
 private:
     fb3ImportContext *m_context;
     ldomDocumentWriter *m_parent;
-    ldomNode *m_footnotesBody;
     bool m_checkRole;
 protected:
     void writeDescription();
 public:
     /// constructor
     fb3DomWriter(ldomDocumentWriter * parent, fb3ImportContext *importContext ) :
-        m_parent(parent), m_context(importContext), m_footnotesBody(NULL), m_checkRole(false)
+        m_parent(parent), m_context(importContext), m_checkRole(false)
     {
     }
     // LVXMLParserCallback interface
@@ -321,13 +320,11 @@ ldomNode *fb3DomWriter::OnTagOpen(const lChar16 *nsname, const lChar16 *tagname)
         writeDescription();
         tagname = L"body";
     } else if ( !lStr_cmp(tagname, "notes" )) {
-        if ( m_footnotesBody == NULL ) {
-            m_parent->OnTagClose(NULL, L"body");
-            m_footnotesBody = m_parent->OnTagOpen(NULL,L"body");
-            m_parent->OnAttribute(NULL, L"name", L"notes");
-            m_parent->OnTagBody();
-            return m_footnotesBody;
-        }
+         m_parent->OnTagClose(NULL, L"body");
+         ldomNode *footnotesBody = m_parent->OnTagOpen(NULL,L"body");
+         m_parent->OnAttribute(NULL, L"name", L"notes");
+         m_parent->OnTagBody();
+         return footnotesBody;
     } else if( !lStr_cmp(tagname, "notebody") ) {
         tagname = L"section";
     } else if( !lStr_cmp(tagname, "note") ) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -27,6 +27,8 @@
 #include "../include/chmfmt.h"
 #include "../include/wordfmt.h"
 #include "../include/pdbfmt.h"
+#include "../include/fb3fmt.h"
+
 /// to show page bounds rectangles
 //#define SHOW_PAGE_RECT
 
@@ -3890,6 +3892,37 @@ bool LVDocView::LoadDocument(LVStreamRef stream) {
 				return true;
 			}
 		}
+
+        if( DetectFb3Format(m_stream) ) {
+            CRLog::info("FB3 format detected");
+            createEmptyDocument();
+            m_doc->setProps( m_doc_props );
+            setRenderProps( 0, 0 );
+            setDocFormat( doc_format_fb3 );
+            if ( m_callback )
+                m_callback->OnLoadFileFormatDetected(doc_format_fb3);
+            bool res = ImportFb3Document( m_stream, m_doc, m_callback, this );
+            if ( !res ) {
+                setDocFormat( doc_format_none );
+                createDefaultDocument( cs16("ERROR: Error reading FB3 format"), cs16("Cannot open document") );
+                if ( m_callback ) {
+                    m_callback->OnLoadFileError( cs16("Error reading FB3 document") );
+                }
+                return false;
+            } else {
+                m_container = m_doc->getContainer();
+                m_doc_props = m_doc->getProps();
+                setRenderProps( 0, 0 );
+                REQUEST_RENDER("loadDocument")
+                if ( m_callback ) {
+                    m_callback->OnLoadFileEnd( );
+                    //m_doc->compact();
+                    m_doc->dumpStatistics();
+                }
+                m_arc = m_doc->getContainer();
+                return true;
+            }
+        }
 #if CHM_SUPPORT_ENABLED==1
         if ( DetectCHMFormat( m_stream ) ) {
 			// CHM
@@ -4111,6 +4144,8 @@ const lChar16 * getDocFormatName(doc_format_t fmt) {
 	switch (fmt) {
 	case doc_format_fb2:
 		return L"FictionBook (FB2)";
+    case doc_format_fb3:
+        return L"FictionBook (FB3)";
 	case doc_format_txt:
 		return L"Plain text (TXT)";
 	case doc_format_rtf:

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3901,6 +3901,7 @@ bool LVDocView::LoadDocument(LVStreamRef stream) {
             setDocFormat( doc_format_fb3 );
             if ( m_callback )
                 m_callback->OnLoadFileFormatDetected(doc_format_fb3);
+            updateDocStyleSheet();
             bool res = ImportFb3Document( m_stream, m_doc, m_callback, this );
             if ( !res ) {
                 setDocFormat( doc_format_none );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1269,7 +1269,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
             */
             //int offs = 0;
-            if ( txform->GetSrcCount()==0 && style->white_space!=css_ws_pre ) {
+            if ( (txform->GetSrcCount()==0 || (tflags & LTEXT_IS_LINK)) && style->white_space!=css_ws_pre ) {
                 // clear leading spaces for first text of paragraph
                 int i=0;
                 for ( ;txt.length()>i && (txt[i]==' ' || txt[i]=='\t'); i++ )

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -505,16 +505,21 @@ public:
             }
             bool isObject = false;
             bool prevCharIsObject = false;
+            bool isLetterSpacingChanged = false;
             if ( i<m_length ) {
                 newSrc = m_srcs[i];
                 isObject = m_charindex[i] == OBJECT_CHAR_INDEX;
                 newFont = isObject ? NULL : (LVFont *)newSrc->t.font;
+                if (i > 0 && m_srcs[i]->letter_spacing != m_srcs[i -1]->letter_spacing) {
+                    isLetterSpacingChanged = true;
+                }
             }
             if (i > 0)
                 prevCharIsObject = m_charindex[i - 1] == OBJECT_CHAR_INDEX;
             if ( !lastFont )
                 lastFont = newFont;
-            if ( i>start && (newFont!=lastFont || isObject || prevCharIsObject || i>=start+MAX_TEXT_CHUNK_SIZE || (m_flags[i]&LCHAR_MANDATORY_NEWLINE)) ) {
+            if ( i>start && (newFont!=lastFont || isObject || prevCharIsObject || isLetterSpacingChanged
+                             || i>=start+MAX_TEXT_CHUNK_SIZE || (m_flags[i]&LCHAR_MANDATORY_NEWLINE)) ) {
                 // measure start..i-1 chars
                 if ( m_charindex[i-1]!=OBJECT_CHAR_INDEX ) {
                     // measure text

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11035,7 +11035,7 @@ public:
 };
 
 /// returns object image ref name
-lString16 ldomNode::getObjectImageRefName()
+lString16 ldomNode::getObjectImageRefName(bool percentDecode)
 {
     if (!isElement())
         return lString16::empty_str;
@@ -11072,7 +11072,8 @@ lString16 ldomNode::getObjectImageRefName()
     }
     if ( refName.length()<2 )
         return lString16::empty_str;
-    refName = DecodeHTMLUrlString(refName);
+    if (percentDecode)
+        refName = DecodeHTMLUrlString(refName);
     return refName;
 }
 
@@ -11090,11 +11091,18 @@ LVStreamRef ldomNode::getObjectImageStream()
 /// returns object image source
 LVImageSourceRef ldomNode::getObjectImageSource()
 {
-    lString16 refName = getObjectImageRefName();
+    lString16 refName = getObjectImageRefName(true);
     LVImageSourceRef ref;
     if ( refName.empty() )
         return ref;
     ref = getDocument()->getObjectImageSource( refName );
+    if (ref.isNull()) {
+        // try again without percent decoding (for fb3)
+        refName = getObjectImageRefName(false);
+        if ( refName.empty() )
+            return ref;
+        ref = getDocument()->getObjectImageSource( refName );
+    }
     if ( !ref.isNull() ) {
         int dx = ref->GetWidth();
         int dy = ref->GetHeight();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10612,7 +10612,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
             for (int i = 0; i < parent->getChildCount(); i++) {
                 ldomNode * child = parent->getChildNode(i);
                 css_style_ref_t cs = child->getStyle();
-                if ( cs.isNull() )
+                if ( cs.isNull() || cs->display != css_d_list_item )
                     continue;
                 switch ( cs->list_style_type ) {
                 case css_lst_decimal:


### PR DESCRIPTION
### Open issues

- Advanced FB3 features such as SVG images, float property, extended description etc are not supported
- fb2.css was used for fb3 as is, probably some tweaks will be required for FB3
- Not much tested, https://github.com/gribuser/FB3/blob/master/Examples/Hardcore%20file%20structure.fb3 can't be opened. 
- images having names like '%D0%BA%D0%BB%D0%B5%D1%82%D0%BA%D0%B0.jpg' in Anathomy tutorial example.fb3 also can't be opened (getObjectImageRefName() calls DecodeHTMLUrlString() which converts these %* chars, as a result the file can't be found in a zip file, not sure how to handle this caseproperly
