### PR TITLE
3.2.43 fixes

### DIFF
--- a/android/res/raw/htm.css
+++ b/android/res/raw/htm.css
@@ -93,3 +93,23 @@ table { font-size: 100% }
 td, th { text-indent: 0px; padding: 3px } 
 th { font-weight: bold; text-align: center; background-color: #808080; } 
 table caption { text-indent: 0px; padding: 4px; }
+
+ruby {
+  display: ruby;
+}
+
+/* crengine+: additionally needed for prettier Ruby support */
+ruby {
+    /* These will have no effect when ruby is reset to display: inline */
+    text-align: center;
+    text-indent: 0;
+}
+rb, rubyBox[T=rb] {
+    line-height: 1;
+}
+rt, rubyBox[T=rt] {
+    line-height: 1.2;
+    font-size: 50%;
+    font-variant-east-asian: ruby;
+    -cr-hint: text-selection-skip;
+}

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -417,14 +417,16 @@ public class CoolReader extends BaseActivity {
 				}
 			}
 		}
-		File file;
-		int pos = filePath.indexOf("@/");
-		if (pos > 0)
-			file = new File(filePath.substring(0, pos));
-		else
-			file = new File(filePath);
-		if (!file.exists())
-			filePath = null;
+		if (null != filePath) {
+			File file;
+			int pos = filePath.indexOf("@/");
+			if (pos > 0)
+				file = new File(filePath.substring(0, pos));
+			else
+				file = new File(filePath);
+			if (!file.exists())
+				filePath = null;
+		}
 		return filePath;
 	}
 

--- a/android/src/org/coolreader/crengine/FileInfo.java
+++ b/android/src/org/coolreader/crengine/FileInfo.java
@@ -96,6 +96,10 @@ public class FileInfo {
     public static final int TYPE_FS_ROOT = 1;
     public static final int TYPE_DOWNLOAD_DIR = 2;
 
+    // bits 26..29 - profile id (0..15 max)
+	public static final int PROFILE_ID_SHIFT = 26;
+	public static final int PROFILE_ID_MASK = 0x0F;
+
 	/**
 	 * Get book reading state. 
 	 * @return reading state (one of STATE_XXX constants)
@@ -148,11 +152,8 @@ public class FileInfo {
 	 * To separate archive name from file name inside archive.
 	 */
 	public static final String ARC_SEPARATOR = "@/";
-	
-	public static final int PROFILE_ID_SHIFT = 16;
-	public static final int PROFILE_ID_MASK = 0x0F;
-	
-	
+
+
 	public void setFlag( int flag, boolean value ) {
 		flags = flags & (~flag) | (value? flag : 0);
 	}

--- a/cr3qt/data/htm.css
+++ b/cr3qt/data/htm.css
@@ -93,3 +93,23 @@ table { font-size: 100% }
 td, th { text-indent: 0px; padding: 3px } 
 th { font-weight: bold; text-align: center; background-color: #808080; } 
 table caption { text-indent: 0px; padding: 4px; }
+
+ruby {
+  display: ruby;
+}
+
+/* crengine+: additionally needed for prettier Ruby support */
+ruby {
+    /* These will have no effect when ruby is reset to display: inline */
+    text-align: center;
+    text-indent: 0;
+}
+rb, rubyBox[T=rb] {
+    line-height: 1;
+}
+rt, rubyBox[T=rt] {
+    line-height: 1.2;
+    font-size: 50%;
+    font-variant-east-asian: ruby;
+    -cr-hint: text-selection-skip;
+}

--- a/cr3wx/src/cr3.cpp
+++ b/cr3wx/src/cr3.cpp
@@ -297,6 +297,7 @@ void testFormatting()
                 0x000000,       /* text color */
                 0xFFFFFF,     /* background color */
                 font.get(),        /* font to draw string */
+                NULL,
                 flags,
                 16,    /* interline space, *16 (16=single, 32=double) */
                 30,    /* first line margin */

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -63,6 +63,7 @@ XS_TAG1D( title, true, css_d_block, css_ws_inherit )
 XS_TAG1D( style, true, css_d_none, css_ws_inherit )
 XS_TAG1D( script, true, css_d_none, css_ws_inherit )
 XS_TAG1D( base, false, css_d_none, css_ws_inherit ) // among crengine autoclose elements
+XS_TAG1D( link, false, css_d_none, css_ws_inherit )
 XS_TAG1T( body )
 XS_TAG1( param ) /* quite obsolete, child of <object>... was there, let's keep it */
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2533,7 +2533,13 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             if ( baseflags & LTEXT_FLAG_NEWLINE ) {
                 if ( enode->getNodeIndex() == 0 && parent && parent->getChildCount() > 1 ) {
                     ldomNode * next_sibling = parent->getChildNode(1);
-                    if ( next_sibling && !next_sibling->isNull() ) {
+                    if ( next_sibling && !next_sibling->isNull() && !next_sibling->isElement() ) {
+                        // The next sibling might be a text node, so get the next one
+                        if ( parent->getChildCount() > 2 ) {
+                            next_sibling = parent->getChildNode(2);
+                        }
+                    }
+                    if ( next_sibling && !next_sibling->isNull() && next_sibling->isElement() ) {
                         // next_sibling is an original block node that should have
                         // been erm_final, but has been made erm_inline so it can
                         // be prepended with the run-in node content.

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7819,7 +7819,7 @@ private:
 public:
     virtual ~LVBase64NodeStream() { }
     LVBase64NodeStream( ldomNode * element )
-        : m_elem(element), m_curr_node(element), m_size(0), m_pos(0)
+        : m_elem(element), m_curr_node(element), m_text_pos(0), m_size(0), m_pos(0)
     {
         // calculate size
         rewind();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -84,7 +84,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.12.67"
+#define CACHE_FILE_FORMAT_VERSION "3.12.68"
 
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
@@ -7440,7 +7440,7 @@ ldomNode * ldomDocumentWriter::OnTagOpen( const lChar16 * nsname, const lChar16 
     lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
 
     // Set a flag for OnText to accumulate the content of any <HEAD><STYLE>
-    if ( tagname[0] == 's' && !lStr_cmp(tagname, "style") && _currNode && _currNode->getElement()->isNodeName("head") ) {
+    if ( id == el_style && _currNode && _currNode->getElement()->getNodeId() == el_head ) {
         _inHeadStyle = true;
     }
 
@@ -7504,23 +7504,31 @@ ldomDocumentWriter::~ldomDocumentWriter()
 void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
 {
     //logfile << "ldomDocumentWriter::OnTagClose() [" << nsname << ":" << tagname << "]";
-    if (!_currNode)
+    if (!_currNode || !_currNode->getElement())
     {
         _errFlag = true;
         //logfile << " !c-err!\n";
         return;
     }
 
+    //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
+    lUInt16 curNodeId = _currNode->getElement()->getNodeId();
+    lUInt16 id = _document->getElementNameIndex(tagname);
+    _errFlag |= (id != curNodeId); // (we seem to not do anything with _errFlag)
+    // We should expect the tagname we got to be the same as curNode's element name,
+    // but it looks like we may get an upper closing tag, that pop() below might
+    // handle. So, here below, we check that both id and curNodeId match the
+    // element id we check for.
+
     // Parse <link rel="stylesheet">, put the css file link in _stylesheetLinks.
     // They will be added to <body><stylesheet> when we meet <BODY>
     // (duplicated in ldomDocumentWriterFilter::OnTagClose)
-    if (tagname[0] == 'l' && _currNode && !lStr_cmp(tagname, "link")) {
-        // link node
-        if ( _currNode && _currNode->getElement() && _currNode->getElement()->isNodeName("link") &&
-             _currNode->getElement()->getParentNode() && _currNode->getElement()->getParentNode()->isNodeName("head") &&
-             lString16(_currNode->getElement()->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
-             lString16(_currNode->getElement()->getAttributeValue("type")).lowercase() == L"text/css" ) {
-            lString16 href = _currNode->getElement()->getAttributeValue("href");
+    if ( id == el_link && curNodeId == el_link ) { // link node
+        ldomNode * n = _currNode->getElement();
+        if ( n->getParentNode() && n->getParentNode()->getNodeId() == el_head &&
+                 lString16(n->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
+                 lString16(n->getAttributeValue("type")).lowercase() == L"text/css" ) {
+            lString16 href = n->getAttributeValue("href");
             lString16 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
             CRLog::debug("Internal stylesheet file: %s", LCSTR(stylesheetFile));
             // We no more apply it immediately: it will be when <BODY> is met
@@ -7530,23 +7538,8 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
         }
     }
 
-    /* This is now dealt with in :OnTagBody(), just before creating this <stylesheet> tag
-    bool isStyleSheetTag = !lStr_cmp(tagname, "stylesheet");
-    if ( isStyleSheetTag ) {
-        ldomNode *parentNode = _currNode->getElement()->getParentNode();
-        if (parentNode && parentNode->isNodeName("DocFragment")) {
-            _document->parseStyleSheet(_currNode->getElement()->getAttributeValue(attr_href),
-                                       _currNode->getElement()->getText());
-            isStyleSheetTag = false;
-        }
-    }
-    */
-    bool isStyleSheetTag = tagname[0] == 's' && !lStr_cmp(tagname, "stylesheet");
-
-    lUInt16 id = _document->getElementNameIndex(tagname);
-    //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
-    _errFlag |= (id != _currNode->getElement()->getNodeId());
     _currNode = pop( _currNode, id );
+        // _currNode is now the parent
 
     if ( _currNode )
         _flags = _currNode->getFlags();
@@ -7571,7 +7564,7 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
     // Caveat: any style set on the <FictionBook> element itself won't be applied now
     // in this loading phase (as we have already set its style) - but it will apply
     // on re-renderings.
-    if ( isStyleSheetTag && _currNode && _currNode->getElement()->getNodeId() == el_FictionBook ) {
+    if ( id == el_stylesheet && _currNode && _currNode->getElement()->getNodeId() == el_FictionBook ) {
         //CRLog::trace("</stylesheet> found");
 #if BUILD_LITE!=1
         if ( !_popStyleOnFinish && _document->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) ) {
@@ -12913,8 +12906,11 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
 //        lStr_lowercase( const_cast<lChar16 *>(nsname), lStr_len(nsname) );
 //    lStr_lowercase( const_cast<lChar16 *>(tagname), lStr_len(tagname) );
 
+    lUInt16 id = _document->getElementNameIndex(tagname);
+    lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
+
     // Set a flag for OnText to accumulate the content of any <HEAD><STYLE>
-    if ( tagname[0] == 's' && !lStr_cmp(tagname, "style") && _currNode && _currNode->getElement()->isNodeName("head") ) {
+    if ( id == el_style && _currNode && _currNode->getElement()->getNodeId() == el_head ) {
         _inHeadStyle = true;
     }
 
@@ -12923,18 +12919,15 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
     // requested to keep previously recorded XPATHs valid.
     if ( _libRuDocumentDetected || gDOMVersionRequested < 20180503) {
         // Patch for bad LIB.RU books - BR delimited paragraphs in "Fine HTML" format
-        if ((tagname[0] == 'b' && tagname[1] == 'r' && tagname[2] == 0)
-            || (tagname[0] == 'd' && tagname[1] == 'd' && tagname[2] == 0)) {
+        if ( id == el_br || id == el_dd ) {
             // substitute to P
-            tagname = L"p";
+            id = el_p;
             _libRuParagraphStart = true; // to trim leading &nbsp;
         } else {
             _libRuParagraphStart = false;
         }
     }
 
-    lUInt16 id = _document->getElementNameIndex(tagname);
-    lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
     AutoClose( id, true );
     _currNode = new ldomElementWriter( _document, nsid, id, _currNode );
     _flags = _currNode->getFlags();
@@ -13119,23 +13112,31 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
 //    if ( nsname && nsname[0] )
 //        lStr_lowercase( const_cast<lChar16 *>(nsname), lStr_len(nsname) );
 //    lStr_lowercase( const_cast<lChar16 *>(tagname), lStr_len(tagname) );
-    if (!_currNode)
+    if (!_currNode || !_currNode->getElement())
     {
         _errFlag = true;
         //logfile << " !c-err!\n";
         return;
     }
 
+    //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
+    lUInt16 curNodeId = _currNode->getElement()->getNodeId();
+    lUInt16 id = _document->getElementNameIndex(tagname);
+    _errFlag |= (id != curNodeId); // (we seem to not do anything with _errFlag)
+    // We should expect the tagname we got to be the same as curNode's element name,
+    // but it looks like we may get an upper closing tag, that pop() or AutoClose()
+    // below might handle. So, here below, we check that both id and curNodeId match
+    // the element id we check for.
+
     // Parse <link rel="stylesheet">, put the css file link in _stylesheetLinks,
     // they will be added to <body><stylesheet> when we meet <BODY>
     // (duplicated in ldomDocumentWriter::OnTagClose)
-    if (tagname[0] == 'l' && _currNode && !lStr_cmp(tagname, "link")) {
-        // link node
-        if ( _currNode && _currNode->getElement() && _currNode->getElement()->isNodeName("link") &&
-             _currNode->getElement()->getParentNode() && _currNode->getElement()->getParentNode()->isNodeName("head") &&
-             lString16(_currNode->getElement()->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
-             lString16(_currNode->getElement()->getAttributeValue("type")).lowercase() == L"text/css" ) {
-            lString16 href = _currNode->getElement()->getAttributeValue("href");
+    if ( id == el_link && curNodeId == el_link ) { // link node
+        ldomNode * n = _currNode->getElement();
+        if ( n->getParentNode() && n->getParentNode()->getNodeId() == el_head &&
+                 lString16(n->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
+                 lString16(n->getAttributeValue("type")).lowercase() == L"text/css" ) {
+            lString16 href = n->getAttributeValue("href");
             lString16 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
             CRLog::debug("Internal stylesheet file: %s", LCSTR(stylesheetFile));
             // We no more apply it immediately: it will be when <BODY> is met
@@ -13145,11 +13146,9 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
         }
     }
 
-    lUInt16 id = _document->getElementNameIndex(tagname);
-
     // HTML title detection
-    if ( id==el_title && _currNode && _currNode->_element && _currNode->_element->getParentNode() != NULL
-                                   && _currNode->_element->getParentNode()->getNodeId() == el_head ) {
+    if ( id == el_title && curNodeId == el_title && _currNode->_element->getParentNode() &&
+                           _currNode->_element->getParentNode()->getNodeId() == el_head ) {
         lString16 s = _currNode->_element->getText();
         s.trim();
         if ( !s.empty() ) {
@@ -13158,15 +13157,13 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
         }
     }
     //======== START FILTER CODE ============
-    if ( _currNode->_element ) // (should always be true, but avoid clang warning)
-        AutoClose( _currNode->_element->getNodeId(), false );
+    AutoClose( curNodeId, false );
     //======== END FILTER CODE ==============
-    //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
     // save closed element
-    ldomNode * closedElement = _currNode->getElement();
-    _errFlag |= (!closedElement || id != closedElement->getNodeId());
-    _currNode = pop( _currNode, id );
+    // ldomNode * closedElement = _currNode->getElement();
 
+    _currNode = pop( _currNode, id );
+        // _currNode is now the parent
 
     if ( _currNode ) {
         _flags = _currNode->getFlags();

--- a/crengine/src/private/lvfontboldtransform.h
+++ b/crengine/src/private/lvfontboldtransform.h
@@ -46,7 +46,7 @@ public:
 
     /// get fallback font for this font
     virtual LVFont *getFallbackFont(lUInt32 fallbackPassMask) {
-        _baseFont->getFallbackFont(fallbackPassMask);
+        return _baseFont->getFallbackFont(fallbackPassMask);
     }
 
     /// returns font weight


### PR DESCRIPTION
Fixes for mint bugs:
* NullPointerException in Android UI:
```java
java.lang.NullPointerException:
at org.coolreader.CoolReader.filePathFromUri (CoolReader.java:421)
at org.coolreader.CoolReader.processIntent (CoolReader.java:302)
at org.coolreader.CoolReader.onStart (CoolReader.java:547)
at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1392)
```
* SEGFAULT fixed, possible closes issue #148.

Updates from koreader: https://github.com/koreader/crengine/pull/363

Fixed parsing of the "meta" tag when detecting text encoding in html files while opening it. This fixes incorrect character set with some chm and html files.
Unfortunately method ldomDocumentWriter::OnEncoding() is not intended for this and empty :(
I found one chm file created with "htm2chm 3.0.9.3", which has language code 1033 in the header that corresponding cp1252 encoding, but contains an html file with the cp1251 encoding, which is specified via ```<meta http-equiv=Content-Type content="text/html; charset=windows-1251">```, but this line incorrectly processes, and since cp1252 encoding was previously specified this prevents the algorithm for determining encoding by content from working. So fixing the parsing of this line solves the problem.

Fixed compilation error when the program is configured to use wxWidgets as GUI. Fixes issue #151.