### PR TITLE
The target Android API is set to 28.

### DIFF
--- a/android/.idea/codeStyles/Project.xml
+++ b/android/.idea/codeStyles/Project.xml
@@ -6,5 +6,114 @@
         <option name="LABEL_INDENT_ABSOLUTE" value="true" />
       </indentOptions>
     </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
   </code_scheme>
 </component>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -31,6 +31,7 @@
         android:icon="@mipmap/cr3_logo"
         android:allowClearUserData="true"
         android:process="org.coolreader"
+        android:usesCleartextTraffic="true"
         >
 <!--
             android:configChanges="orientation|keyboardHidden|locale|screenSize"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     defaultConfig {
         applicationId "org.coolreader"
         minSdkVersion 3
-        targetSdkVersion 26
+        targetSdkVersion 28
         // When new version released, version code must be incremented at least by 8
         // for compatibility with ABI versioning of split apk (see below).
         versionCode 32320
@@ -54,7 +54,6 @@ android {
         debug {
             minifyEnabled false
             shrinkResources false
-            useProguard false
             jniDebuggable true
             debuggable true
             externalNativeBuild {
@@ -115,9 +114,6 @@ android {
         // but continue the build even when errors are found:
         abortOnError false
     }
-
-    // https://developer.android.com/about/versions/marshmallow/android-6.0-changes#behavior-apache-http-client
-    useLibrary 'org.apache.http.legacy'
 }
 
 dependencies {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,8 @@
         android:icon="@mipmap/cr3_logo"
         android:label="@string/app_name"
         android:process="org.coolreader"
-        android:resizeableActivity="true">
+        android:resizeableActivity="true"
+        android:usesCleartextTraffic="true" >
 <!--
            android:configChanges="orientation|keyboardHidden|locale|screenSize"
 -->

--- a/android/app/src/test/java/org/coolreader/plugins/litres/UrlEncodedFormEntityReplacementTest.java
+++ b/android/app/src/test/java/org/coolreader/plugins/litres/UrlEncodedFormEntityReplacementTest.java
@@ -1,0 +1,95 @@
+package org.coolreader.plugins.litres;
+
+//import org.apache.http.NameValuePair;
+//import org.apache.http.client.entity.UrlEncodedFormEntity;
+//import org.apache.http.message.BasicNameValuePair;
+
+import org.junit.Test;
+
+//import java.io.ByteArrayOutputStream;
+//import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Iterator;
+//import java.util.LinkedList;
+//import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class UrlEncodedFormEntityReplacementTest {
+	/*
+	@Test
+	public void testUrlEncodedFormEntity() {
+		int offset = 0;
+		int maxCount = 50;
+
+		String result1 = null;
+		final String result_ref = "checkpoint=2000-01-01+00%3A00%3A00&rating=hot&limit=0%2C50&search_types=0";
+
+		Map<String, String> params = new HashMap<String, String>();
+		params.put("rating", "hot");
+		params.put("limit", "" + offset + "," + maxCount);
+		params.put("search_types", "0");
+		params.put("checkpoint", "2000-01-01 00:00:00");
+
+		List<NameValuePair> list = new LinkedList<NameValuePair>();
+		for (Map.Entry<String, String> entry : params.entrySet()) {
+			list.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
+		}
+		try {
+			UrlEncodedFormEntity postParams = new UrlEncodedFormEntity(list, "utf-8");
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			postParams.writeTo(outputStream);
+			outputStream.flush();
+			outputStream.close();
+			result1 = outputStream.toString("UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			fail(e.toString());
+		} catch (IOException e) {
+			fail(e.toString());
+		}
+		assertEquals(result1, result_ref);
+	}
+	 */
+
+	@Test
+	public void testUrlEncodedFormEntityReplacement() {
+		int offset = 0;
+		int maxCount = 50;
+
+		String result1 = null;
+		final String result_ref = "checkpoint=2000-01-01+00%3A00%3A00&rating=hot&limit=0%2C50&search_types=0";
+
+		Map<String, String> params = new HashMap<String, String>();
+		params.put("rating", "hot");
+		params.put("limit", "" + offset + "," + maxCount);
+		params.put("search_types", "0");
+		params.put("checkpoint", "2000-01-01 00:00:00");
+
+		Iterator<Map.Entry<String, String>> iterator = params.entrySet().iterator();
+		String value;
+		String entry_str;
+		result1 = "";
+		while (true) {
+			Map.Entry<String, String> entry = iterator.next();
+			if (null != entry.getValue()) {
+				try {
+					value = URLEncoder.encode(entry.getValue(), "UTF-8");
+				} catch (UnsupportedEncodingException e) {
+					value = "";
+				}
+			} else {
+				value = "";
+			}
+			entry_str = entry.getKey() + "=" + value;
+			result1 += entry_str;
+			if (iterator.hasNext())
+				result1 += "&";
+			else
+				break;
+		}
+		assertEquals(result1, result_ref);
+	}
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 05 12:50:49 GMT+04:00 2019
+#Tue Sep 17 21:53:58 GMT+04:00 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/android/src/org/coolreader/plugins/litres/LitresConnection.java
+++ b/android/src/org/coolreader/plugins/litres/LitresConnection.java
@@ -283,19 +283,6 @@ public class LitresConnection {
 					if (params != null) {
 						connection.setDoOutput(true);
 						connection.setRequestMethod("POST");
-			/*
-						List<NameValuePair> list = new LinkedList<NameValuePair>();
-						for (Map.Entry<String, String> entry : params.entrySet())
-							list.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
-						UrlEncodedFormEntity postParams = new UrlEncodedFormEntity(list, "utf-8");
-						//Log.d(TAG, "params: " + postParams.toString());
-						OutputStream wr = connection.getOutputStream();
-						//OutputStreamWriter wr = new OutputStreamWriter(connection.getOutputStream());
-						postParams.writeTo(wr);
-						//wr.write(postParams.toString());
-						wr.flush();
-						wr.close();
-			 */
 						String postParams = mapParamsToEncodedString(params);
 						OutputStream outputStream = connection.getOutputStream();
 						OutputStreamWriter wr = new OutputStreamWriter(connection.getOutputStream());

--- a/android/src/org/coolreader/plugins/litres/LitresConnection.java
+++ b/android/src/org/coolreader/plugins/litres/LitresConnection.java
@@ -151,7 +151,7 @@ public class LitresConnection {
 
 					String postParams = mapParamsToEncodedString(params);
 					OutputStream outputStream = connection.getOutputStream();
-					OutputStreamWriter wr = new OutputStreamWriter(connection.getOutputStream());
+					OutputStreamWriter wr = new OutputStreamWriter(outputStream);
 					wr.write(postParams);
 					wr.close();
 					outputStream.flush();
@@ -285,7 +285,7 @@ public class LitresConnection {
 						connection.setRequestMethod("POST");
 						String postParams = mapParamsToEncodedString(params);
 						OutputStream outputStream = connection.getOutputStream();
-						OutputStreamWriter wr = new OutputStreamWriter(connection.getOutputStream());
+						OutputStreamWriter wr = new OutputStreamWriter(outputStream);
 						wr.write(postParams);
 						wr.close();
 						outputStream.flush();


### PR DESCRIPTION
1. The target Android API is set to 28.
1.1. HTTP trafic is allowed (by default now only HTTPS is allowed).
1.2. Apache HTTP client deprecation (org.apache.http.*). So part of code in android/src/org/coolreader/plugins/litres/LitresConnection.java is rewrited to implement replacement of org.apache.http.client.entity.UrlEncodedFormEntity.
Test unit has also been created for this purpose.
2. Switch to gradle-5.4.1, Android Gradle plugin 3.5.0.