### PR TITLE
Issue126

### DIFF
--- a/android/jni/cr3engine.cpp
+++ b/android/jni/cr3engine.cpp
@@ -857,6 +857,7 @@ static JNINativeMethod sDocViewMethods[] = {
   {"destroyInternal", "()V", (void*)Java_org_coolreader_crengine_DocView_destroyInternal},
   {"getPageImageInternal", "(Landroid/graphics/Bitmap;I)V", (void*)Java_org_coolreader_crengine_DocView_getPageImageInternal},
   {"loadDocumentInternal", "(Ljava/lang/String;)Z", (void*)Java_org_coolreader_crengine_DocView_loadDocumentInternal},
+  {"loadDocumentFromMemoryInternal", "([BLjava/lang/String;)Z", (void*)Java_org_coolreader_crengine_DocView_loadDocumentFromMemoryInternal},
   {"getSettingsInternal", "()Ljava/util/Properties;", (void*)Java_org_coolreader_crengine_DocView_getSettingsInternal},
   {"applySettingsInternal", "(Ljava/util/Properties;)Z", (void*)Java_org_coolreader_crengine_DocView_applySettingsInternal},
   {"setStylesheetInternal", "(Ljava/lang/String;)V", (void*)Java_org_coolreader_crengine_DocView_setStylesheetInternal},

--- a/android/jni/docview.h
+++ b/android/jni/docview.h
@@ -30,6 +30,7 @@ public:
 	bool saveHistory( lString16 filename );
 	void createDefaultDocument( lString16 title, lString16 message );
 	bool loadDocument( lString16 filename );
+	bool loadDocument( LVStreamRef stream, lString16 contentPath );
 	int doCommand( int cmd, int param );
     bool findText( lString16 pattern, int origin, bool reverse, bool caseInsensitive );
     void clearSelection();

--- a/android/jni/org_coolreader_crengine_DocView.h
+++ b/android/jni/org_coolreader_crengine_DocView.h
@@ -55,6 +55,14 @@ JNIEXPORT jboolean JNICALL Java_org_coolreader_crengine_DocView_loadDocumentInte
 
 /*
  * Class:     org_coolreader_crengine_DocView
+ * Method:    loadDocumentFromMemoryInternal
+ * Signature: ([BLjava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_coolreader_crengine_DocView_loadDocumentFromMemoryInternal
+        (JNIEnv *, jobject, jbyteArray, jstring);
+
+/*
+ * Class:     org_coolreader_crengine_DocView
  * Method:    getSettingsInternal
  * Signature: ()Ljava/util/Properties;
  */

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -1,6 +1,7 @@
 // Main Class
 package org.coolreader;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -278,16 +279,6 @@ public class CoolReader extends BaseActivity {
 			mReaderFrame.updateFullscreen(fullscreen);
 	}
 
-	private String extractFileName(Uri uri) {
-		if (uri != null) {
-			if (uri.equals(Uri.parse("file:///")))
-				return null;
-			else
-				return uri.getPath();
-		}
-		return null;
-	}
-
 	@Override
 	protected void onNewIntent(Intent intent) {
 		log.i("onNewIntent : " + intent);
@@ -303,21 +294,12 @@ public class CoolReader extends BaseActivity {
 		if (intent == null)
 			return false;
 		String fileToOpen = null;
-		String scheme = null;
-		String host = null;
 		Uri uri = null;
 		if (Intent.ACTION_VIEW.equals(intent.getAction())) {
 			uri = intent.getData();
 			intent.setData(null);
 			if (uri != null) {
-				scheme = uri.getScheme();
-				host = uri.getHost();
-				if (uri.getEncodedPath().contains("%00"))
-					fileToOpen = uri.getEncodedPath();
-				else
-					fileToOpen = uri.getPath();
-//				if (fileToOpen.startsWith("file://"))
-//					fileToOpen = fileToOpen.substring("file://".length());
+				fileToOpen = filePathFromUri(uri);
 			}
 		}
 		if (fileToOpen == null && intent.getExtras() != null) {
@@ -325,68 +307,6 @@ public class CoolReader extends BaseActivity {
 			fileToOpen = intent.getExtras().getString(OPEN_FILE_PARAM);
 		}
 		if (fileToOpen != null) {
-			// parse uri from system filemanager
-			if (fileToOpen.contains("%00")) {
-				// splitter between archive file name and inner file.
-				fileToOpen = fileToOpen.replace("%00", "@/");
-				fileToOpen = Uri.decode(fileToOpen);
-			}
-			if ("content".equals(scheme)) {
-				if ("com.android.externalstorage.documents".equals(host)) {
-					// application "Files" by Google, package="com.android.externalstorage.documents"
-					if (fileToOpen.matches("^/document/.*:.*$")) {
-						// decode special uri form: /document/primary:<somebody>
-						//                          /document/XXXX-XXXX:<somebody>
-						String shortcut = fileToOpen.replaceFirst("^/document/(.*):.*$", "$1");
-						String mountRoot = Engine.getMountRootByShortcut(shortcut);
-						if (mountRoot != null) {
-							fileToOpen = fileToOpen.replaceFirst("^/document/.*:(.*)$", mountRoot + "/$1");
-							scheme = "file";
-						}
-					}
-				} else if ("com.google.android.apps.nbu.files.provider".equals(host)) {
-					// application "Files" by Google, package="com.google.android.apps.nbu.files"
-					if (fileToOpen.startsWith("/1////")) {
-						// skip "/1///"
-						fileToOpen = fileToOpen.substring(5);
-						fileToOpen = Uri.decode(fileToOpen);
-						scheme = "file";
-					} else if (fileToOpen.startsWith("/1/file:///")) {
-						// skip "/1/file://"
-						fileToOpen = fileToOpen.substring(10);
-						fileToOpen = Uri.decode(fileToOpen);
-						scheme = "file";
-					}
-				}
-			}
-		}
-		if ("content".equals(scheme) && null != uri) {
-			final String finalUriString = uri.toString();
-			loadDocumentFromUri(uri, new Runnable() {
-				@Override
-				public void run() {
-					BackgroundThread.instance().postGUI(new Runnable() {
-						@Override
-						public void run() {
-							// if document not loaded show error & then root window
-							ErrorDialog errDialog = new ErrorDialog(CoolReader.this, CoolReader.this.getString(R.string.error), CoolReader.this.getString(R.string.cant_open_file, finalUriString));
-							errDialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
-								@Override
-								public void onDismiss(DialogInterface dialog) {
-									showRootWindow();
-								}
-							});
-							errDialog.show();
-						}
-					}, 500);
-				}
-			});
-			return true;
-		} else if (fileToOpen != null) {
-			// patch for opening of books from ReLaunch (under Nook Simple Touch) 
-			while (fileToOpen.indexOf("%2F") >= 0) {
-				fileToOpen = fileToOpen.replace("%2F", "/");
-			}
 			log.d("FILE_TO_OPEN = " + fileToOpen);
 			final String finalFileToOpen = fileToOpen;
 			loadDocument(fileToOpen, new Runnable() {
@@ -409,10 +329,103 @@ public class CoolReader extends BaseActivity {
 				}
 			});
 			return true;
+		} else if (null != uri) {
+			log.d("URI_TO_OPEN = " + uri);
+			final String uriString = uri.toString();
+			loadDocumentFromUri(uri, new Runnable() {
+				@Override
+				public void run() {
+					BackgroundThread.instance().postGUI(new Runnable() {
+						@Override
+						public void run() {
+							// if document not loaded show error & then root window
+							ErrorDialog errDialog = new ErrorDialog(CoolReader.this, CoolReader.this.getString(R.string.error), CoolReader.this.getString(R.string.cant_open_file, uriString));
+							errDialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
+								@Override
+								public void onDismiss(DialogInterface dialog) {
+									showRootWindow();
+								}
+							});
+							errDialog.show();
+						}
+					}, 500);
+				}
+			});
+			return true;
 		} else {
 			log.d("No file to open");
 			return false;
 		}
+	}
+
+	private String filePathFromUri(Uri uri) {
+		if (null == uri)
+			return null;
+		String filePath = null;
+		String scheme = uri.getScheme();
+		String host = uri.getHost();
+		if ("file".equals(scheme)) {
+			filePath = uri.getPath();
+			// patch for opening of books from ReLaunch (under Nook Simple Touch)
+			if (null != filePath) {
+				if (filePath.contains("%2F"))
+					filePath = filePath.replace("%2F", "/");
+			}
+		} else if ("content".equals(scheme)) {
+			if (uri.getEncodedPath().contains("%00"))
+				filePath = uri.getEncodedPath();
+			else
+				filePath = uri.getPath();
+			if (null != filePath) {
+				// parse uri from system filemanager
+				if (filePath.contains("%00")) {
+					// splitter between archive file name and inner file.
+					filePath = filePath.replace("%00", "@/");
+					filePath = Uri.decode(filePath);
+				}
+				if ("com.android.externalstorage.documents".equals(host)) {
+					// application "Files" by Google, package="com.android.externalstorage.documents"
+					if (filePath.matches("^/document/.*:.*$")) {
+						// decode special uri form: /document/primary:<somebody>
+						//                          /document/XXXX-XXXX:<somebody>
+						String shortcut = filePath.replaceFirst("^/document/(.*):.*$", "$1");
+						String mountRoot = Engine.getMountRootByShortcut(shortcut);
+						if (mountRoot != null) {
+							filePath = filePath.replaceFirst("^/document/.*:(.*)$", mountRoot + "/$1");
+						}
+					}
+				} else if ("com.google.android.apps.nbu.files.provider".equals(host)) {
+					// application "Files" by Google, package="com.google.android.apps.nbu.files"
+					if (filePath.startsWith("/1////")) {
+						// skip "/1///"
+						filePath = filePath.substring(5);
+						filePath = Uri.decode(filePath);
+					} else if (filePath.startsWith("/1/file:///")) {
+						// skip "/1/file://"
+						filePath = filePath.substring(10);
+						filePath = Uri.decode(filePath);
+					}
+				} else {
+					// Try some common conversions...
+					if (filePath.startsWith("/file%3A%2F%2F")) {
+						filePath = filePath.substring(14);
+						filePath = Uri.decode(filePath);
+						if (filePath.contains("%20")) {
+							filePath = filePath.replace("%20", " ");
+						}
+					}
+				}
+			}
+		}
+		File file;
+		int pos = filePath.indexOf("@/");
+		if (pos > 0)
+			file = new File(filePath.substring(0, pos));
+		else
+			file = new File(filePath);
+		if (!file.exists())
+			filePath = null;
+		return filePath;
 	}
 
 	@Override

--- a/android/src/org/coolreader/crengine/DocView.java
+++ b/android/src/org/coolreader/crengine/DocView.java
@@ -166,6 +166,7 @@ public class DocView {
 	/**
 	 * Load document from input stream.
 	 * @param inputStream
+	 * @param contentPath
 	 * @return
 	 */
 	public boolean loadDocumentFromStream(InputStream inputStream, String contentPath) {

--- a/android/src/org/coolreader/crengine/DocView.java
+++ b/android/src/org/coolreader/crengine/DocView.java
@@ -3,6 +3,10 @@ package org.coolreader.crengine;
 
 import android.graphics.Bitmap;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 public class DocView {
 
 	public static final Logger log = L.create("dv");
@@ -156,6 +160,31 @@ public class DocView {
 	public boolean loadDocument(String fileName) {
 		synchronized(mutex) {
 			return loadDocumentInternal(fileName);
+		}
+	}
+
+	/**
+	 * Load document from input stream.
+	 * @param inputStream
+	 * @return
+	 */
+	public boolean loadDocumentFromStream(InputStream inputStream, String contentPath) {
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		byte [] buf = new byte [1024];
+		int readBytes;
+		while (true) {
+			try {
+				readBytes = inputStream.read(buf);
+				if (readBytes > 0)
+					outputStream.write(buf, 0, readBytes);
+				else
+					break;
+			} catch (IOException e) {
+				break;
+			}
+		}
+		synchronized(mutex) {
+			return loadDocumentFromMemoryInternal(outputStream.toByteArray(), contentPath);
 		}
 	}
 
@@ -410,6 +439,8 @@ public class DocView {
 	private native void createDefaultDocumentInternal(String title, String message);
 
 	private native boolean loadDocumentInternal(String fileName);
+
+	private native boolean loadDocumentFromMemoryInternal(byte [] buf, String contentPath);
 
 	private native java.util.Properties getSettingsInternal();
 

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -3,6 +3,7 @@ package org.coolreader.crengine;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Locale;
@@ -2957,7 +2958,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	public boolean reloadDocument() {
 		if (this.mBookInfo != null && this.mBookInfo.getFileInfo() != null) {
 			save(); // save current position
-			post(new LoadDocumentTask(this.mBookInfo, null));
+			post(new LoadDocumentTask(this.mBookInfo, null, null));
 			return true;
 		}
 		return false;
@@ -2983,7 +2984,37 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 							@Override
 							public void run() {
 								log.v("synced posting LoadDocument task to GUI thread");
-								post(new LoadDocumentTask(bookInfo, errorHandler));
+								post(new LoadDocumentTask(bookInfo, null, errorHandler));
+							}
+						});
+					}
+				});
+			}
+		});
+		return true;
+	}
+
+	public boolean loadDocumentFromStream(final InputStream inputStream, final FileInfo fileInfo, final Runnable errorHandler) {
+		log.v("loadDocument(" + fileInfo.getPathName() + ")");
+		if (this.mBookInfo != null && this.mBookInfo.getFileInfo().pathname.equals(fileInfo.pathname) && mOpened) {
+			log.d("trying to load already opened document");
+			mActivity.showReader();
+			drawPage();
+			return false;
+		}
+		Services.getHistory().getOrCreateBookInfo(mActivity.getDB(), fileInfo, new History.BookInfoLoadedCallack() {
+			@Override
+			public void onBookInfoLoaded(final BookInfo bookInfo) {
+				log.v("posting LoadDocument task to background thread");
+				BackgroundThread.instance().postBackground(new Runnable() {
+					@Override
+					public void run() {
+						log.v("posting LoadDocument task to GUI thread");
+						BackgroundThread.instance().postGUI(new Runnable() {
+							@Override
+							public void run() {
+								log.v("synced posting LoadDocument task to GUI thread");
+								post(new LoadDocumentTask(bookInfo, inputStream, errorHandler));
 							}
 						});
 					}
@@ -3074,6 +3105,30 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			log.v("loadDocument() : item from history : " + fi);
 		}
 		return loadDocument(fi, errorHandler);
+	}
+
+	public boolean loadDocumentFromStream(InputStream inputStream, String contentPath, final Runnable errorHandler) {
+		BackgroundThread.ensureGUI();
+		save();
+		log.i("loadDocument(" + contentPath + ")");
+		if (contentPath == null || inputStream == null) {
+			log.v("loadDocument() : no filename specified");
+			if (errorHandler != null)
+				errorHandler.run();
+			return false;
+		}
+		BookInfo book = Services.getHistory().getBookInfo(contentPath);
+		if (book != null)
+			log.v("loadDocument() : found book in history : " + book);
+		FileInfo fi = null;
+		if (book == null) {
+			log.v("loadDocument() : book not found in history, building FileInfo by Uri...");
+			fi = new FileInfo(contentPath);
+		} else {
+			fi = book.getFileInfo();
+			log.v("loadDocument() : item from history : " + fi);
+		}
+		return loadDocumentFromStream(inputStream, fi, errorHandler);
 	}
 
 	public BookInfo getBookInfo() {
@@ -4749,13 +4804,14 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	private class LoadDocumentTask extends Task {
 		String filename;
 		String path;
+		InputStream inputStream;
 		Runnable errorHandler;
 		String pos;
 		int profileNumber;
 		boolean disableInternalStyles;
 		boolean disableTextAutoformat;
 
-		LoadDocumentTask(BookInfo bookInfo, Runnable errorHandler) {
+		LoadDocumentTask(BookInfo bookInfo, InputStream inputStream, Runnable errorHandler) {
 			BackgroundThread.ensureGUI();
 			mBookInfo = bookInfo;
 			FileInfo fileInfo = bookInfo.getFileInfo();
@@ -4773,6 +4829,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			mEngine.setHyphenationLanguage(language);
 			this.filename = fileInfo.getPathName();
 			this.path = fileInfo.arcname != null ? fileInfo.arcname : fileInfo.pathname;
+			this.inputStream = inputStream;
 			this.errorHandler = errorHandler;
 			//FileInfo fileInfo = new FileInfo(filename);
 			disableInternalStyles = mBookInfo.getFileInfo().getFlag(FileInfo.DONT_USE_DOCUMENT_STYLES_FLAG);
@@ -4820,7 +4877,11 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			log.i("Loading document " + filename);
 			doc.doCommand(ReaderCommand.DCMD_SET_INTERNAL_STYLES.nativeId, disableInternalStyles ? 0 : 1);
 			doc.doCommand(ReaderCommand.DCMD_SET_TEXT_FORMAT.nativeId, disableTextAutoformat ? 0 : 1);
-			boolean success = doc.loadDocument(filename);
+			boolean success;
+			if (null != inputStream)
+				success = doc.loadDocumentFromStream(inputStream, filename);
+			else
+				success = doc.loadDocument(filename);
 			if (success) {
 				log.v("loadDocumentInternal completed successfully");
 

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -3112,7 +3112,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		save();
 		log.i("loadDocument(" + contentPath + ")");
 		if (contentPath == null || inputStream == null) {
-			log.v("loadDocument() : no filename specified");
+			log.v("loadDocument() : no filename or stream specified");
 			if (errorHandler != null)
 				errorHandler.run();
 			return false;
@@ -4816,7 +4816,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			mBookInfo = bookInfo;
 			FileInfo fileInfo = bookInfo.getFileInfo();
 			log.v("LoadDocumentTask for " + fileInfo);
-			if (fileInfo.getTitle() == null) {
+			if (fileInfo.getTitle() == null && inputStream == null) {
 				// As a book 'should' have a title, no title means we should
 				// retrieve the book metadata from the engine to get the
 				// book language.
@@ -4951,7 +4951,9 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 						mActivity.showReader();
 					}
 				});
-				mActivity.setLastBook(filename);
+				// Save last opened book ONLY if book opened from real file not stream.
+				if (null == inputStream)
+					mActivity.setLastBook(filename);
 			}
 		}
 

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -398,6 +398,8 @@ protected:
     void createEmptyDocument();
     /// get document rectangle for specified cursor position, returns false if not visible
     bool getCursorDocRect( ldomXPointer ptr, lvRect & rc );
+    /// load document from stream (internal)
+    bool loadDocumentInt( LVStreamRef stream, bool metadataOnly = false );
 public:
     /// get outer (before margins are applied) page rectangle
     virtual void getPageRectangle( int pageIndex, lvRect & pageRect );
@@ -884,7 +886,7 @@ public:
     /// load document from file
     bool LoadDocument( const lChar16 * fname, bool metadataOnly = false );
     /// load document from stream
-    bool LoadDocument( LVStreamRef stream, bool metadataOnly = false );
+    bool LoadDocument( LVStreamRef stream, const lChar16 * contentPath, bool metadataOnly = false );
 
     /// save last file position
     void savePosition();

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3070,7 +3070,7 @@ bool LVDocView::goLink(lString16 link, bool savePos) {
 					(int) stream->GetSize()));
             m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 			// TODO: load document from stream properly
-			if (!LoadDocument(stream)) {
+			if (!loadDocumentInt(stream)) {
                 createDefaultDocument(cs16("Load error"), lString16(
                         "Cannot open file ") + filename);
 				return false;
@@ -3818,7 +3818,7 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
             m_doc_props->setInt(PROP_RENDER_BLOCK_RENDERING_FLAGS, 0);
 
 		// loading document
-		if (LoadDocument(stream, metadataOnly)) {
+		if (loadDocumentInt(stream, metadataOnly)) {
 			m_filename = lString16(fname);
 			m_stream.Clear();
             if(convertBookmarks) {
@@ -3876,7 +3876,7 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
     if(convertBookmarks)
         m_doc_props->setInt(PROP_RENDER_BLOCK_RENDERING_FLAGS, 0);
 
-	if (LoadDocument(stream, metadataOnly)) {
+	if (loadDocumentInt(stream, metadataOnly)) {
 		m_filename = lString16(fname);
 		m_stream.Clear();
 
@@ -3890,6 +3890,112 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
 #define DUMP_OPENED_DOCUMENT_SENTENCES 0 // debug XPointer navigation
 #if DUMP_OPENED_DOCUMENT_SENTENCES==1
         LVStreamRef out = LVOpenFileStream("/tmp/sentences.txt", LVOM_WRITE);
+        if ( !out.isNull() ) {
+            checkRender();
+            {
+                ldomXPointerEx ptr( m_doc->getRootNode(), m_doc->getRootNode()->getChildCount());
+                *out << "FORWARD ORDER:\n\n";
+                //ptr.nextVisibleText();
+                ptr.prevVisibleWordEnd();
+                if ( ptr.thisSentenceStart() ) {
+                    while ( 1 ) {
+                        ldomXPointerEx ptr2(ptr);
+                        ptr2.thisSentenceEnd();
+                        ldomXRange range(ptr, ptr2);
+                        lString16 str = range.getRangeText();
+                        *out << ">sentence: " << UnicodeToUtf8(str) << "\n";
+                        if ( !ptr.nextSentenceStart() )
+                            break;
+                    }
+                }
+            }
+            {
+                ldomXPointerEx ptr( m_doc->getRootNode(), 1);
+                *out << "\n\nBACKWARD ORDER:\n\n";
+                while ( ptr.lastChild() )
+                    ;// do nothing
+                if ( ptr.thisSentenceStart() ) {
+                    while ( 1 ) {
+                        ldomXPointerEx ptr2(ptr);
+                        ptr2.thisSentenceEnd();
+                        ldomXRange range(ptr, ptr2);
+                        lString16 str = range.getRangeText();
+                        *out << "<sentence: " << UnicodeToUtf8(str) << "\n";
+                        if ( !ptr.prevSentenceStart() )
+                            break;
+                    }
+                }
+            }
+        }
+#endif
+
+		return true;
+	}
+	m_stream.Clear();
+	return false;
+}
+
+bool LVDocView::LoadDocument( LVStreamRef stream, const lChar16 * contentPath, bool metadataOnly )
+{
+	if (stream.isNull() || !contentPath || !contentPath[0])
+		return false;
+
+	Clear();
+
+	CRLog::debug("LoadDocument(%s) textMode=%s", LCSTR(lString16(contentPath)), getTextFormatOptions()==txt_format_pre ? "pre" : "autoformat");
+
+	// split file path and name
+	lString16 contentPath16(contentPath);
+
+	lString16 fn = LVExtractFilename(contentPath16);
+	lString16 dir = LVExtractPath(contentPath16);
+
+	CRLog::info("Loading document %s : fn=%s, dir=%s", LCSTR(contentPath16),
+				LCSTR(fn), LCSTR(dir));
+#if 0
+	int i;
+	int last_slash = -1;
+	lChar16 slash_char = 0;
+	for ( i=0; fname[i]; i++ ) {
+		if ( fname[i]=='\\' || fname[i]=='/' ) {
+			last_slash = i;
+			slash_char = fname[i];
+		}
+	}
+	lString16 dir;
+	if ( last_slash==-1 )
+        dir = ".";
+	else if ( last_slash == 0 )
+        dir << slash_char;
+	else
+        dir = lString16( fname, last_slash );
+	lString16 fn( fname + last_slash + 1 );
+#endif
+
+	m_doc_props->setString(DOC_PROP_FILE_PATH, dir);
+	m_doc_props->setString(DOC_PROP_FILE_NAME, fn);
+	m_doc_props->setString(DOC_PROP_FILE_SIZE, lString16::itoa(
+			(int) stream->GetSize()));
+	m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
+
+	CRFileHistRecord* record = m_hist.getRecord( contentPath16, stream->GetSize() );
+	bool convertBookmarks = needToConvertBookmarks(record) && !metadataOnly;
+	if(convertBookmarks)
+		m_doc_props->setInt(PROP_RENDER_BLOCK_RENDERING_FLAGS, 0);
+
+	if (loadDocumentInt(stream, metadataOnly)) {
+		m_filename = lString16(contentPath);
+
+		if(convertBookmarks) {
+			record->convertBookmarks(m_doc);
+			record->setDOMversion(gDOMVersionCurrent);
+			gDOMVersionRequested = gDOMVersionCurrent;
+			m_doc_props->setIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS);
+			//FIXME: need to reload file after this
+		}
+#define DUMP_OPENED_DOCUMENT_SENTENCES 0 // debug XPointer navigation
+#if DUMP_OPENED_DOCUMENT_SENTENCES==1
+		LVStreamRef out = LVOpenFileStream("/tmp/sentences.txt", LVOM_WRITE);
         if ( !out.isNull() ) {
             checkRender();
             {
@@ -4035,7 +4141,7 @@ void LVDocView::createDefaultDocument(lString16 title, lString16 message) {
 }
 
 /// load document from stream
-bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
+bool LVDocView::loadDocumentInt(LVStreamRef stream, bool metadataOnly) {
 
 
 	m_swapDone = false;


### PR DESCRIPTION
This PR should close issue #126 .
1. Implemented opening a document from a stream, not from file. It is useful when other Android applications transfer a document to CoolReader according to the “content” scheme, rather than the “file”.
2. In this case, the last open book is not saved, because during the subsequent launch CoolReader will not be able to access this stream and, as a result, the last open document will also not be available.