### PR TITLE
cr3.2.33 fixes

### DIFF
--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -3246,6 +3246,8 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			return currentImageViewer.prepareImage();
 
 		PositionProperties currpos = doc.getPositionProps(null);
+		if (null == currpos)
+			return null;
 
 		boolean isPageView = currpos.pageMode != 0;
 

--- a/crengine/Tools/glyphcache_bench/CMakeLists.txt
+++ b/crengine/Tools/glyphcache_bench/CMakeLists.txt
@@ -5,12 +5,22 @@ set(SRC_LIST
     lvfontglyphcache_b.cpp
 )
 
+set(crengine_part_SRC_LIST
+    ../../src/crconcurrent.cpp
+    ../../src/lvstring.cpp
+    ../../src/lvmemman.cpp
+    ../../src/lvstream.cpp
+    ../../src/crtxtenc.cpp
+    ../../src/cp_stats.cpp
+    ../../src/private/lvfontglyphcache.cpp
+)
+
 if(WIN32)
     add_definitions(-DWIN32 -D_CONSOLE)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mconsole")
 endif(WIN32)
 
-add_executable(glyphcache_bench ${SRC_LIST})
-#target_link_libraries(glyphcache_bench)
+add_executable(glyphcache_bench ${SRC_LIST} ${crengine_part_SRC_LIST})
+target_link_libraries(glyphcache_bench ${ZLIB_LIBRARIES})
 
 configure_file(valgrind_check.sh.cmake ${CMAKE_CURRENT_BINARY_DIR}/valgrind_check.sh)

--- a/crengine/Tools/glyphcache_bench/lvfontglyphcache_a.cpp
+++ b/crengine/Tools/glyphcache_bench/lvfontglyphcache_a.cpp
@@ -15,11 +15,11 @@
 // This file contains copy of class LVFontLocalGlyphCacheA from cr3.2.31
 
 #include "lvfontglyphcache_a.h"
-//#include "../../include/crlocks.h"
+#include "../../include/crlocks.h"
 
 
 void LVFontLocalGlyphCacheA::clear() {
-    //FONT_LOCAL_GLYPH_CACHE_GUARD
+    FONT_LOCAL_GLYPH_CACHE_GUARD
     while (head) {
         LVFontGlyphCacheItemA *ptr = head;
         remove(ptr);
@@ -29,7 +29,7 @@ void LVFontLocalGlyphCacheA::clear() {
 }
 
 LVFontGlyphCacheItemA *LVFontLocalGlyphCacheA::getByChar(lChar16 ch) {
-    //FONT_LOCAL_GLYPH_CACHE_GUARD
+    FONT_LOCAL_GLYPH_CACHE_GUARD
     LVFontGlyphCacheItemA *ptr = head;
     for (; ptr; ptr = ptr->next_local) {
         if (ptr->data.ch == ch) {
@@ -43,7 +43,7 @@ LVFontGlyphCacheItemA *LVFontLocalGlyphCacheA::getByChar(lChar16 ch) {
 #if USE_HARFBUZZ==1
 LVFontGlyphCacheItemA* LVFontLocalGlyphCacheA::getByIndex(lUInt32 index)
 {
-    //FONT_LOCAL_GLYPH_CACHE_GUARD
+    FONT_LOCAL_GLYPH_CACHE_GUARD
     LVFontGlyphCacheItemA *ptr = head;
     for (; ptr; ptr = ptr->next_local) {
         if (ptr->data.gindex == index) {
@@ -56,7 +56,7 @@ LVFontGlyphCacheItemA* LVFontLocalGlyphCacheA::getByIndex(lUInt32 index)
 #endif
 
 void LVFontLocalGlyphCacheA::put(LVFontGlyphCacheItemA *item) {
-    //FONT_LOCAL_GLYPH_CACHE_GUARD
+    FONT_LOCAL_GLYPH_CACHE_GUARD
     global_cache->put(item);
     item->next_local = head;
     if (head)
@@ -68,7 +68,7 @@ void LVFontLocalGlyphCacheA::put(LVFontGlyphCacheItemA *item) {
 
 /// remove from list, but don't delete
 void LVFontLocalGlyphCacheA::remove(LVFontGlyphCacheItemA *item) {
-    //FONT_LOCAL_GLYPH_CACHE_GUARD
+    FONT_LOCAL_GLYPH_CACHE_GUARD
     if (item == head)
         head = item->next_local;
     if (item == tail)
@@ -84,7 +84,7 @@ void LVFontLocalGlyphCacheA::remove(LVFontGlyphCacheItemA *item) {
 }
 
 void LVFontGlobalGlyphCacheA::refresh(LVFontGlyphCacheItemA *item) {
-    //FONT_GLYPH_CACHE_GUARD
+    FONT_GLYPH_CACHE_GUARD
     if (tail != item) {
         //move to head
         removeNoLock(item);
@@ -93,7 +93,7 @@ void LVFontGlobalGlyphCacheA::refresh(LVFontGlyphCacheItemA *item) {
 }
 
 void LVFontGlobalGlyphCacheA::put(LVFontGlyphCacheItemA *item) {
-    //FONT_GLYPH_CACHE_GUARD
+    FONT_GLYPH_CACHE_GUARD
     putNoLock(item);
 }
 
@@ -119,7 +119,7 @@ void LVFontGlobalGlyphCacheA::putNoLock(LVFontGlyphCacheItemA *item) {
 }
 
 void LVFontGlobalGlyphCacheA::remove(LVFontGlyphCacheItemA *item) {
-    //FONT_GLYPH_CACHE_GUARD
+    FONT_GLYPH_CACHE_GUARD
     removeNoLock(item);
 }
 
@@ -140,7 +140,7 @@ void LVFontGlobalGlyphCacheA::removeNoLock(LVFontGlyphCacheItemA *item) {
 }
 
 void LVFontGlobalGlyphCacheA::clear() {
-    //FONT_GLYPH_CACHE_GUARD
+    FONT_GLYPH_CACHE_GUARD
     while (head) {
         LVFontGlyphCacheItemA *ptr = head;
         remove(ptr);

--- a/crengine/Tools/glyphcache_bench/lvfontglyphcache_b.h
+++ b/crengine/Tools/glyphcache_bench/lvfontglyphcache_b.h
@@ -53,6 +53,8 @@ public:
 
 	void remove(LVFontGlyphCacheItemB *item);
 
+	void refresh(LVFontGlyphCacheItemB *item);
+
 	void clear();
 
 	int getSize() { return size; }

--- a/crengine/Tools/glyphcache_bench/main.cpp
+++ b/crengine/Tools/glyphcache_bench/main.cpp
@@ -278,7 +278,7 @@ int main(int /*argc*/, char* /*argv*/[])
     LVFontLocalGlyphCache localCache(&globalCache);
     LVFontGlyphCacheItem* item;
 
-    uint64_t tmp;
+    volatile uint64_t tmp;
     struct timeval ts1;
     struct timeval ts2;
     int64_t elapsed;
@@ -334,7 +334,7 @@ int main(int /*argc*/, char* /*argv*/[])
     printf("t = %lld\n", tmp);
 
     // bench lookup based on hash table
-    printf("bench cache based on hash table (copy from cr3.2.32)...\n");
+    printf("bench cache based on hash table (candidate introduced in cr3.2.32)...\n");
     gettimeofday(&ts1, NULL);
     for (j = 0; j < bench_sz; j++)
     {

--- a/crengine/Tools/glyphcache_bench/main.cpp
+++ b/crengine/Tools/glyphcache_bench/main.cpp
@@ -1,9 +1,11 @@
 
 #include "lvfontglyphcache_a.h"
 #include "lvfontglyphcache_b.h"
+#include "../../src/private/lvfontglyphcache.h"
 #include "lvtypes.h"
 
 #include <stdio.h>
+#include <stdint.h>
 #include <sys/time.h>
 #include <limits.h>
 
@@ -271,7 +273,12 @@ int main(int /*argc*/, char* /*argv*/[])
     LVFontGlobalGlyphCacheB globalCacheB(0x40000);
     LVFontLocalGlyphCacheB localCacheB(&globalCacheB, 256);
     LVFontGlyphCacheItemB* itemB;
-    u_int64_t tmp;
+
+    LVFontGlobalGlyphCache globalCache(0x40000);
+    LVFontLocalGlyphCache localCache(&globalCache);
+    LVFontGlyphCacheItem* item;
+
+    uint64_t tmp;
     struct timeval ts1;
     struct timeval ts2;
     int64_t elapsed;
@@ -296,10 +303,18 @@ int main(int /*argc*/, char* /*argv*/[])
             itemB->origin_y = 0;
             localCacheB.put(itemB);
         }
+        item = LVFontGlyphCacheItem::newItem(&localCache, glyphCodes_tofill[i], 10, 10);
+        if (item)
+        {
+            item->origin_x = 0;
+            item->origin_y = 0;
+            localCache.put(item);
+        }
     }
 
     printf("size of global cacheA: %u\n", globalCacheA.getSize());
     printf("size of global cacheB: %u\n", globalCacheB.getSize());
+    printf("size of global cache: no data...\n");
 
     // bench lookup based on linked list
     printf("bench cache based on linked list...\n");
@@ -319,7 +334,7 @@ int main(int /*argc*/, char* /*argv*/[])
     printf("t = %lld\n", tmp);
 
     // bench lookup based on hash table
-    printf("bench cache based on hash table...\n");
+    printf("bench cache based on hash table (copy from cr3.2.32)...\n");
     gettimeofday(&ts1, NULL);
     for (j = 0; j < bench_sz; j++)
     {
@@ -334,9 +349,26 @@ int main(int /*argc*/, char* /*argv*/[])
     printf("%lld us\n", elapsed);
     printf("t = %lld\n", tmp);
 
+    // bench lookup based on hash table
+    printf("bench cache based on hash table (current version)...\n");
+    gettimeofday(&ts1, NULL);
+    for (j = 0; j < bench_sz; j++)
+    {
+        for (i = 0; i < lookup_seq_sz; i++)
+        {
+            item = localCache.get(lookup_seq[i]);
+            tmp += item->origin_x;
+        }
+    }
+    gettimeofday(&ts2, NULL);
+    elapsed = timevalcmp(&ts2, &ts1);
+    printf("%lld us\n", elapsed);
+    printf("t = %lld\n", tmp);
+
     // cleanup
     globalCacheA.clear();
     globalCacheB.clear();
+    globalCache.clear();
     return 0;
 }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11313,8 +11313,8 @@ ldomNode * ldomNode::persist()
         } else {
             // TEXT->PTEXT
             lString8 utf8 = _data._text_ptr->getText();
-            delete _data._text_ptr;
             lUInt32 parentIndex = _data._text_ptr->getParentIndex();
+            delete _data._text_ptr;
             _handle._dataIndex = (_handle._dataIndex & ~0xF) | NT_PTEXT;
             _data._ptext_addr = getDocument()->_textStorage.allocText(_handle._dataIndex, parentIndex, utf8 );
             // change type

--- a/tinydict/tinydict.cpp
+++ b/tinydict/tinydict.cpp
@@ -606,7 +606,7 @@ TinyDictZStream::~TinyDictZStream()
     if ( chunks )
         delete [] chunks;
     if ( offsets )
-        delete offsets;
+        delete [] offsets;
 }
 
 bool TinyDictZStream::open( FILE * file )

--- a/tinydict/tinydict.cpp
+++ b/tinydict/tinydict.cpp
@@ -604,7 +604,7 @@ TinyDictZStream::~TinyDictZStream()
     if ( unp_buffer )
         free( unp_buffer );
     if ( chunks )
-        delete chunks;
+        delete [] chunks;
     if ( offsets )
         delete offsets;
 }


### PR DESCRIPTION
1. Try to fix NPE: java.lang.NullPointerException:
at org.coolreader.crengine.ReaderView.preparePageImage (ReaderView.java:3250)
at org.coolreader.crengine.ReaderView.access$1700 (ReaderView.java:42)
at org.coolreader.crengine.ReaderView$LoadDocumentTask$6.run (ReaderView.java:4907)
2. Fixed clang-analyzer warning: 'Bad deallocator'. Memory allocated by 'new[]' should be deallocated by 'delete[]', not 'delete'.
2.1. Fixed memory error in lvtinydom.cpp: Use-after-free.
3. Updated subproject glyphcache_bench.
