### PR TITLE
ODT format support fixes

### DIFF
--- a/crengine/src/odtfmt.cpp
+++ b/crengine/src/odtfmt.cpp
@@ -767,6 +767,9 @@ void odt_documentHandler::handleTagClose(const lChar16 *nsname, const lChar16 *t
         m_writer->OnTagClose(L"", L"section");
         m_writer = m_saveWriter;
         break;
+    case odt_el_noteCitation:
+        m_writer->OnTagClose(L"", L"a");
+        break;
     case odt_el_table:
         m_inTable = false;
     default:
@@ -806,6 +809,7 @@ void odt_documentHandler::handleText(const lChar16 *text, int len, lUInt32 flags
         break;
     case odt_el_noteCitation:
         m_noteRefText = text;
+        m_writer->OnTagBody();
     case odt_el_bookmarkRef:
     case odt_el_noteRef:
     case odt_el_referenceRef:

--- a/crengine/src/odtfmt.cpp
+++ b/crengine/src/odtfmt.cpp
@@ -642,6 +642,10 @@ void odt_documentHandler::handleAttribute(const lChar16 *attrname, const lChar16
 
             if(value.atoi(tmp))
                 m_outlineLevel = tmp - 1;
+            break;
+        }
+        if( !lStr_cmp(attrname, "style-name") ) {
+            m_StyleName = attrValue;
         }
         break;
     case odt_el_note:
@@ -963,7 +967,7 @@ void odt_stylesHandler::handleAttribute(const lChar16 *attrname, const lChar16 *
             int n = parse_name(odt_fontWeigth_attr_values, attrvalue);
             if( n != -1 )
                 m_rPr->setBold( n >= 600 );
-        } else if( !lStr_cmp(attrname, "text-underline-type") ) {
+        } else if( !lStr_cmp(attrname, "text-underline-style") ) {
             m_rPr->setUnderline( lStr_cmp( attrvalue, "none") !=0 );
         } else if( !lStr_cmp(attrname, "text-line-through-type") ) {
             m_rPr->setStrikeThrough( lStr_cmp( attrvalue, "none") !=0 );

--- a/crengine/src/odtfmt.cpp
+++ b/crengine/src/odtfmt.cpp
@@ -36,7 +36,6 @@
     ODT_TAG2(referenceMarkStart, "reference-mark-start")\
     ODT_TAG2(referenceRef, "reference-ref")\
     ODT_TAG(s)\
-    ODT_TAG2(softPageBreak, "soft-page-break")\
     ODT_TAG(span)\
     ODT_TAG(style)\
     ODT_TAG(styles)\
@@ -105,7 +104,6 @@ const struct item_def_t odt_elements_mapping[] = {
     { odt_el_referenceMarkStart, L"a" },
     { odt_el_referenceRef, L"a" },
     { odt_el_s, NULL },
-    { odt_el_softPageBreak, NULL },
     { odt_el_span, NULL },
     { odt_el_style, NULL },
     { odt_el_styles, NULL },
@@ -143,7 +141,6 @@ const struct item_def_t odt_elements[] = {
     ODT_TAG_CHILD(referenceMarkStart),
     ODT_TAG_CHILD(referenceRef),
     ODT_TAG_CHILD(s),
-    ODT_TAG_CHILD(softPageBreak),
     ODT_TAG_CHILD(span),
     ODT_TAG_CHILD(tab),
     ODT_TAG_CHILD(table),
@@ -559,14 +556,6 @@ ldomNode *odt_documentHandler::handleTagOpen(int tagId)
     case odt_el_listItem:
         m_inListItem = true;
         m_listItemHadContent = false;
-        break;
-    case odt_el_softPageBreak:
-        if( odt_el_p == m_state)
-            checkParagraphStart();
-        m_writer->OnTagOpen(L"", L"div");
-        m_writer->OnAttribute(L"", L"style", L"page-break-before: always");
-        m_writer->OnTagBody();
-        m_writer->OnTagClose(L"", L"div");
         break;
     case odt_el_tab:
     case odt_el_s:


### PR DESCRIPTION
The following bugs were discovered (thanks to @virxkane)  and fixed:
- a bug when style not applied to a heading element
- superfluous page break, 
- crash when processing footnote