### PR TITLE
Update search activity for Wikipedia app.

### DIFF
--- a/android/src/org/coolreader/Dictionaries.java
+++ b/android/src/org/coolreader/Dictionaries.java
@@ -79,7 +79,7 @@ public class Dictionaries {
 		new DictInfo("PopupDictionary", "Popup Dictionary", "com.barisatamer.popupdictionary", "com.barisatamer.popupdictionary.MainActivity", "android.intent.action.VIEW", 0),
 		new DictInfo("GoogleTranslate", "Google Translate", "com.google.android.apps.translate", "com.google.android.apps.translate.TranslateActivity", Intent.ACTION_SEND, 4),
 		new DictInfo("YandexTranslate", "Yandex Translate", "ru.yandex.translate", "ru.yandex.translate.ui.activities.MainActivity", Intent.ACTION_SEND, 4),
-		new DictInfo("Wikipedia", "Wikipedia", "org.wikipedia", "org.wikipedia.main.MainActivity", Intent.ACTION_SEND, 4),
+		new DictInfo("Wikipedia", "Wikipedia", "org.wikipedia", "org.wikipedia.search.SearchActivity", Intent.ACTION_SEND, 0),
 	};
 
 	public static final String DEFAULT_DICTIONARY_ID = "com.ngc.fora";


### PR DESCRIPTION
The Wikipedia app added an extra search activity in
https://github.com/wikimedia/apps-android-wikipedia/commit/6c188f765b3a6b0fbea86067125d6041c9addf60
and
https://github.com/wikimedia/apps-android-wikipedia/commit/ce9f4447faa94626939073e34a1e5376c33f5816
so change .main.MainActivity to .search.SearchActivity.

Change the search type as well, with 4 it only works if the Wikipedia
app isn't running (second search will just focus the app with whatever
was shown before), with 0 new searches actually search.

Closes #128.