### PR TITLE
Support raw picture (not hex encoded) in RTF

### DIFF
--- a/crengine/include/rtfcmd.h
+++ b/crengine/include/rtfcmd.h
@@ -17,6 +17,7 @@ RTF_CHR( "\r", par_r, 13 )
 RTF_CHR( "_", nb_hyphen, '-' )
 RTF_IPR( ansicpg, pi_ansicpg, 1252 )
 RTF_IPR( b, pi_ch_bold, 1 )
+RTF_IPR( bin, pi_bin, 0 )
 RTF_CHC( bullet, 'o' )
 RTF_TPR( cell, tpi_cell, 0 )     // Denotes the end of a table cell.
 RTF_TPR( clmgf, tpi_clmgf, 0 )   // The first cell in a range of table cells to be merged.

--- a/crengine/include/rtfimp.h
+++ b/crengine/include/rtfimp.h
@@ -62,6 +62,7 @@ enum propIndex {
     pi_align,
     pi_intbl,
     pi_imgfmt,
+    pi_bin,
     pi_max
 };
 
@@ -168,6 +169,7 @@ public:
     virtual void OnAction( int action ) = 0;
     virtual void OnControlWord( const char * control, int param ) = 0;
     virtual void OnText( const lChar16 * text, int len, lUInt32 flags ) = 0;
+    virtual void OnBlob(const lUInt8 * data, int size) = 0;
     virtual void SetCharsetTable(const lChar16 * table);
     virtual ~LVRtfDestination() { }
 };

--- a/crengine/src/rtfimp.cpp
+++ b/crengine/src/rtfimp.cpp
@@ -175,6 +175,8 @@ public:
         bool intbl = m_stack.getInt( pi_intbl )>0;
         bool asteriskFlag = (s == "* * *");
         bool titleFlag = m_stack.getInt( pi_align )==ha_center && len<200;
+        if( !intbl )
+            SetTableState( tbls_none );
         if ( last_notitle && titleFlag && !asteriskFlag ) {
             OnAction(RA_SECTION);
         }

--- a/crengine/src/rtfimp.cpp
+++ b/crengine/src/rtfimp.cpp
@@ -17,7 +17,9 @@
 
 //==================================================
 // RTF file parser
-
+#ifdef LOG_RTF_PARSING
+#include "../include/crlog.h"
+#endif
 
 #undef RTF_CMD
 #undef RTF_CHR
@@ -230,6 +232,9 @@ public:
             m_callback->OnTagClose(NULL, L"strong");
         }
     }
+    virtual void OnBlob(const lUInt8*, int)
+    {
+    }
     virtual void OnAction( int action )
     {
         if ( action==RA_PARA || action==RA_SECTION ) {
@@ -281,6 +286,9 @@ public:
     virtual void OnText( const lChar16 *, int, lUInt32 )
     {
     }
+    virtual void OnBlob(const lUInt8*, int)
+    {
+    }
     virtual void OnTblProp( int, int )
     {
     }
@@ -329,6 +337,12 @@ public:
                     _lastDigit = d;
             }
         }
+    }
+    virtual void OnBlob(const lUInt8 * data, int size)
+    {
+        _fmt = m_stack.getInt(pi_imgfmt);
+        if(_fmt)
+            _buf.append(data, size);
     }
     virtual void OnTblProp( int, int )
     {
@@ -562,6 +576,17 @@ bool LVRtfParser::Parse()
                 OnControlWord( cwname, PARAM_VALUE_NONE, asteriskFlag );
             }
             m_buf_pos += (int)(p - (m_buf + m_buf_pos));
+            int binLength = m_stack.getInt( pi_bin );
+            if(binLength > 0) {
+                if(m_buf_len - m_buf_pos < binLength) {
+                    if( !FillBuffer(binLength)) {
+                        errorFlag = true;
+                        break;
+                    }
+                }
+                m_stack.getDestination()->OnBlob( m_buf + m_buf_pos, binLength);
+                m_buf_pos += binLength;
+            }
         } else {
             //lChar16 txtch = 0;
             if ( ch=='\\' ) {


### PR DESCRIPTION
Added support of \binN keywoard in RTF to show properly pictures stored as raw binary data.