### PR TITLE
Fixed docx parser to handle properly a case when only content element in a paragraph is hyperlink

### DIFF
--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -1912,6 +1912,7 @@ ldomNode * docx_pHandler::handleTagOpen(int tagId)
 {
     switch(tagId) {
     case docx_el_r:
+    case docx_el_hyperlink:
         if ( 0 == m_runCount ) {
             m_pPr.combineWith(m_importContext->get_pPrDefault());
             css_length_t outlineLevel = m_pPr.getOutlineLvl();
@@ -1942,14 +1943,15 @@ ldomNode * docx_pHandler::handleTagOpen(int tagId)
                 m_writer->OnAttribute(L"", L"style", style.c_str());
             m_writer->OnTagBody();
         }
-        m_rHandler.start();
+        if(docx_el_r == tagId)
+            m_rHandler.start();
+        else
+            m_hyperlinkHandler.start();
         m_runCount++;
         break;
     case docx_el_bookmarkStart:
         m_state = tagId;
         break;
-    case docx_el_hyperlink:
-        m_hyperlinkHandler.start();
         break;
     case docx_el_pPr:
         m_pPrHandler.start(&m_pPr);

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -318,15 +318,13 @@ public:
     static const int PROP_COUNT = N;
 
     virtual void reset() {
-        for(int i = 0; i < N; i++) {
-            m_properties[i].type = css_val_unspecified;
-            m_properties[i].value = 0;
-        }
+        init();
     }
+
     virtual ~docx_PropertiesContainer() {}
 
     docx_PropertiesContainer() {
-        reset();
+        init();
     }
 
     css_length_t get(int index) const {
@@ -377,6 +375,13 @@ public:
 
 protected:
     css_length_t m_properties[N];
+private:
+    void init() {
+        for(int i = 0; i < N; i++) {
+            m_properties[i].type = css_val_unspecified;
+            m_properties[i].value = 0;
+        }
+    }
 };
 
 enum docx_run_properties

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -2743,7 +2743,7 @@ void docx_hyperlinkHandler::handleAttribute(const lChar16 *attrname, const lChar
         if ( !lStr_cmp(attrname, "id") ) {
             m_target = m_importContext->getLinkTarget(lString16(attrvalue));
         } else if (!lStr_cmp(attrname, "anchor") && m_target.empty()) {
-            m_target = lString16(attrvalue);
+            m_target = cs16("#") + lString16(attrvalue);
         }
     }
 }


### PR DESCRIPTION
The following example illustrates the problem:
```xml
	<w:p>
	               <w:pPr>
                         ...
			</w:pPr>
			<w:hyperlink w:anchor="bookmark238" w:tooltip="Current Document">
				<w:r>
					<w:rPr>
					</w:rPr>
					<w:t>Some item</w:t>
				</w:r>
				<w:r>
					<w:rPr>
					</w:rPr>
					<w:tab/>
					<w:t>27</w:t>
				</w:r>
			</w:hyperlink>
	</w:p>
```
Before the fix, no `<p>` element was produced for the above code, because of it, all such paragraphs were glued together on a single line and it is not good for reading :)

@poire-z, FYI this bug was reported by koreader user.