### PR TITLE
Updates 2020.08-1

### DIFF
--- a/android/jni/cr3engine.cpp
+++ b/android/jni/cr3engine.cpp
@@ -936,7 +936,7 @@ static JNINativeMethod sDocViewMethods[] = {
   {"doCommandInternal", "(II)Z", (void*)Java_org_coolreader_crengine_DocView_doCommandInternal},
   {"getCurrentPageBookmarkInternal", "()Lorg/coolreader/crengine/Bookmark;", (void*)Java_org_coolreader_crengine_DocView_getCurrentPageBookmarkInternal},
   {"goToPositionInternal", "(Ljava/lang/String;Z)Z", (void*)Java_org_coolreader_crengine_DocView_goToPositionInternal},
-  {"getPositionPropsInternal", "(Ljava/lang/String;)Lorg/coolreader/crengine/PositionProperties;", (void*)Java_org_coolreader_crengine_DocView_getPositionPropsInternal},
+  {"getPositionPropsInternal", "(Ljava/lang/String;Z)Lorg/coolreader/crengine/PositionProperties;", (void*)Java_org_coolreader_crengine_DocView_getPositionPropsInternal},
   {"updateBookInfoInternal", "(Lorg/coolreader/crengine/BookInfo;)V", (void*)Java_org_coolreader_crengine_DocView_updateBookInfoInternal},
   {"getTOCInternal", "()Lorg/coolreader/crengine/TOCItem;", (void*)Java_org_coolreader_crengine_DocView_getTOCInternal},
   {"clearSelectionInternal", "()V", (void*)Java_org_coolreader_crengine_DocView_clearSelectionInternal},

--- a/android/jni/org_coolreader_crengine_DocView.h
+++ b/android/jni/org_coolreader_crengine_DocView.h
@@ -128,10 +128,10 @@ JNIEXPORT jboolean JNICALL Java_org_coolreader_crengine_DocView_goToPositionInte
 /*
  * Class:     org_coolreader_crengine_DocView
  * Method:    getPositionPropsInternal
- * Signature: (Ljava/lang/String;)Lorg/coolreader/crengine/PositionProperties;
+ * Signature: (Ljava/lang/String;Z)Lorg/coolreader/crengine/PositionProperties;
  */
 JNIEXPORT jobject JNICALL Java_org_coolreader_crengine_DocView_getPositionPropsInternal
-  (JNIEnv *, jobject, jstring);
+  (JNIEnv *, jobject, jstring, jboolean);
 
 /*
  * Class:     org_coolreader_crengine_DocView

--- a/android/res/raw/fb2.css
+++ b/android/res/raw/fb2.css
@@ -82,12 +82,12 @@ code, pre {
 }
 
 body[name="notes"] { $footnote.all; }
-body[name="notes"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; }
+body[name="notes"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; font-variant: tabular-nums; }
 body[name="notes"] section title p { display: inline; }
 body[name="notes"] section { -cr-hint: footnote-inpage; }
 
 body[name="comments"] { $footnote.all; font-style: italic; }
-body[name="comments"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; }
+body[name="comments"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; font-variant: tabular-nums; }
 body[name="comments"] section title p { display: inline; }
 body[name="comments"] section { -cr-hint: footnote-inpage; }
 

--- a/android/src/org/coolreader/crengine/DocView.java
+++ b/android/src/org/coolreader/crengine/DocView.java
@@ -308,9 +308,9 @@ public class DocView {
 	 * @param xPath
 	 * @return
 	 */
-	public PositionProperties getPositionProps(String xPath) {
+	public PositionProperties getPositionProps(String xPath, boolean precise) {
 		synchronized(mutex) {
-			return getPositionPropsInternal(xPath);
+			return getPositionPropsInternal(xPath, precise);
 		}
 	}
 
@@ -473,8 +473,8 @@ public class DocView {
 
 	private native boolean goToPositionInternal(String xPath, boolean saveToHistory);
 
-	private native PositionProperties getPositionPropsInternal(String xPath);
-	
+	private native PositionProperties getPositionPropsInternal(String xPath, boolean precise);
+
 	private native void updateBookInfoInternal(BookInfo info);
 
 	private native TOCItem getTOCInternal();

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -1716,7 +1716,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	public boolean isFormatWithEmbeddedStyles() {
 		if (mOpened && mBookInfo != null) {
 			DocumentFormat fmt = mBookInfo.getFileInfo().format;
-			return fmt == DocumentFormat.EPUB || fmt == DocumentFormat.HTML || fmt == DocumentFormat.FB2 || fmt == DocumentFormat.FB3;
+			return fmt == DocumentFormat.EPUB || fmt == DocumentFormat.HTML || fmt == DocumentFormat.CHM || fmt == DocumentFormat.FB2 || fmt == DocumentFormat.FB3;
 		}
 		return false;
 	}
@@ -1724,7 +1724,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	public boolean isHtmlFormat() {
 		if (mOpened && mBookInfo != null) {
 			DocumentFormat fmt = mBookInfo.getFileInfo().format;
-			return fmt == DocumentFormat.EPUB || fmt == DocumentFormat.HTML || fmt == DocumentFormat.PDB;
+			return fmt == DocumentFormat.EPUB || fmt == DocumentFormat.HTML || fmt == DocumentFormat.PDB || fmt == DocumentFormat.CHM;
 		}
 		return false;
 	}

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -3998,6 +3998,8 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	class ScrollViewAnimation extends ViewAnimationBase {
 		int startY;
 		int maxY;
+		int pageHeight;
+		int fullHeight;
 		int pointerStartPos;
 		int pointerDestPos;
 		int pointerCurrPos;
@@ -4018,6 +4020,8 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			pointerStartPos = pos;
 			pointerCurrPos = pos;
 			pointerDestPos = startY;
+			pageHeight = currPos.pageHeight;
+			fullHeight = currPos.fullHeight;
 			doc.doCommand(ReaderCommand.DCMD_GO_POS.nativeId, pos0);
 			image1 = preparePageImage(0);
 			if (image1 == null) {
@@ -4044,6 +4048,10 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 				int delta = startY - y;
 				pointerCurrPos = pointerStartPos + delta;
 			}
+			if (pointerCurrPos < 0)
+				pointerCurrPos = 0;
+			if (pointerCurrPos > fullHeight - pageHeight)
+				pointerCurrPos = fullHeight - pageHeight;
 			pointerDestPos = pointerCurrPos;
 			draw();
 			doc.doCommand(ReaderCommand.DCMD_GO_POS.nativeId, pointerDestPos);
@@ -4063,6 +4071,10 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 				for (int i = 1; i < steps; i++) {
 					int x = x0 + (x1 - x0) * i / steps;
 					pointerCurrPos = accelerated ? accelerate(x0, x1, x) : x;
+					if (pointerCurrPos < 0)
+						pointerCurrPos = 0;
+					if (pointerCurrPos > fullHeight - pageHeight)
+						pointerCurrPos = fullHeight - pageHeight;
 					draw();
 				}
 			}
@@ -4074,6 +4086,10 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		public void update(int x, int y) {
 			int delta = startY - y;
 			pointerDestPos = pointerStartPos + delta;
+			if (pointerDestPos < 0)
+				pointerDestPos = 0;
+			if (pointerDestPos > fullHeight - pageHeight)
+				pointerDestPos = fullHeight - pageHeight;
 		}
 
 		public void animate() {

--- a/android/src/org/coolreader/db/MainDB.java
+++ b/android/src/org/coolreader/db/MainDB.java
@@ -14,7 +14,7 @@ public class MainDB extends BaseDB {
 	public static final Logger vlog = L.create("mdb", Log.VERBOSE);
 	
 	private boolean pathCorrectionRequired = false;
-	public final int DB_VERSION = 29;
+	public final int DB_VERSION = 30;
 	@Override
 	protected boolean upgradeSchema() {
 		// When the database is just created, its version is 0.
@@ -197,6 +197,10 @@ public class MainDB extends BaseDB {
 						mDB.endTransaction();
 					}
 				}
+			}
+			if (currentVersion < 30) {
+				// Forced update DOM version from previous latest (20200223) to current (20200824).
+				execSQLIgnoreErrors("UPDATE book SET domVersion=20200824 WHERE domVersion=20200223");
 			}
 
 			//==============================================================

--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -105,6 +105,7 @@ body[name="comments"] section title {
     display: run-in;   /* technical trick to have the footnote number inline with the followup text */
     font-weight: bold;
     font-size: 100%; /* counteract default of 110% with regular title */
+    font-variant: tabular-nums; /* get fixed width digits for nicer text alignment */
     text-align: start; /* counteract default of center with regular title */
     page-break-before: auto; /* counteract default of always with regular title */
     page-break-inside: auto;

--- a/cr3qt/data/fb2.css
+++ b/cr3qt/data/fb2.css
@@ -82,12 +82,12 @@ code, pre {
 }
 
 body[name="notes"] { $footnote.all; }
-body[name="notes"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; }
+body[name="notes"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; font-variant: tabular-nums; }
 body[name="notes"] section title p { display: inline; }
 body[name="notes"] section { -cr-hint: footnote-inpage; }
 
 body[name="comments"] { $footnote.all; font-style: italic; }
-body[name="comments"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; }
+body[name="comments"] section title { display: run-in; text-align: left; $footnote-title.all page-break-before: auto; page-break-inside: auto; page-break-after: auto; font-variant: tabular-nums; }
 body[name="comments"] section title p { display: inline; }
 body[name="comments"] section { -cr-hint: footnote-inpage; }
 

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -285,6 +285,7 @@ XS_ATTR( recindex ) // used with mobi images
 XS_ATTR( T )      // to flag subtype of boxing internal elements if needed
 XS_ATTR( Before ) // for pseudoElem internal element
 XS_ATTR( After )  // for pseudoElem internal element
+XS_ATTR( ParserHint )   // HTML parser hints (used for Lib.ru support)
 // Other classic attributes present in html5.css
 XS_ATTR2( accept_charset, "accept-charset" )
 XS_ATTR( alt )

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -63,10 +63,20 @@ XS_TAG1D( title, true, css_d_block, css_ws_inherit )
 XS_TAG1D( style, true, css_d_none, css_ws_inherit )
 XS_TAG1D( script, true, css_d_none, css_ws_inherit )
 XS_TAG1D( base, false, css_d_none, css_ws_inherit ) // among crengine autoclose elements
+XS_TAG1D( basefont, false, css_d_none, css_ws_inherit )
+XS_TAG1D( bgsound, false, css_d_none, css_ws_inherit )
+XS_TAG1D( meta, false, css_d_none, css_ws_inherit )
 XS_TAG1D( link, false, css_d_none, css_ws_inherit )
 XS_TAG1T( body )
-XS_TAG1( param ) /* quite obsolete, child of <object>... was there, let's keep it */
 
+// Limits for head handling by our HTML Parser (ldomDocumentWriterFilter)
+// (if met before any HEAD or BODY, HTML/HEAD might be auto-inserted)
+#define EL_IN_HEAD_START el_head
+#define EL_IN_HEAD_END   el_link
+#define EL_IN_BODY_START el_body
+
+                // HTML5: start of special tags, closing all
+                // the way, and closing any <P>
 // Block elements
 XS_TAG1T( hr )
 XS_TAG1T( svg )
@@ -84,6 +94,29 @@ XS_TAG1T( p )
 XS_TAG1T( output )
 XS_TAG1T( section )
 
+// Lists
+XS_TAG1T( ol )
+XS_TAG1T( ul )
+XS_TAG1D( li, true, css_d_list_item_block, css_ws_inherit )
+
+// Definitions
+XS_TAG1T( dl )
+XS_TAG1T( dt )
+XS_TAG1T( dd )
+
+// Tables
+XS_TAG1D( table, false, css_d_table, css_ws_inherit )
+XS_TAG1D( caption, true, css_d_table_caption, css_ws_inherit )
+XS_TAG1D( colgroup, false, css_d_table_column_group, css_ws_inherit )
+XS_TAG1D( col, false, css_d_table_column, css_ws_inherit )
+XS_TAG1D( thead, false, css_d_table_header_group, css_ws_inherit )
+XS_TAG1D( tbody, false, css_d_table_row_group, css_ws_inherit )
+XS_TAG1D( tfoot, false, css_d_table_footer_group, css_ws_inherit )
+XS_TAG1D( tr, false, css_d_table_row, css_ws_inherit )
+XS_TAG1D( th, true, css_d_table_cell, css_ws_inherit )
+XS_TAG1D( td, true, css_d_table_cell, css_ws_inherit )
+
+// Added 20180528
 // Keep this block starting with "address" and ending with "xmp" as we
 // are using: if (id >= el_address && id <= el_xmp) in lvrend.cpp
 // Additional semantic block elements
@@ -113,66 +146,101 @@ XS_TAG1D( textarea, true, css_d_block, css_ws_pre ) // similar to "pre"
 XS_TAG1D( plaintext, true, css_d_block, css_ws_pre ) // start of raw text (no end tag), not supported
 XS_TAG1D( xmp, true, css_d_block, css_ws_pre ) // similar to "pre"
 
-// Lists
-XS_TAG1T( ol )
-XS_TAG1T( ul )
-XS_TAG1D( li, true, css_d_list_item_block, css_ws_inherit )
+// Added 20200824
+// Keep this block starting with "details" and ending with "wbr" as we
+// are using: if (id >= el_details && id <= el_wbr) in lvrend.cpp
+// Additional semantic block elements
+XS_TAG1T( details )
+XS_TAG1T( dialog )
+XS_TAG1T( summary )
+// Additional "special" elements mentionned in the HTML standard,
+// not supposed to close any P, but let's consider them similarly,
+// and be block elements, so their content is shown.
+XS_TAG1T( frame )
+XS_TAG1T( frameset )
+XS_TAG1T( iframe )
+XS_TAG1T( noembed )
+XS_TAG1T( template )
+XS_TAG1T( select )
+// BUTTON should not close a P, so we could have P > BUTTON > P,
+// and other elements close a P "in button scope" - but we want to
+// avoid nested Ps - so for our HTML parser, a BUTTON closes a P)
+XS_TAG1T( button )
+// HTML5: these 3 are special tags, that should not close any <P>,
+// but they start a new "scope" that should not be crossed when
+// other special tags are closing a P. As they are rare, we make
+// them close a P too, just so that we'll never have nested Ps.
+XS_TAG1T( marquee )
+XS_TAG1( applet )
+XS_TAG1( object )
+                // HTML5: end of special tags, closing all
+                // the way, and closing any <P>
+// Other HTML elements with usually no content or no usable content
+XS_TAG1T( optgroup ) // shown as block
+XS_TAG1I( option )   // shown as inline
+XS_TAG1T( map )
+XS_TAG1( area )
+XS_TAG1( track )
+XS_TAG1( embed )
+XS_TAG1( input )
+XS_TAG1( keygen )
+XS_TAG1( param )
+XS_TAG1( audio )
+XS_TAG1( source )
+XS_TAG1I( picture ) // may contain one <img>, and multiple <source>
+XS_TAG1I( wbr )
 
-// Definitions
-XS_TAG1T( dl )
-XS_TAG1T( dt )
-XS_TAG1T( dd )
-
-// Tables
-XS_TAG1D( table, false, css_d_table, css_ws_inherit )
-XS_TAG1D( caption, true, css_d_table_caption, css_ws_inherit )
-XS_TAG1D( col, false, css_d_table_column, css_ws_inherit )
-XS_TAG1D( colgroup, false, css_d_table_column_group, css_ws_inherit )
-XS_TAG1D( tr, false, css_d_table_row, css_ws_inherit )
-XS_TAG1D( tbody, false, css_d_table_row_group, css_ws_inherit )
-XS_TAG1D( thead, false, css_d_table_header_group, css_ws_inherit )
-XS_TAG1D( tfoot, false, css_d_table_footer_group, css_ws_inherit )
-XS_TAG1D( th, true, css_d_table_cell, css_ws_inherit )
-XS_TAG1D( td, true, css_d_table_cell, css_ws_inherit )
+// Limits for special handling by our HTML Parser (ldomDocumentWriterFilter)
+#define EL_SPECIAL_START           el_html
+#define EL_SPECIAL_END             el_wbr
+#define EL_SPECIAL_CLOSING_P_START el_hr
+#define EL_SPECIAL_CLOSING_P_END   el_object
 
 // Inline elements
 XS_TAG1OBJ( img ) /* inline and specific handling as 'object' */
+
+                // HTML5: start of "active formatting elements"
 XS_TAG1I( a )
-XS_TAG1I( acronym )
 XS_TAG1I( b )
-XS_TAG1I( bdi )
-XS_TAG1I( bdo )
 XS_TAG1I( big )
-XS_TAG1I( br )
-XS_TAG1I( cite ) // conflict between HTML (inline) and FB2 (block): default here to inline (fb2.css puts it back to block)
 XS_TAG1I( code ) // should not be css_ws_pre according to specs
-XS_TAG1I( del )
-XS_TAG1I( dfn )
 XS_TAG1I( em )
-XS_TAG1I( emphasis )
 XS_TAG1I( font )
 XS_TAG1I( i )
-XS_TAG1I( ins )
-XS_TAG1I( kbd )
 XS_TAG1I( nobr )
-XS_TAG1I( q )
-XS_TAG1I( samp )
-XS_TAG1I( small )
-XS_TAG1I( span )
 XS_TAG1I( s )
+XS_TAG1I( small )
 XS_TAG1I( strike )
 XS_TAG1I( strong )
-XS_TAG1I( sub )
-XS_TAG1I( sup )
 XS_TAG1I( tt )
 XS_TAG1I( u )
+                // HTML5: end of "active formatting elements"
+                // This is just for refence: we don't handle them specifically
+                // (in HTML5, when mis-nested tags would close one of these,
+                // they are re-opened when leaving the mis-nested tag container)
+
+XS_TAG1I( acronym )
+XS_TAG1I( bdi )
+XS_TAG1I( bdo )
+XS_TAG1I( br )
+XS_TAG1I( cite ) // conflict between HTML (inline) and FB2 (block): default here to inline (fb2.css puts it back to block)
+XS_TAG1I( del )
+XS_TAG1I( dfn )
+XS_TAG1I( emphasis )
+XS_TAG1I( ins )
+XS_TAG1I( kbd )
+XS_TAG1I( q )
+XS_TAG1I( samp )
+XS_TAG1I( span )
+XS_TAG1I( sub )
+XS_TAG1I( sup )
 XS_TAG1I( var )
 
 // Ruby elements (defaults to inline)
 XS_TAG1D( ruby, true, css_d_ruby, css_ws_inherit )
 XS_TAG1I( rbc ) // no more in HTML5, but in 2001's https://www.w3.org/TR/ruby/
-XS_TAG1I( rtc )
 XS_TAG1I( rb )
+XS_TAG1I( rtc )
 XS_TAG1I( rt )
 XS_TAG1I( rp )
 

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -597,7 +597,7 @@ public:
     void updateSelections();
     void updateBookMarksRanges();
     /// get page document range, -1 for current page
-    LVRef<ldomXRange> getPageDocumentRange( int pageIndex=-1, bool precise = true );
+    LVRef<ldomXRange> getPageDocumentRange( int pageIndex=-1 );
     /// get page text, -1 for current page
     lString16 getPageText( bool wrapWords, int pageIndex=-1 );
     /// returns number of non-space characters on current page

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -81,7 +81,8 @@ extern "C" {
 
 #define LTEXT_FIT_GLYPHS             0x08000000  // Avoid glyph overflows and override at line edges and between text nodes
 
-#define LTEXT__AVAILABLE_BIT_29__    0x10000000
+#define LTEXT_LEGACY_RENDERING       0x10000000  // Legacy rendering exceptions: new line processing: set indentation for **each** new line, etc.
+
 #define LTEXT__AVAILABLE_BIT_30__    0x20000000
 #define LTEXT__AVAILABLE_BIT_31__    0x40000000
 #define LTEXT__AVAILABLE_BIT_32__    0x80000000

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2647,7 +2647,7 @@ public:
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
     /// called on attribute
     virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
     /// close tags
@@ -2700,7 +2700,7 @@ public:
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
     /// called on text
     virtual void OnText( const lChar16 * text, int len, lUInt32 flags );
     /// constructor
@@ -2788,7 +2788,7 @@ public:
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
     /// called on attribute
     virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
     /// called on text

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2690,7 +2690,16 @@ protected:
     lUInt16 _classAttrId;
     lUInt16 * _rules[MAX_ELEMENT_TYPE_ID];
     bool _tagBodyCalled;
+    // Some states used when gDOMVersionRequested >= 20200824
+    bool _htmlTagSeen;
+    bool _headTagSeen;
+    bool _bodyTagSeen;
+    bool _curNodeIsSelfClosing;
+    bool _curTagIsIgnored;
+    ldomElementWriter * _lastP;
     virtual void AutoClose( lUInt16 tag_id, bool open );
+    virtual bool AutoOpenClosePop( int step, lUInt16 tag_id );
+    virtual lUInt16 popUpTo( ldomElementWriter * target, lUInt16 target_id=0, int scope=0 );
     virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
     virtual void appendStyle( const lChar16 * style );
     virtual void setClass( const lChar16 * className, bool overrideExisting=false );

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1053,7 +1053,7 @@ public:
     /// inserts child text
     ldomNode * insertChildText( const lString16 & value );
     /// inserts child text
-    ldomNode * insertChildText(const lString8 & value);
+    ldomNode * insertChildText(const lString8 & value, bool before_last_child=false);
     /// remove child
     ldomNode * removeChild( lUInt32 index );
 
@@ -2595,11 +2595,11 @@ class ldomElementWriter
         return _element;
     }
     lString16 getPath();
-    void onText( const lChar16 * text, int len, lUInt32 flags );
+    void onText( const lChar16 * text, int len, lUInt32 flags, bool insert_before_last_child=false );
     void addAttribute( lUInt16 nsid, lUInt16 id, const wchar_t * value );
     //lxmlElementWriter * pop( lUInt16 id );
 
-    ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUInt16 id, ldomElementWriter * parent);
+    ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUInt16 id, ldomElementWriter * parent, bool insert_before_last_child=false);
     ~ldomElementWriter();
 
     friend class ldomDocumentWriter;
@@ -2696,10 +2696,13 @@ protected:
     bool _bodyTagSeen;
     bool _curNodeIsSelfClosing;
     bool _curTagIsIgnored;
+    ldomElementWriter * _curNodeBeforeFostering;
+    ldomElementWriter * _curFosteredNode;
     ldomElementWriter * _lastP;
     virtual void AutoClose( lUInt16 tag_id, bool open );
     virtual bool AutoOpenClosePop( int step, lUInt16 tag_id );
     virtual lUInt16 popUpTo( ldomElementWriter * target, lUInt16 target_id=0, int scope=0 );
+    virtual bool CheckAndEnsureFosterParenting(lUInt16 tag_id);
     virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
     virtual void appendStyle( const lChar16 * style );
     virtual void setClass( const lChar16 * className, bool overrideExisting=false );

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1746,6 +1746,8 @@ public:
     bool prevVisibleWordEndInSentence();
     /// move to next visible word beginning (in sentence)
     bool nextVisibleWordStartInSentence();
+    /// move to end of current word (in sentence)
+    bool thisVisibleWordEndInSentence();
     /// move to next visible word end (in sentence)
     bool nextVisibleWordEndInSentence();
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2682,14 +2682,16 @@ public:
 class ldomDocumentWriterFilter : public ldomDocumentWriter
 {
 protected:
+    bool _libRuDocumentToDetect;
     bool _libRuDocumentDetected;
     bool _libRuParagraphStart;
+    bool _libRuParseAsPre;
     lUInt16 _styleAttrId;
     lUInt16 _classAttrId;
     lUInt16 * _rules[MAX_ELEMENT_TYPE_ID];
     bool _tagBodyCalled;
     virtual void AutoClose( lUInt16 tag_id, bool open );
-    virtual void ElementCloseHandler( ldomNode * elem );
+    virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
     virtual void appendStyle( const lChar16 * style );
     virtual void setClass( const lChar16 * className, bool overrideExisting=false );
 public:

--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -61,10 +61,10 @@ public:
     {
         OnTagOpen( nsname, tagname );
         OnTagBody();
-        OnTagClose( nsname, tagname );
+        OnTagClose( nsname, tagname, true );
     }
     /// called on tag close
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname ) = 0;
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false ) = 0;
     /// called on element attribute
     virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue ) = 0;
     /// called on text

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -725,7 +725,7 @@ public:
     void OnTagBody();
 
     /// called on tag close
-    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
 
     /// called on element attribute
     void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
@@ -1319,7 +1319,7 @@ void docXMLreader::OnTagBody()
         m_handler->handleTagBody();
 }
 
-void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag )
 {
     CR_UNUSED(nsname);
 
@@ -2777,7 +2777,7 @@ void docx_drawingHandler::handleAttribute(const lChar16 *attrname, const lChar16
             m_writer->OnTagOpen(L"", L"img");
             m_writer->OnAttribute(L"", L"src",  imgPath.c_str());
             m_writer->OnTagBody();
-            m_writer->OnTagClose(L"", L"img");
+            m_writer->OnTagClose(L"", L"img", true);
         }
     }
 }

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -388,7 +388,7 @@ public:
         return NULL;
     }
     /// called on tag close
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname ) {
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false ) {
         CR_UNUSED(nsname);
         if (!lStr_cmp(tagname, "encryption"))
             insideEncryption = false;

--- a/crengine/src/fb3fmt.cpp
+++ b/crengine/src/fb3fmt.cpp
@@ -61,7 +61,7 @@ public:
 public:
     ldomNode *OnTagOpen(const lChar16 *nsname, const lChar16 *tagname);
     /// called on closing tag
-    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
     void OnTagBody();
     void OnAttribute(const lChar16 *nsname, const lChar16 *attrname, const lChar16 *attrvalue);
 
@@ -166,7 +166,7 @@ void fb3DomWriter::writeDescription()
         m_parent->OnTagOpenNoAttr( NULL, L"coverpage" );
         m_parent->OnTagOpen(NULL, L"image");
         m_parent->OnAttribute(L"l", L"href", m_context->m_coverImage.c_str());
-        m_parent->OnTagClose( NULL, L"image" );
+        m_parent->OnTagClose( NULL, L"image", true );
         m_parent->OnTagClose( NULL, L"coverpage" );
     }
     m_parent->OnTagClose( NULL, L"title-info" );
@@ -194,7 +194,7 @@ ldomNode *fb3DomWriter::OnTagOpen(const lChar16 *nsname, const lChar16 *tagname)
     return m_parent->OnTagOpen(nsname, tagname);
 }
 
-void fb3DomWriter::OnTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void fb3DomWriter::OnTagClose(const lChar16 *nsname, const lChar16 *tagname, bool self_closing_tag)
 {
     if ( !lStr_cmp(tagname, "fb3-body") ) {
         m_parent->OnTagClose(NULL, L"body");
@@ -206,7 +206,7 @@ void fb3DomWriter::OnTagClose(const lChar16 *nsname, const lChar16 *tagname)
     } else if ( !lStr_cmp(tagname, "notes" )) {
         tagname = L"body";
     }
-    m_parent->OnTagClose(nsname, tagname);
+    m_parent->OnTagClose(nsname, tagname, self_closing_tag);
 }
 
 void fb3DomWriter::OnTagBody()

--- a/crengine/src/hist.cpp
+++ b/crengine/src/hist.cpp
@@ -118,7 +118,7 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
     {
         if ( lStr_cmp(nsname, "FictionBookMarks")==0 && state==in_fbm ) {
             state = in_xml;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -669,7 +669,7 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
     {
         CR_UNUSED2(nsname, tagname);
         insidePatternTag = false;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -5904,7 +5904,7 @@ int LVDocView::doCommand(LVDocCmd cmd, int param) {
 		break;
 	case DCMD_GO_POS: {
 		if (m_view_mode == DVM_SCROLL) {
-			return SetPos(param);
+			return SetPos(param, true, true);
 		} else {
 			return goToPage(m_pages.FindNearestPage(param, 0));
 		}

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2616,7 +2616,7 @@ void LVDocView::setHeaderIcons(LVRefVec<LVImageSource> icons) {
 }
 
 /// get page document range, -1 for current page
-LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex, bool precise) {
+LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex) {
     LVLock lock(getMutex());
     CHECK_RENDER("getPageDocRange()")
     // On some pages (eg: that ends with some padding between an
@@ -2636,13 +2636,6 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex, bool precise) {
         int fh = GetFullHeight();
         if (end_y >= fh)
             end_y = fh - 1;
-        if (!precise) {
-            ldomXPointer start = m_doc->createXPointer(lvPoint(0, start_y));
-            ldomXPointer end = m_doc->createXPointer(lvPoint(0, end_y));
-            if (start.isNull() || end.isNull())
-                return res;
-            res = LVRef<ldomXRange> (new ldomXRange(start, end));
-        }
     }
     else {
         // PAGES mode
@@ -2652,16 +2645,8 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex, bool precise) {
             LVRendPageInfo * page = m_pages[pageIndex];
             if (page->flags & RN_PAGE_TYPE_COVER)
                 return res;
-            if (!precise) {
-                ldomXPointer start = m_doc->createXPointer(lvPoint(0, page->start));
-                ldomXPointer end = m_doc->createXPointer(lvPoint(0, page->start + page->height), 1);
-                if (start.isNull() || end.isNull())
-                    return res;
-                res = LVRef<ldomXRange>(new ldomXRange(start, end));
-            } else {
-                start_y = page->start;
-                end_y = page->start + page->height;
-            }
+            start_y = page->start;
+            end_y = page->start + page->height;
         }
         else {
             return res;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4713,6 +4713,13 @@ bool LVDocView::ParseDocument() {
         ldomDocumentWriter writer(m_doc);
         ldomDocumentWriterFilter writerFilter(m_doc, false, HTML_AUTOCLOSE_TABLE);
         lString16 txt_autodet_lang;
+        // Note: creating these 2 writers here, and using only one,
+        // will still have both their destructors called when
+        // leaving this scope. Each destructor call will have
+        // ldomDocumentWriter::~ldomDocumentWriter() called, and
+        // both will do the same work on m_doc. So, beware there
+        // that this causes no issue.
+        // We might want to refactor this section to avoid any issue.
 
         LVFileFormatParser * parser = NULL;
         if (m_stream->GetSize() >= 5) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8839,28 +8839,36 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->white_space = type_ptr->white_space;
 
         // Account for backward incompatible changes in fb2def.h
-        if (gDOMVersionRequested < 20180528) { // revert what was changed 20180528
-            if (nodeElementId == el_form) {
-                pstyle->display = css_d_none; // otherwise shown as block, as it may have textual content
-            }
-            if (nodeElementId == el_code) {
-                pstyle->white_space = css_ws_pre; // otherwise white-space: normal, as browsers do
-            }
-            if (nodeElementId >= el_address && nodeElementId <= el_xmp) { // newly added block elements
+        if (gDOMVersionRequested < 20200824) { // revert what was changed 20200824
+            if (nodeElementId >= el_details && nodeElementId <= el_wbr) { // newly added block elements
                 pstyle->display = css_d_inline; // previously unknown and shown as inline
                 if (gDOMVersionRequested < 20180524) {
                     pstyle->display = css_d_inherit; // previously unknown and display: inherit
                 }
             }
-            if (gDOMVersionRequested < 20180524) { // revert what was fixed 20180524
-                if (nodeElementId == el_cite) {
-                    pstyle->display = css_d_block; // otherwise correctly set to css_d_inline
+            if (gDOMVersionRequested < 20180528) { // revert what was changed 20180528
+                if (nodeElementId == el_form) {
+                    pstyle->display = css_d_none; // otherwise shown as block, as it may have textual content
                 }
-                if (nodeElementId == el_li) {
-                    pstyle->display = css_d_list_item_legacy; // otherwise correctly set to css_d_list_item_block
+                if (nodeElementId == el_code) {
+                    pstyle->white_space = css_ws_pre; // otherwise white-space: normal, as browsers do
                 }
-                if (nodeElementId == el_style) {
-                    pstyle->display = css_d_inline; // otherwise correctly set to css_d_none (hidden)
+                if (nodeElementId >= el_address && nodeElementId <= el_xmp) { // newly added block elements
+                    pstyle->display = css_d_inline; // previously unknown and shown as inline
+                    if (gDOMVersionRequested < 20180524) {
+                        pstyle->display = css_d_inherit; // previously unknown and display: inherit
+                    }
+                }
+                if (gDOMVersionRequested < 20180524) { // revert what was fixed 20180524
+                    if (nodeElementId == el_cite) {
+                        pstyle->display = css_d_block; // otherwise correctly set to css_d_inline
+                    }
+                    if (nodeElementId == el_li) {
+                        pstyle->display = css_d_list_item_legacy; // otherwise correctly set to css_d_list_item_block
+                    }
+                    if (nodeElementId == el_style) {
+                        pstyle->display = css_d_inline; // otherwise correctly set to css_d_none (hidden)
+                    }
                 }
             }
         }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -5676,8 +5676,8 @@ public:
         RenderRectAccessor fmt( node );
         int width = fmt.getWidth();
         int height = fmt.getHeight();
-        int x = fmt.getX();   // a floatBox has no margin and no padding, but these
-        int y = fmt.getY();   // x/y carries the container's padding left/top
+        int x = fmt.getX();   // a floatBox has no margin and no padding, but x carries the container's padding left
+        int y = fmt.getY();   // (but y must be =0, as padding_top has already been accounted in c_y
         // printf("  block addFloat w=%d h=%d x=%d y=%d\n", width, height, x, y);
         int shift_x = 0;
         int shift_y = 0;
@@ -6980,9 +6980,11 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         // and if !DO_NOT_CLEAR_OWN_FLOATS, we'll fill the remaining
                         // height taken by floats if any.
                         LVRendPageContext alt_context( NULL, flow->getPageHeight(), false );
-                        // For floats too, the provided x/y must be the padding-left/top of the
+                        // For floats too, the provided x must be the padding-left of the
                         // parent container of the float (and width must exclude the parent's
-                        // padding-left/right) for the flow to correctly position inner floats:
+                        // padding-left/right) for the flow to correctly position inner floats
+                        // (but we don't provide padding_top, as if non-zero, we already
+                        // flow->addContentLine() it above, so the flow is already aware of it):
                         // flow->addFloat() will additionally shift its positionning by the
                         // child x/y set by this renderBlockElement().
                         // We provide 0,0 as the usable left/right overflows, so no glyph/hanging
@@ -6990,7 +6992,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         // the initial float element's margins, which can then be used if it has
                         // no border (if borders, only the padding can be used).
                         renderBlockElement( alt_context, child, (is_rtl ? 0 : list_marker_padding) + padding_left,
-                                    padding_top, width - list_marker_padding - padding_left - padding_right, 0, 0, direction );
+                                    0, width - list_marker_padding - padding_left - padding_right, 0, 0, direction );
                         flow->addFloat(child, child_clear, is_right, flt_vertical_margin);
                         // Gather footnotes links accumulated by alt_context
                         lString16Collection * link_ids = alt_context.getLinkIds();
@@ -7528,6 +7530,7 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
         // in a float, etc...)
         FlowState flow( context, width, usable_left_overflow, usable_right_overflow, rend_flags,
                                 direction, TextLangMan::getLangNodeIndex(enode) );
+        flow.moveDown(y);
         if (baseline != NULL) {
             flow.setRequestedBaselineType(*baseline);
         }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3757,10 +3757,15 @@ public:
         while ( pos<m_length ) { // each loop makes a line
             // x is this line indent. We use it like a x coordinates below, but
             // we'll use it on the right in addLine() if para is RTL.
-            int x = m_indent_current;
-            if ( !m_indent_first_line_done ) {
-                m_indent_first_line_done = true;
-                m_indent_current = m_indent_after_first_line;
+            int x;
+            if (para->flags & LTEXT_LEGACY_RENDERING) {
+                x = para->indent > 0 ? (pos == 0 ? para->indent : 0 ) : (pos==0 ? 0 : -para->indent);
+            } else {
+                x = m_indent_current;
+                if ( !m_indent_first_line_done ) {
+                    m_indent_first_line_done = true;
+                    m_indent_current = m_indent_after_first_line;
+                }
             }
             int w0 = pos>0 ? m_widths[pos-1] : 0; // measured cumulative width at start of this line
             int lastNormalWrap = -1;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1378,6 +1378,21 @@ public:
                             else if ( c >= 0x2066 ) m_flags[pos] = LCHAR_IS_TO_IGNORE; // 2066>2069
                         }
                     }
+                    else if ( c <= 0x009F ) {
+                        // Also ignore some ASCII and Unicode control chars
+                        // in the ranges 00>1F and 7F>9F, except a few.
+                        // (Some of these can be found in old documents or
+                        // badly converted ones)
+                        if ( c <= 0x001F ) {
+                            // Let \t \n \r be (they might have already been
+                            // expanded to spaces, converted or skipped)
+                            if ( c != 0x000A && c!= 0x000D && c!= 0x0009 )
+                                m_flags[pos] = LCHAR_IS_TO_IGNORE; // 0000>001F except those above
+                        }
+                        else if ( c >= 0x007F ) {
+                            m_flags[pos] = LCHAR_IS_TO_IGNORE;     // 007F>009F
+                        }
+                    }
                     // We might want to add some others when we happen to meet them.
                     // todo: see harfbuzz hb-unicode.hh is_default_ignorable() for how
                     // to do this kind of check fast

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7511,7 +7511,7 @@ ldomDocumentWriter::~ldomDocumentWriter()
 #endif
 }
 
-void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
+void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname, bool self_closing_tag )
 {
     //logfile << "ldomDocumentWriter::OnTagClose() [" << nsname << ":" << tagname << "]";
     if (!_currNode || !_currNode->getElement())
@@ -12784,7 +12784,7 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar16 * nsname, const 
 }
 
 /// called on closing tag
-void ldomDocumentFragmentWriter::OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void ldomDocumentFragmentWriter::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag )
 {
     styleDetectionState = headStyleState = 0;
     if ( insideTag && baseTag==tagname ) {
@@ -12797,7 +12797,7 @@ void ldomDocumentFragmentWriter::OnTagClose( const lChar16 * nsname, const lChar
         return;
     }
     if ( insideTag )
-        parent->OnTagClose(nsname, tagname);
+        parent->OnTagClose(nsname, tagname, self_closing_tag);
 }
 
 /// called after > of opening tag (when entering tag body) or just before /> closing tag for empty tags
@@ -13112,7 +13112,7 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
 }
 
 /// called on closing tag
-void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lChar16 * tagname )
+void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lChar16 * tagname, bool self_closing_tag )
 {
     if ( !_tagBodyCalled ) {
         CRLog::error("OnTagClose w/o parent's OnTagBody : %s", LCSTR(lString16(tagname)));

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -84,7 +84,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.12.68"
+#define CACHE_FILE_FORMAT_VERSION "3.12.69"
 
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11476,7 +11476,7 @@ bool ldomXPointerEx::prevVisibleWordStartInSentence()
     for ( ;; ) {
         if ( !isText() || !isVisible() || _data->getOffset()==0 ) {
             // move to previous text
-            if ( !prevVisibleText(true) )
+            if ( !prevVisibleText(false) )
                 return false;
             node = getNode();
             text = node->getText();
@@ -11513,7 +11513,7 @@ bool ldomXPointerEx::nextVisibleWordStartInSentence()
     bool moved = false;
     for ( ;; ) {
         if ( !isText() || !isVisible() ) {
-            // move to previous text
+            // move to next text
             if ( !nextVisibleText(false) )
                 return false;
             node = getNode();
@@ -11558,6 +11558,37 @@ bool ldomXPointerEx::nextVisibleWordStartInSentence()
         if ( moved && _data->getOffset()<textLen )
             return true;
     }
+}
+
+/// move to end of current word
+bool ldomXPointerEx::thisVisibleWordEndInSentence()
+{
+    if ( isNull() )
+        return false;
+    ldomNode * node = NULL;
+    lString16 text;
+    int textLen = 0;
+    bool moved = false;
+    if ( !isText() || !isVisible() )
+        return false;
+    node = getNode();
+    text = node->getText();
+    textLen = text.length();
+    if ( _data->getOffset() >= textLen )
+        return false;
+    // skip spaces
+    while ( _data->getOffset()<textLen && IsUnicodeSpace(text[ _data->getOffset() ]) ) {
+        _data->addOffset(1);
+        //moved = true;
+    }
+    // skip non-spaces
+    while ( _data->getOffset()<textLen ) {
+        if ( IsUnicodeSpace(text[ _data->getOffset() ]) )
+            break;
+        moved = true;
+        _data->addOffset(1);
+    }
+    return moved;
 }
 
 /// move to next visible word end (in sentence)
@@ -11866,8 +11897,8 @@ bool ldomXPointerEx::isSentenceEnd()
     // word is not ended with . ! ?
     // check whether it's last word of block
     ldomXPointerEx pos(*this);
-    //return !pos.nextVisibleWordStart(true);
-    return !pos.thisVisibleWordEnd(true);
+    //return !pos.nextVisibleWordStartInSentence();
+    return !pos.thisVisibleWordEndInSentence();
 }
 
 /// move to beginning of current visible text sentence
@@ -11919,7 +11950,7 @@ bool ldomXPointerEx::prevSentenceStart()
     if ( !thisSentenceStart() )
         return false;
     for (;;) {
-        if ( !prevVisibleWordStart() )
+        if ( !prevVisibleWordStartInSentence() )
             return false;
         if ( isSentenceStart() )
             return true;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6236,7 +6236,10 @@ void ldomNode::initNodeRendMethod()
                             autoboxChildren( j, i, handleFloating );
                         i = j;
                     }
-                    else if ( i>0 ) {
+                    else if ( i>0 && node->getRendMethod() == erm_final ) {
+                        // (We skip the following if the current node is not erm_final, as
+                        // if it is erm_block, we would break the block layout by making
+                        // it all inline in an erm_final autoBoxing.)
                         // This node is not inline, but might be preceeded by a css_d_run_in node:
                         // https://css-tricks.com/run-in/
                         // https://developer.mozilla.org/en-US/docs/Web/CSS/display

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5843,16 +5843,24 @@ bool LVHTMLParser::CheckFormat()
     if ( charsDecoded > 30 ) {
         lString16 s( chbuf, charsDecoded );
         s.lowercase();
-        if ( s.pos("<html") >=0 && ( s.pos("<head") >= 0 || s.pos("<body") >=0 ) ) //&& s.pos("<FictionBook") >= 0
+        if ( s.pos("<html") >=0 && ( s.pos("<head") >= 0 || s.pos("<body") >=0 ) ) {
             res = true;
-        lString16 name=m_stream->GetName();
-        name.lowercase();
-        bool html_ext = name.endsWith(".htm") || name.endsWith(".html")
-                        || name.endsWith(".hhc")
-                        || name.endsWith(".xhtml");
-        if ( html_ext && (s.pos("<!--")>=0 || s.pos("UL")>=0
-                           || s.pos("<p>")>=0 || s.pos("ul")>=0) )
-            res = true;
+        }
+        if ( !res ) { // check <!doctype html> (and others) which may have no/implicit <html/head/body>
+            int doctype_pos = s.pos("<!doctype ");
+            if ( doctype_pos >= 0 ) {
+                int html_pos = s.pos("html", doctype_pos);
+                if ( html_pos >= 0 && html_pos < 32 )
+                    res = true;
+            }
+        }
+        if ( !res ) { // check filename extension and present of common HTML tags
+            lString16 name=m_stream->GetName();
+            name.lowercase();
+            bool html_ext = name.endsWith(".htm") || name.endsWith(".html") || name.endsWith(".hhc") || name.endsWith(".xhtml");
+            if ( html_ext && (s.pos("<!--")>=0 || s.pos("ul")>=0 || s.pos("<p>")>=0) )
+                res = true;
+        }
         lString16 enc = htmlCharset( s );
         if ( !enc.empty() )
             SetCharset( enc.c_str() );

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -1829,7 +1829,7 @@ public:
             callback->OnTagOpen(L"", L"img");
             callback->OnAttribute(L"", L"src", url.c_str());
             callback->OnTagBody();
-            callback->OnTagClose(L"", L"img");
+            callback->OnTagClose(L"", L"img", true);
         }
 
         void startParagraph() {
@@ -3053,8 +3053,8 @@ bool LVXMLParser::Parse()
                 {
                     m_callback->OnTagBody();
                     // end of tag
-                    if ( ch!='>' )
-                        m_callback->OnTagClose(tagns.c_str(), tagname.c_str());
+                    if ( ch!='>' ) // '/' in '<hr/>' : self closing tag
+                        m_callback->OnTagClose(tagns.c_str(), tagname.c_str(), true);
                     if ( ch=='>' )
                         PeekNextCharFromBuffer();
                     else
@@ -6286,7 +6286,7 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
     {
         if ( lStr_cmp(nsname, "FictionBook")==0) {
             insideFictionBook = false;

--- a/crengine/src/rtfimp.cpp
+++ b/crengine/src/rtfimp.cpp
@@ -169,7 +169,7 @@ public:
         len = s.length();
         if ( !len ) {
             m_callback->OnTagOpenNoAttr(NULL, L"empty-line");
-            m_callback->OnTagClose(NULL, L"empty-line");
+            m_callback->OnTagClose(NULL, L"empty-line", true);
             return;
         }
         bool intbl = m_stack.getInt( pi_intbl )>0;
@@ -370,7 +370,7 @@ public:
 #endif
         m_callback->OnTagOpen(LXML_NS_NONE, L"img");
         m_callback->OnAttribute(LXML_NS_NONE, L"src", name.c_str());
-        m_callback->OnTagClose(LXML_NS_NONE, L"img");
+        m_callback->OnTagClose(LXML_NS_NONE, L"img", true);
     }
 };
 

--- a/crengine/src/wordfmt.cpp
+++ b/crengine/src/wordfmt.cpp
@@ -714,7 +714,7 @@ bTranslateImage(diagram_type *pDiag, FILE *pFile, BOOL bMinimalInformation,
             writer->OnBlob(name, pucJpeg, len);
             writer->OnTagOpen(LXML_NS_NONE, L"img");
             writer->OnAttribute(LXML_NS_NONE, L"src", name.c_str());
-            writer->OnTagClose(LXML_NS_NONE, L"img");
+            writer->OnTagClose(LXML_NS_NONE, L"img", true);
 
             free(pucJpeg);
             return TRUE;


### PR DESCRIPTION
* Fixed fb2 coverpage drawing in scroll mode (continuous) with enhanced render.
* Android: use fast (not precise) mode for functions LVDocView::getBookmark() **only** for page turn & text scroll.
* Optimized calculation of average animation duration.
* Android: fixed scrolling of text around start and end of a book in scrolling mode.
* Improved methods for selecting next/previous sentence when using "***" paragraph separators. In fact, this is a continuation of PR #144, i.e. restoration of old functionality.
* Legacy rendering mode: display block elements that are inside inline elements as block elements.
* Trying to update the structure of a database that has been modified by some kind of uncoordinated fork of the program.
* Forced update the DOM level in database from previous newest to latest newest.

Updates from KOReader:
* New HTML parser, libRu and FB2 tweaks https://github.com/koreader/crengine/pull/370