### PR TITLE
Fixed bypassing fallback fonts when rendering.

### DIFF
--- a/crengine/include/lvfont.h
+++ b/crengine/include/lvfont.h
@@ -140,13 +140,6 @@ typedef LVProtectedFastRef<LVFont> LVFontRef;
 class LVFont : public LVRefCounter {
 protected:
     int _visual_alignment_width;
-    /**
-     * @brief depth in fallback fonts chain:<br/>
-     * -1 - normal font (not fallback)
-     * 0 - first fallback font in chain
-     * n-1 - n'th fallback font in chain
-     */
-    int _fallback_index;
 public:
     lUInt32 _hash;
     /// glyph properties structure
@@ -268,7 +261,7 @@ public:
                        lUInt32 fallbackPassMask = 0) = 0;
 
     /// constructor
-    LVFont() : _visual_alignment_width(-1), _hash(0), _fallback_index(-1) {}
+    LVFont() : _visual_alignment_width(-1), _hash(0) {}
 
     /// get bitmap mode (true=monochrome bitmap, false=antialiased)
     virtual bool getBitmapMode() { return false; }
@@ -332,8 +325,8 @@ public:
         return NULL;
     }
     
-    virtual int getFallbackIndex() const { return _fallback_index; }
-    virtual void setFallbackIndex(int index) { _fallback_index = index; }
+    virtual lUInt32 getFallbackMask() const { return 0; }
+    virtual void setFallbackMask(lUInt32 mask) { CR_UNUSED(mask) }
 };
 
 /// to compare two fonts

--- a/crengine/src/private/lvfontboldtransform.h
+++ b/crengine/src/private/lvfontboldtransform.h
@@ -30,6 +30,25 @@ class LVFontBoldTransform : public LVFont {
     int _baseline;
     LVFontLocalGlyphCache _glyph_cache;
 public:
+
+    virtual lUInt32 getFallbackMask() const {
+        return _baseFont->getFallbackMask();
+    }
+
+    virtual void setFallbackMask(lUInt32 mask) {
+        _baseFont->setFallbackMask(mask);
+    }
+
+    /// set fallback font for this font
+    virtual void setFallbackFont(LVFontRef font) {
+        _baseFont->setFallbackFont(font);
+    }
+
+    /// get fallback font for this font
+    virtual LVFont *getFallbackFont(lUInt32 fallbackPassMask) {
+        _baseFont->getFallbackFont(fallbackPassMask);
+    }
+
     /// returns font weight
     virtual int getWeight() const;
 
@@ -192,11 +211,6 @@ public:
 
     virtual void Clear() {
         _baseFont->Clear();
-    }
-
-    virtual void setFallbackIndex(int index) {
-        LVFont::setFallbackIndex(index);
-        _baseFont->setFallbackIndex(index);
     }
 
     virtual ~LVFontBoldTransform() {

--- a/crengine/src/private/lvfreetypeface.h
+++ b/crengine/src/private/lvfreetypeface.h
@@ -137,6 +137,12 @@ protected:
     shaping_mode_t _shapingMode;
     bool _fallbackFontIsSet;
     LVFontRef _fallbackFont;
+    /**
+     * @brief Fallback mask for this fallback font.
+     * 0 - for normal (not fallback) font
+     * <any> - A mask with only one bit set, the number of which corresponds to the number in the fallback font chain.
+     */
+    lUInt32 _fallback_mask;
     bool           _embolden; // fake/synthetized bold
     bool           _allowKerning;
     FT_Pos         _embolden_half_strength; // for emboldening with Harfbuzz
@@ -153,6 +159,15 @@ protected:
 public:
 
     // fallback font support
+    
+    virtual lUInt32 getFallbackMask() const {
+        return _fallback_mask;
+    }
+
+    virtual void setFallbackMask(lUInt32 mask) {
+        _fallback_mask = mask;
+    }
+
     /// set fallback font for this font
     virtual void setFallbackFont(LVFontRef font);
 


### PR DESCRIPTION
Fixed bypassing fallback fonts when rendering.
In particular, fixes a stack overflow (endless recursion) when retrieving a fallback font.