### PR TITLE
cr3.2.44 fixes

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -81,6 +81,9 @@
                 <data android:pathPattern=".*\\.xhtml"/>
                 <data android:pathPattern=".*\\.htm"/>
                 <data android:pathPattern=".*\\.chm"/>
+                <data android:pathPattern=".*\\..*\\.chm"/>
+                <data android:pathPattern=".*\\..*\\..*\\.chm"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.chm"/>
                 <data android:pathPattern=".*\\.epub"/>
                 <data android:pathPattern=".*\\..*\\.epub"/>
                 <data android:pathPattern=".*\\..*\\..*\\.epub"/>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -82,6 +82,9 @@
                 <data android:pathPattern=".*\\.xhtml"/>
                 <data android:pathPattern=".*\\.htm"/>
                 <data android:pathPattern=".*\\.chm"/>
+                <data android:pathPattern=".*\\..*\\.chm"/>
+                <data android:pathPattern=".*\\..*\\..*\\.chm"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.chm"/>
                 <data android:pathPattern=".*\\.epub"/>
                 <data android:pathPattern=".*\\..*\\.epub"/>
                 <data android:pathPattern=".*\\..*\\..*\\.epub"/>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 09 22:09:35 SAMT 2020
+#Tue Aug 11 09:49:14 GMT+04:00 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/android/src/org/coolreader/crengine/BookInfo.java
+++ b/android/src/org/coolreader/crengine/BookInfo.java
@@ -221,7 +221,7 @@ public class BookInfo {
 			if ( ps.length()<2 )
 				ps = "0" + ps;
 			ps = String.valueOf(percent/100) + "." + ps  + "%";
-			buf.append("## " + ps + " - " + (bm.getType()!=Bookmark.TYPE_COMMENT ? "comment" : "correction")  + "\n");
+			buf.append("## " + ps + " - " + (bm.getType()==Bookmark.TYPE_COMMENT ? "comment" : "correction")  + "\n");
 			if ( bm.getTitleText()!=null )
 				buf.append("## " + bm.getTitleText() + "\n");
 			if ( bm.getPosText()!=null )

--- a/android/src/org/coolreader/crengine/CoverpageManager.java
+++ b/android/src/org/coolreader/crengine/CoverpageManager.java
@@ -659,7 +659,7 @@ public class CoverpageManager {
 	public void drawCoverpageFor(final CRDBService.LocalBinder db, final FileInfo file, final Bitmap buffer, final CoverpageBitmapReadyListener callback) {
 		db.loadBookCoverpage(file, (fileInfo, data) -> BackgroundThread.instance().postBackground(() -> {
 			byte[] imageData = data;
-			if (data == null && file.format.canParseCoverpages) {
+			if (data == null && file.format != null && file.format.canParseCoverpages) {
 				imageData = Services.getEngine().scanBookCover(file.getPathName());
 				if (imageData == null)
 					imageData = new byte[] {};

--- a/android/src/org/coolreader/crengine/DocView.java
+++ b/android/src/org/coolreader/crengine/DocView.java
@@ -171,22 +171,29 @@ public class DocView {
 	 */
 	public boolean loadDocumentFromStream(InputStream inputStream, String contentPath) {
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		byte [] buf = new byte [1024];
-		int readBytes;
-		while (true) {
-			try {
+		int errorCode = 0;
+		try {
+			byte [] buf = new byte [4096];
+			int readBytes;
+			while (true) {
 				readBytes = inputStream.read(buf);
 				if (readBytes > 0)
 					outputStream.write(buf, 0, readBytes);
 				else
 					break;
-			} catch (IOException e) {
-				break;
+			}
+		} catch (IOException e1) {
+			errorCode = 1;
+		} catch (OutOfMemoryError e2) {
+			errorCode = 2;
+		}
+		if (0 == errorCode) {
+			synchronized (mutex) {
+				return loadDocumentFromMemoryInternal(outputStream.toByteArray(), contentPath);
 			}
 		}
-		synchronized(mutex) {
-			return loadDocumentFromMemoryInternal(outputStream.toByteArray(), contentPath);
-		}
+		// TODO: pass error code to caller to show message for user.
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Process OutOfMemoryError exception in DocView.loadDocumentFromStream().
Fixed NullPointerException in org.coolreader.crengine.CoverpageManager.lambda$null$3$CoverpageManager.
Fixed bookmark type when bookmarks exported to external application. See issue #153.
Update AndroidManifest.xml: allow up to 3 dots in file names with chm extension.