### PR TITLE
Fixed null-pointer dereference in lStr_cmp() <- LVZipArc::OpenStream().

### DIFF
--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -497,6 +497,12 @@ void lStr_memset(lChar8 * dst, lChar8 value, int count)
 
 int lStr_cmp(const lChar16 * dst, const lChar16 * src)
 {
+    if (dst == src)
+        return 0;
+    if (!dst)
+        return -1;
+    else if (!src)
+        return 1;
     while ( *dst == *src)
     {
         if (! *dst )
@@ -512,6 +518,12 @@ int lStr_cmp(const lChar16 * dst, const lChar16 * src)
 
 int lStr_cmp(const lChar8 * dst, const lChar8 * src)
 {
+    if (dst == src)
+        return 0;
+    if (!dst)
+        return -1;
+    else if (!src)
+        return 1;
     while ( *dst == *src)
     {
         if (! *dst )
@@ -527,6 +539,12 @@ int lStr_cmp(const lChar8 * dst, const lChar8 * src)
 
 int lStr_cmp(const lChar16 * dst, const lChar8 * src)
 {
+    if (!dst && !src)
+        return 0;
+    if (!dst)
+        return -1;
+    else if (!src)
+        return 1;
     while ( *dst == (lChar16)*src)
     {
         if (! *dst )


### PR DESCRIPTION
Synopsis: trying to open some zip files (possibly damaged?) while checking for epub format, when filling out the list of zip archive files, we add a file with an empty name in LVZipArc::ReadContents().
Then in LVZipArc::OpenStream() using m_list[i]->GetName(), the empty name is replaced with NULL, which is passed to lStr_cmp() as second argument, and then dereferenced with SEGFAULT.
Sorry I don't find such files to check this patch.

I only have a stack trace without coredump to fix:

\00 pc 00000000001180a8 /data/app/org.coolreader-4gyZ3VohP-R1OV3NZjowWw==/lib/arm64/libcr3engine-3-2-X.so (LVZipArc::OpenStream(wchar_t const, lvopen_mode_t)+120)
\01 pc 000000000013fdec /data/app/org.coolreader-4gyZ3VohP-R1OV3NZjowWw==/lib/arm64/libcr3engine-3-2-X.so (DetectEpubFormat(LVFastRef<LVStream>)+184)
\02 pc 00000000001b8b08 /data/app/org.coolreader-4gyZ3VohP-R1OV3NZjowWw==/lib/arm64/libcr3engine-3-2-X.so (LVDocView::LoadDocument(LVFastRef<LVStream>)+644)
\03 pc 00000000001c1200 /data/app/org.coolreader-4gyZ3VohP-R1OV3NZjowWw==/lib/arm64/libcr3engine-3-2-X.so (LVDocView::LoadDocument(wchar_t const)+1908)
\04 pc 000000000009eae0 /data/app/org.coolreader-4gyZ3VohP-R1OV3NZjowWw==/lib/arm64/libcr3engine-3-2-X.so (DocViewNative::loadDocument(lString16)+160)
\05 pc 00000000000a2f94 /data/app/org.coolreader-4gyZ3VohP-R1OV3NZjowWw==/lib/arm64/libcr3engine-3-2-X.so (Java_org_coolreader_crengine_DocView_loadDocumentInternal+248)

After addr2line:

\00 pc 0x00000000001180a8: lStr_cmp at crengine\src/lvstring.cpp:500
\01 pc 0x000000000013fdec: DetectEpubFormat(LVFastRef<LVStream>) at crengine\src/epubfmt.cpp:71
\02 pc 0x00000000001b8b08: LVDocView::LoadDocument(LVFastRef<LVStream>) at crengine\src/lvdocview.cpp:3858
\03 pc 0x00000000001c1200: LVDocView::LoadDocument(wchar_t const*) at crengine\src/lvdocview.cpp:3596
\04 pc 0x000000000009eae0: DocViewNative::loadDocument(lString16) at android\jni/docview.cpp:878
\05 pc 0x00000000000a2f94: Java_org_coolreader_crengine_DocView_loadDocumentInternal at android\jni/docview.cpp:1330

Version 3.2.33, commit 766addb5e2caa79a5fa2675865aae77cc311f733 (tag: cr3.2.33):
\00 pc 0x00000000001180a8: lStr_cmp at crengine\src/lvstring.cpp:500
```cpp
	498:	int lStr_cmp(const lChar16 * dst, const lChar16 * src)
	499:	{
	500:	    while ( *dst == *src)
	501:	    {
	502:	        if (! *dst )
	503:	            return 0;
	504:	        ++dst;
	505:	        ++src;
	506:	    }
	507:	    if ( *dst > *src )
	508:	        return 1;
	509:	    else
	510:	        return -1;
	511:	}
```
	Called in crengine/src/lvstream.cpp:
```cpp
	2493:	    virtual LVStreamRef OpenStream( const wchar_t * fname, lvopen_mode_t /*mode*/ )
	2494:	    {
	2495:	        if ( fname[0]=='/' )
	2496:	            fname++;
	2497:	        int found_index = -1;
	2498:	        for (int i=0; i<m_list.length(); i++) {
	2499:	            if ( !lStr_cmp( fname, m_list[i]->GetName() ) ) {
	2500:	                if ( m_list[i]->IsContainer() ) {
	2501:	                    // found directory with same name!!!
	2502:	                    return LVStreamRef();
	2503:	                }
	2504:	                found_index = i;
	2505:	                break;
	2506:	            }
	2507:	        }
```
	m_list[i]->GetName() declated in crengine/include/lvstream.h:539
```cpp
	525:	class LVCommonContainerItemInfo : public LVContainerItemInfo
	526		{
	539:	    virtual const lChar16 * GetName() const { return m_name.empty()?NULL:m_name.c_str(); }
```

	m_list also filled in crengine/src/lvstream.cpp:2724 at int LVZipArc::ReadContents()
```cpp
	2714:	            item->SetItemInfo(fName.c_str(), ZipHeader.UnpSize, (ZipHeader.getAttr() & 0x3f));
	2715:	             item->SetSrc( ZipHeader.getOffset(), ZipHeader.PackSize, ZipHeader.Method );

	2724:	             m_list.add(item);
```

\01 pc 0x000000000013fdec: DetectEpubFormat(LVFastRef<LVStream>) at crengine\src/epubfmt.cpp:71
```cpp
	58:	bool DetectEpubFormat( LVStreamRef stream )
	59:	{
	60:
	61:
	62:	    LVContainerRef m_arc = LVOpenArchieve( stream );
	63:	    if ( m_arc.isNull() )
	64:	        return false; // not a ZIP archive
	65:
	66:	    //dumpZip( m_arc );
	67:
	68:	    // read "mimetype" file contents from root of archive
	69:	    lString16 mimeType;
	70:	    {
	71:	        LVStreamRef mtStream = m_arc->OpenStream(L"mimetype", LVOM_READ );
	72:	        if ( !mtStream.isNull() ) {
	73:	            int size = mtStream->GetSize();
	74:	            if ( size>4 && size<100 ) {
	75:	                LVArray<char> buf( size+1, '\0' );
	76:	                if ( mtStream->Read( buf.get(), size, NULL )==LVERR_OK ) {
	77:	                    for ( int i=0; i<size; i++ )
	78:	                        if ( buf[i]<32 || ((unsigned char)buf[i])>127 )
	79:	                            buf[i] = 0;
	80:	                    buf[size] = 0;
	81:	                    if ( buf[0] )
	82:	                        mimeType = Utf8ToUnicode( lString8( buf.get() ) );
	83:	                }
	84:	            }
	85:	        }
	86:	    }
	87:
	88:	    if ( mimeType != L"application/epub+zip" )
	89:	        return false;
	90:	    return true;
	91:	}
```
\02 pc 0x00000000001b8b08: LVDocView::LoadDocument(LVFastRef<LVStream>) at crengine\src/lvdocview.cpp:3858
```cpp
	3858:			if ( DetectEpubFormat( m_stream ) ) {
```

\03 pc 0x00000000001c1200: LVDocView::LoadDocument(wchar_t const*) at crengine\src/lvdocview.cpp:3596
```cpp
	3595:			// loading document
	3596:			if (LoadDocument(stream)) {
	3597:				m_filename = lString16(fname);
	3598:				m_stream.Clear();
	3599:				return true;
	3600:			}
```

\04 pc 0x000000000009eae0: DocViewNative::loadDocument(lString16) at android\jni/docview.cpp:878
```cpp
	875:	bool DocViewNative::loadDocument( lString16 filename )
	876:	{
	877:		CRLog::info("Loading document %s", LCSTR(filename));
	878:		bool res = _docview->LoadDocument(filename.c_str());
	879:		if (res)
	880:			CRLog::info("Document %s is loaded successfully", LCSTR(filename));
	881:		else {
	882:			CRLog::info("Document %s not is loaded due to error", LCSTR(filename));
	883:			if (_docview->getDocument() == NULL) {
	884:				// _docview->LoadDocument() can return false with _docview->m_doc == NULL when:
	885:				// 1. I/O error - failed to open file
	886:				// 2. open archive without supported files
	887:				CRLog::error("Document is NULL, inserting stub.");
	888:				_docview->createDefaultDocument(lString16::empty_str, Utf8ToUnicode("Error while opening file!"));
	889:			}
	890:		}
	891:	    return res;
	892:	}
```
\05 pc 0x00000000000a2f94: Java_org_coolreader_crengine_DocView_loadDocumentInternal at android\jni/docview.cpp:1330
```cpp
	1319:	JNIEXPORT jboolean JNICALL Java_org_coolreader_crengine_DocView_loadDocumentInternal
	1320:	  (JNIEnv * _env, jobject _this, jstring s)
	1321:	{
	1322:		CRJNIEnv env(_env);
	1323:	    DocViewNative * p = getNative(_env, _this);
	1324:	    if (!p) {
	1325:	    	CRLog::error("Cannot get native view");
	1326:	    	return JNI_FALSE;
	1327:	    }
	1328:		DocViewCallback callback( _env, p->_docview, _this );
	1329:		lString16 str = env.fromJavaString(s);
	1330:	    bool res = p->loadDocument(str);
	1331:	    return res ? JNI_TRUE : JNI_FALSE;
	1332:	}
```