### PR TITLE
Refactoring some globals variable in lvrend.h

### DIFF
--- a/cr3qt/src/settings.cpp
+++ b/cr3qt/src/settings.cpp
@@ -1166,8 +1166,7 @@ void SettingsDlg::on_cbRendFlags_currentIndexChanged(int index)
         m_ui->label_48->setVisible(embedded_lang);
         m_ui->cbEnableHyph->setVisible(embedded_lang);
     }
-    // don't update preview to not change global variable gRenderBlockRenderingFlags too early!
-    //updateStyleSample();
+    updateStyleSample();
 }
 
 void SettingsDlg::on_cbDOMLevel_currentIndexChanged(int index)
@@ -1191,6 +1190,7 @@ void SettingsDlg::on_cbDOMLevel_currentIndexChanged(int index)
         m_ui->cbEnableHyph->setVisible(embedded_lang);
     }
     m_props->setInt(PROP_REQUESTED_DOM_VERSION, DOM_versions[index]);
+    updateStyleSample();
 }
 
 void SettingsDlg::on_cbMultiLang_stateChanged(int state)

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -126,12 +126,12 @@ lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt
 /// renders block as single text formatter object
 void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & flags,
                        int indent, int line_h, TextLangCfg * lang_cfg=NULL, int valign_dy=0, bool * is_link_start=NULL );
-/// renders block which contains subblocks (with gRenderBlockRenderingFlags as flags)
+/// renders block which contains subblocks (with enode document's getRenderBlockRenderingFlags() as flags)
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
         int usable_left_overflow=0, int usable_right_overflow=0, int direction=REND_DIRECTION_UNSET, int * baseline=NULL );
 /// renders block which contains subblocks
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
-        int usable_left_overflow, int usable_right_overflow, int direction, int * baseline, int rend_flags );
+        int usable_left_overflow, int usable_right_overflow, int direction, int * baseline, lUInt32 rend_flags );
 /// renders table element
 int renderTable( LVRendPageContext & context, ldomNode * element, int x, int y, int width,
                  bool shrink_to_fit, int & fitted_width, int direction=REND_DIRECTION_UNSET,
@@ -179,8 +179,6 @@ extern int gRootFontSize;
 #define INTERLINE_SCALE_FACTOR_SHIFT 10
 extern int gInterlineScaleFactor;
 
-extern int gRenderBlockRenderingFlags;
-
 // Enhanced rendering flags
 #define BLOCK_RENDERING_ENHANCED                           0x00000001
 #define BLOCK_RENDERING_ALLOW_PAGE_BREAK_WHEN_NO_CONTENT   0x00000002 // Allow consecutive page breaks when only separated
@@ -221,7 +219,6 @@ extern int gRenderBlockRenderingFlags;
 // Enable everything
 #define BLOCK_RENDERING_FULL_FEATURED                      0x7FFFFFFF
 
-#define BLOCK_RENDERING_G(f) ( gRenderBlockRenderingFlags & BLOCK_RENDERING_##f )
 #define BLOCK_RENDERING(v, f) ( v & BLOCK_RENDERING_##f )
 
 // rendering flags presets
@@ -247,7 +244,5 @@ extern int gRenderBlockRenderingFlags;
                                            BLOCK_RENDERING_BOX_INLINE_BLOCKS )
 #define BLOCK_RENDERING_FLAGS_WEB        BLOCK_RENDERING_FULL_FEATURED
 #define BLOCK_RENDERING_FLAGS_DEFAULT    BLOCK_RENDERING_FLAGS_WEB
-
-int validateBlockRenderingFlags( int f );
 
 #endif

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -177,7 +177,6 @@ extern int gRootFontSize;
 
 #define INTERLINE_SCALE_FACTOR_NO_SCALE 1024
 #define INTERLINE_SCALE_FACTOR_SHIFT 10
-extern int gInterlineScaleFactor;
 
 // Enhanced rendering flags
 #define BLOCK_RENDERING_ENHANCED                           0x00000001

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -175,8 +175,6 @@ extern int gRenderDPI;
 extern bool gRenderScaleFontWithDPI;
 extern int gRootFontSize;
 
-extern bool gHangingPunctuationEnabled;
-
 #define INTERLINE_SCALE_FACTOR_NO_SCALE 1024
 #define INTERLINE_SCALE_FACTOR_SHIFT 10
 extern int gInterlineScaleFactor;

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -81,7 +81,7 @@ private:
 public:
     void apply( css_style_rec_t * style );
     bool empty() { return _data==NULL; }
-    bool parse( const char * & decl, bool higher_importance=false, lxmlDocBase * doc=NULL, lString16 codeBase=lString16::empty_str );
+    bool parse( const char * & decl, lUInt32 domVersionRequested, bool higher_importance=false, lxmlDocBase * doc=NULL, lString16 codeBase=lString16::empty_str );
     lUInt32 getHash();
     LVCssDeclaration() : _data(NULL) { }
     ~LVCssDeclaration() { if (_data) delete[] _data; }

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -497,6 +497,7 @@ protected:
     int calcFinalBlocks();
     void dropStyles();
 #endif
+    bool _hangingPunctuationEnabled;
 
     ldomDataStorageManager _textStorage; // persistent text node data storage
     ldomDataStorageManager _elemStorage; // persistent element data storage
@@ -585,9 +586,7 @@ public:
         _renderedBlockCache.clear();
         return true;
     }
-#endif
 
-#if BUILD_LITE!=1
     /// add named BLOB data to document
     bool addBlob(lString16 name, const lUInt8 * data, int size) { _cacheFileStale = true ; return _blobCache.addBlob(data, size, name); }
     /// get BLOB by name
@@ -613,6 +612,12 @@ public:
 
     bool createCacheFile();
 #endif
+
+    bool getHangingPunctiationEnabled() const {
+        return _hangingPunctuationEnabled;
+    }
+
+    bool setHangingPunctiationEnabled(bool value);
 
     inline bool getDocFlag( lUInt32 mask )
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -45,7 +45,6 @@
 
 // Allows for requesting older DOM building code (including bugs NOT fixed)
 extern const int gDOMVersionCurrent;
-extern int gDOMVersionRequested;
 
 // Also defined in src/lvtinydom.cpp
 #define DOM_VERSION_WITH_NORMALIZED_XPOINTERS 20200223
@@ -499,6 +498,7 @@ protected:
 #endif
     bool _hangingPunctuationEnabled;
     lUInt32 _renderBlockRenderingFlags;
+    lUInt32 _DOMVersionRequested;
 
     ldomDataStorageManager _textStorage; // persistent text node data storage
     ldomDataStorageManager _elemStorage; // persistent element data storage
@@ -623,6 +623,11 @@ public:
         return _renderBlockRenderingFlags;
     }
     bool setRenderBlockRenderingFlags(lUInt32 flags);
+
+    lUInt32 getDOMVersionRequested() const {
+        return _DOMVersionRequested;
+    }
+    bool setDOMVersionRequested(lUInt32 version);
 
     inline bool getDocFlag( lUInt32 mask )
     {
@@ -1579,7 +1584,8 @@ public:
     /// converts to string
     lString16 toString( XPointerMode mode = XPATH_USE_NAMES) {
         if( XPATH_USE_NAMES==mode ) {
-            if( gDOMVersionRequested >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS)
+            tinyNodeCollection* doc = (tinyNodeCollection*)_data->getDocument();
+            if ( doc != NULL && doc->getDOMVersionRequested() >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS )
                 return toStringV2();
             return toStringV1();
         }
@@ -2564,7 +2570,7 @@ public:
     /// create xpointer from relative pointer string
     ldomXPointer createXPointer( ldomNode * baseNode, const lString16 & xPointerStr )
     {
-        if( gDOMVersionRequested >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS)
+        if( _DOMVersionRequested >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS)
             return createXPointerV2(baseNode, xPointerStr);
         return createXPointerV1(baseNode, xPointerStr);
     }

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -499,6 +499,7 @@ protected:
     bool _hangingPunctuationEnabled;
     lUInt32 _renderBlockRenderingFlags;
     lUInt32 _DOMVersionRequested;
+    int _interlineScaleFactor;
 
     ldomDataStorageManager _textStorage; // persistent text node data storage
     ldomDataStorageManager _elemStorage; // persistent element data storage
@@ -628,6 +629,11 @@ public:
         return _DOMVersionRequested;
     }
     bool setDOMVersionRequested(lUInt32 version);
+
+    int getInterlineScaleFactor() const {
+        return _interlineScaleFactor;
+    }
+    bool setInterlineScaleFactor(int value);
 
     inline bool getDocFlag( lUInt32 mask )
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -498,6 +498,7 @@ protected:
     void dropStyles();
 #endif
     bool _hangingPunctuationEnabled;
+    lUInt32 _renderBlockRenderingFlags;
 
     ldomDataStorageManager _textStorage; // persistent text node data storage
     ldomDataStorageManager _elemStorage; // persistent element data storage
@@ -616,8 +617,12 @@ public:
     bool getHangingPunctiationEnabled() const {
         return _hangingPunctuationEnabled;
     }
-
     bool setHangingPunctiationEnabled(bool value);
+
+    lUInt32 getRenderBlockRenderingFlags() const {
+        return _renderBlockRenderingFlags;
+    }
+    bool setRenderBlockRenderingFlags(lUInt32 flags);
 
     inline bool getDocFlag( lUInt32 mask )
     {

--- a/crengine/src/hist.cpp
+++ b/crengine/src/hist.cpp
@@ -461,23 +461,25 @@ void CRFileHistRecord::setLastPos( CRBookmark * bmk )
 
 void CRFileHistRecord::convertBookmarks(ldomDocument *doc, int newDOMversion)
 {
+    // TODO: Don't call tinyNodeCollection::setDOMVersionRequested()
+    // but directly use functions ldomDocument::createXPointerV1() & ldomDocument::createXPointerV2().
     for ( int i=0; i< getBookmarks().length(); i++) {
         CRBookmark * bmk = getBookmarks()[i];
 
         if( bmk->isValid() ) {
             if (bmk->getType() != bmkt_lastpos) {
-                gDOMVersionRequested = getDOMversion();
+                doc->setDOMVersionRequested(getDOMversion());
                 ldomXPointer p = doc->createXPointer(bmk->getStartPos());
                 if ( !p.isNull() ) {
-                    gDOMVersionRequested = newDOMversion;
+                    doc->setDOMVersionRequested(newDOMversion);
                     bmk->setStartPos(p.toString());
                 }
                 lString16 endPos = bmk->getEndPos();
                 if( !endPos.empty() ) {
-                    gDOMVersionRequested = getDOMversion();
+                    doc->setDOMVersionRequested(getDOMversion());
                     p = doc->createXPointer(endPos);
                     if( !p.isNull() ) {
-                        gDOMVersionRequested = newDOMversion;
+                        doc->setDOMVersionRequested(newDOMversion);
                         bmk->setEndPos(p.toString());
                     }
                 }

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4645,6 +4645,7 @@ void LVDocView::createEmptyDocument() {
     m_doc->setMinSpaceCondensingPercent(m_props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT));
     m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT));
     m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT));
+    m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, true));
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)
@@ -6684,12 +6685,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             REQUEST_RENDER("propsApply footnotes")
         } else if (name == PROP_FLOATING_PUNCTUATION) {
             bool value = props->getBoolDef(PROP_FLOATING_PUNCTUATION, true);
-            if ( gHangingPunctuationEnabled != value ) {
-                gHangingPunctuationEnabled = value;
-                REQUEST_RENDER("propsApply - hanging punctuation")
-                // requestRender() does m_doc->clearRendBlockCache(), which is needed
-                // on hanging punctuation change
-            }
+            if (m_doc) // not when noDefaultDocument=true
+                if (getDocument()->setHangingPunctiationEnabled(value)) {
+                    REQUEST_RENDER("propsApply - hanging punctuation")
+                    // requestRender() does m_doc->clearRendBlockCache(), which is needed
+                    // on hanging punctuation change
+                }
         } else if (name == PROP_REQUESTED_DOM_VERSION) {
             int value = props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent);
             if (gDOMVersionRequested != value) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4646,6 +4646,7 @@ void LVDocView::createEmptyDocument() {
     m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT));
     m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT));
     m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, true));
+    m_doc->setRenderBlockRenderingFlags(m_props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, BLOCK_RENDERING_FLAGS_DEFAULT));
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)
@@ -5830,7 +5831,7 @@ int LVDocView::doCommand(LVDocCmd cmd, int param) {
     case DCMD_RENDER_BLOCK_RENDERING_FLAGS:
         CRLog::trace("DCMD_RENDER_BLOCK_RENDERING_FLAGS(%d)", param);
         m_props->setInt(PROP_RENDER_BLOCK_RENDERING_FLAGS, param);
-        gRenderBlockRenderingFlags = param;
+        getDocument()->setRenderBlockRenderingFlags(param);
         REQUEST_RENDER("doCommand-set block rendering flags")
         break;
     case DCMD_REQUEST_RENDER:
@@ -6699,13 +6700,10 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 needUpdateHyphenation = true;
             }
         } else if (name == PROP_RENDER_BLOCK_RENDERING_FLAGS) {
-            int value = props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, BLOCK_RENDERING_FLAGS_DEFAULT);
-            value = validateBlockRenderingFlags(value);
-            if ( gRenderBlockRenderingFlags != value ) {
-                gRenderBlockRenderingFlags = value;
-                REQUEST_RENDER("propsApply render block rendering flags")
-                needUpdateHyphenation = true;
-            }
+            lUInt32 value = (lUInt32)props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, BLOCK_RENDERING_FLAGS_DEFAULT);
+            if (m_doc) // not when noDefaultDocument=true
+                if (getDocument()->setRenderBlockRenderingFlags(value))
+                    REQUEST_RENDER("propsApply render block rendering flags")
         } else if (name == PROP_RENDER_DPI) {
             int value = props->getIntDef(PROP_RENDER_DPI, DEF_RENDER_DPI);
             if ( gRenderDPI != value ) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3519,10 +3519,12 @@ void LVDocView::setDefaultInterlineSpace(int percent) {
     LVLock lock(getMutex());
     REQUEST_RENDER("setDefaultInterlineSpace")
     m_def_interline_space = percent; // not used
-    if (percent == 100) // (avoid any rounding issue)
-        gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE;
-    else
-        gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE * percent / 100;
+    if (m_doc) {
+        if (percent == 100) // (avoid any rounding issue)
+            m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE);
+        else
+            m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE * percent / 100);
+    }
     _posIsSet = false;
 //	goToBookmark( _posBookmark);
 //        updateBookMarksRanges();
@@ -4646,6 +4648,10 @@ void LVDocView::createEmptyDocument() {
     m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, true));
     m_doc->setRenderBlockRenderingFlags(m_props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, BLOCK_RENDERING_FLAGS_DEFAULT));
     m_doc->setDOMVersionRequested(m_props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent));
+    if (m_def_interline_space == 100) // (avoid any rounding issue)
+        m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE);
+    else
+        m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE * m_def_interline_space / 100);
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -51,8 +51,6 @@
 // crengine default used to be "width: 100%", but now that we
 // can shrink to fit, it is "width: auto".
 
-bool gHangingPunctuationEnabled = false;
-
 int gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE;
 
 int gRenderDPI = DEF_RENDER_DPI; // if 0: old crengine behaviour: 1px/pt=1px, 1in/cm/pc...=0px

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -65,19 +65,6 @@ int scaleForRenderDPI( int value ) {
     return value;
 }
 
-int gRenderBlockRenderingFlags = BLOCK_RENDERING_FLAGS_DEFAULT;
-
-int validateBlockRenderingFlags(int f) {
-    // Check coherency and ensure dependancies of flags
-    if (f & ~BLOCK_RENDERING_ENHANCED) // If any other flag is set,
-        f |= BLOCK_RENDERING_ENHANCED; // set ENHANGED
-    if (f & BLOCK_RENDERING_FLOAT_FLOATBOXES)
-        f |= BLOCK_RENDERING_PREPARE_FLOATBOXES;
-    if (f & BLOCK_RENDERING_PREPARE_FLOATBOXES)
-        f |= BLOCK_RENDERING_WRAP_FLOATS;
-    return f;
-}
-
 // Uncomment for debugging enhanced block rendering
 // #define DEBUG_BLOCK_RENDERING
 
@@ -1579,7 +1566,7 @@ public:
                         // Except when table is a single column, and we can just
                         // transfer lines to the upper context.
                         LVRendPageContext * cell_context;
-                        int rend_flags = gRenderBlockRenderingFlags; // global flags
+                        int rend_flags = elem->getDocument()->getRenderBlockRenderingFlags();
                         if ( is_single_column ) {
                             row->single_col_context = new LVRendPageContext(NULL, context.getPageHeight());
                             cell_context = row->single_col_context;
@@ -2463,6 +2450,7 @@ bool renderAsListStylePositionInside( const css_style_ref_t style, bool is_rtl=f
 // and to get paragraph direction (LTR/RTL/UNSET).
 void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & baseflags, int indent, int line_h, TextLangCfg * lang_cfg, int valign_dy, bool * is_link_start )
 {
+    bool legacy_render = !BLOCK_RENDERING(enode->getDocument()->getRenderBlockRenderingFlags(), ENHANCED);
     if ( enode->isElement() ) {
         lvdom_element_render_method rm = enode->getRendMethod();
         if ( rm == erm_invisible )
@@ -2514,7 +2502,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // as in CoolReader 3.2.38 and earlier, i.e. set is_block to true for
         // any block elements.
         bool is_block = rm == erm_final;
-        if (!BLOCK_RENDERING_G(ENHANCED) && !is_block) {
+        if (legacy_render && !is_block) {
             is_block = style->display >= css_d_block;
             if (is_block) {
                 // Hack for "legacy" rendering mode:
@@ -2647,7 +2635,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
         }
 
-        if ( (flags & LTEXT_FLAG_NEWLINE) && ( rm == erm_final || ( !BLOCK_RENDERING_G(ENHANCED) && is_block ) ) ) {
+        if ( (flags & LTEXT_FLAG_NEWLINE) && ( rm == erm_final || ( legacy_render && is_block ) ) ) {
             // Top and single 'final' node (unless in the degenerate case
             // of obsolete css_d_list_item_legacy):
             // Get text-indent and line-height that will apply to the full final block
@@ -3332,7 +3320,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 break;
             }
             // Among inline nodes, only <BR> can carry a "clear: left/right/both".
-            // (No need to check for BLOCK_RENDERING_G(FLOAT_FLOATBOXES), this
+            // (No need to check for BLOCK_RENDERING(rend_flags, FLOAT_FLOATBOXES), this
             // should have no effect when there is not a single float in the way)
             baseflags &= ~LTEXT_SRC_IS_CLEAR_BOTH; // clear previous one
             switch (style->clear) {
@@ -3442,7 +3430,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             } else {
             }
             */
-            if ( !BLOCK_RENDERING_G(ENHANCED) ) {
+            if ( legacy_render ) {
                 // Removal of leading spaces is now managed directly by lvtextfm
                 // but in legacy render mode we don't add lines with only spaces.
                 //int offs = 0;
@@ -3805,7 +3793,7 @@ int pagebreakhelper(ldomNode *enode,int width)
 
 // Prototypes of the 2 alternative block rendering recursive functions
 int  renderBlockElementLegacy(LVRendPageContext & context, ldomNode * enode, int x, int y, int width , int usable_right_overflow);
-void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int width, int flags );
+void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int width, lUInt32 flags );
 
 // Legacy/original CRE block rendering
 int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int usable_right_overflow )
@@ -6153,7 +6141,7 @@ int BlockFloatFootprint::getTopShiftX(int final_width, bool get_right_shift)
 }
 
 // Enhanced block rendering
-void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int container_width, int flags )
+void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int container_width, lUInt32 flags )
 {
     if (!enode)
         return;
@@ -7600,8 +7588,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 }
 
 // Entry points for rendering the root node, a table cell or a float
-int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
-            int usable_left_overflow, int usable_right_overflow, int direction, int * baseline, int rend_flags )
+int renderBlockElement(LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
+            int usable_left_overflow, int usable_right_overflow, int direction, int * baseline, lUInt32 rend_flags )
 {
     if ( BLOCK_RENDERING(rend_flags, ENHANCED) ) {
         // Create a flow state (aka "block formatting context") for the rendering
@@ -7631,10 +7619,8 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
             int usable_left_overflow, int usable_right_overflow, int direction, int * baseline )
 {
-    // Use global rendering flags
-    // Note: we're not currently using it with other flags that the global ones.
     return renderBlockElement( context, enode, x, y, width, usable_left_overflow, usable_right_overflow,
-                                        direction, baseline, gRenderBlockRenderingFlags );
+                                        direction, baseline, enode->getDocument()->getRenderBlockRenderingFlags() );
 }
 
 //draw border lines,support color,width,all styles, not support border-collapse
@@ -8336,6 +8322,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
         doc_x += fmt.getX();
         doc_y += fmt.getY();
         lvdom_element_render_method rm = enode->getRendMethod();
+        lUInt32 rend_flags = enode->getDocument()->getRenderBlockRenderingFlags();
         // A few things differ when done for TR, THEAD, TBODY and TFOOT
         // (erm_table_row_group, erm_table_header_group, erm_table_footer_group, erm_table_row)
         bool isTableRowLike = rm >= erm_table_row_group && rm <= erm_table_row;
@@ -8353,7 +8340,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
             if ( !isTableRowLike ) {
                 return; // out of range
             }
-            if ( BLOCK_RENDERING_G(ENHANCED) ) {
+            if ( BLOCK_RENDERING(rend_flags, ENHANCED) ) {
                 // But in enhanced mode, we have set bottom overflow on
                 // TR and table row groups, so we can trust them.
                 return; // out of range
@@ -8503,7 +8490,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     // first final children would start being drawn further because
                     // some outer floats are involved (as Calibre and Firefox do).
                     int shift_x = 0;
-                    if ( BLOCK_RENDERING_G(ENHANCED) ) {
+                    if ( BLOCK_RENDERING(rend_flags, ENHANCED) ) {
                         ldomNode * tmpnode = enode;
                         // Just look at each first descendant for a final child (we may find
                         // none and would have to look at next children, but well...)
@@ -9031,7 +9018,8 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->display = css_d_none;
     }
 
-    if ( BLOCK_RENDERING_G(PREPARE_FLOATBOXES) ) {
+    lUInt32 rend_flags = enode->getDocument()->getRenderBlockRenderingFlags();
+    if ( BLOCK_RENDERING(rend_flags, PREPARE_FLOATBOXES) ) {
         // https://developer.mozilla.org/en-US/docs/Web/CSS/float
         //  As float implies the use of the block layout, it modifies the computed value
         //  of the display values, in some cases: [...]
@@ -9052,7 +9040,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             }
         }
     }
-    if ( BLOCK_RENDERING_G(WRAP_FLOATS) ) {
+    if ( BLOCK_RENDERING(rend_flags, WRAP_FLOATS) ) {
         if ( nodeElementId == el_floatBox ) {
             // floatBox added, by initNodeRendMethod(), as a wrapper around
             // element with float:.
@@ -9098,7 +9086,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->float_ = css_f_none;
     }
 
-    if ( BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) ) {
+    if ( BLOCK_RENDERING(rend_flags, BOX_INLINE_BLOCKS) ) {
         // See above, same reasoning
         if ( nodeElementId == el_inlineBox ) {
             // el_inlineBox are "display: inline" by default (defined in fb2def.h)
@@ -9143,7 +9131,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         // node probably stayed with the default display: of the element when
         // no other lower specificity CSS set another).
         if ( pstyle->display == css_d_inline_block || pstyle->display == css_d_inline_table ) {
-            if ( !BLOCK_RENDERING_G(ENHANCED) && pstyle->display == css_d_inline_table ) {
+            if ( !BLOCK_RENDERING(rend_flags, ENHANCED) && pstyle->display == css_d_inline_table ) {
                 // In legacy mode, inline-table was handled like css_d_block (as all
                 // not specifically handled css_d_* are, so probably unwillingly).
                 pstyle->display = css_d_block;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8831,8 +8831,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     css_style_rec_t * pstyle = style.get();
 
     lUInt16 nodeElementId = enode->getNodeId();
+    lUInt32 domVersionRequested = enode->getDocument() ? enode->getDocument()->getDOMVersionRequested() : 0;
 
-    if (gDOMVersionRequested < 20180524) {
+    if (domVersionRequested < 20180524) {
         // The display property initial value has been changed from css_d_inherit
         // to css_d_inline (as per spec, and so that an unknown element does not
         // become block when contained in a P, and inline when contained in a SPAN)
@@ -8852,14 +8853,14 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->white_space = type_ptr->white_space;
 
         // Account for backward incompatible changes in fb2def.h
-        if (gDOMVersionRequested < 20200824) { // revert what was changed 20200824
+        if (domVersionRequested < 20200824) { // revert what was changed 20200824
             if (nodeElementId >= el_details && nodeElementId <= el_wbr) { // newly added block elements
                 pstyle->display = css_d_inline; // previously unknown and shown as inline
-                if (gDOMVersionRequested < 20180524) {
+                if (domVersionRequested < 20180524) {
                     pstyle->display = css_d_inherit; // previously unknown and display: inherit
                 }
             }
-            if (gDOMVersionRequested < 20180528) { // revert what was changed 20180528
+            if (domVersionRequested < 20180528) { // revert what was changed 20180528
                 if (nodeElementId == el_form) {
                     pstyle->display = css_d_none; // otherwise shown as block, as it may have textual content
                 }
@@ -8868,11 +8869,11 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                 }
                 if (nodeElementId >= el_address && nodeElementId <= el_xmp) { // newly added block elements
                     pstyle->display = css_d_inline; // previously unknown and shown as inline
-                    if (gDOMVersionRequested < 20180524) {
+                    if (domVersionRequested < 20180524) {
                         pstyle->display = css_d_inherit; // previously unknown and display: inherit
                     }
                 }
-                if (gDOMVersionRequested < 20180524) { // revert what was fixed 20180524
+                if (domVersionRequested < 20180524) { // revert what was fixed 20180524
                     if (nodeElementId == el_cite) {
                         pstyle->display = css_d_block; // otherwise correctly set to css_d_inline
                     }
@@ -8945,7 +8946,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             // We can't get the codeBase of this node anymore at this point, which
             // would be needed to resolve "background-image: url(...)" relative
             // file path... So these won't work when defined in a style= attribute.
-            if ( decl.parse( s ) ) {
+            if ( decl.parse( s, domVersionRequested ) ) {
                 decl.apply( pstyle );
             }
         }
@@ -9143,7 +9144,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     }
 
     // Avoid some new features when migration to normalized xpointers has not yet been done
-    if ( gDOMVersionRequested < DOM_VERSION_WITH_NORMALIZED_XPOINTERS ) {
+    if ( domVersionRequested < DOM_VERSION_WITH_NORMALIZED_XPOINTERS ) {
         // display: ruby may wrap the element content in many inlineBox/rubyBox.
         // Avoid that until migrated to normalized xpointers by handling
         // them as css_d_inline like before ruby support.
@@ -9191,7 +9192,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         //parent_style->text_align = css_ta_center;
     //}
 
-    if (gDOMVersionRequested < 20180524) { // display should not be inherited
+    if (domVersionRequested < 20180524) { // display should not be inherited
         UPDATE_STYLE_FIELD( display, css_d_inherit );
     }
     UPDATE_STYLE_FIELD( white_space, css_ws_inherit );

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1821,7 +1821,7 @@ enum cr_only_if_t {
     cr_only_if_fb2_document, // fb2 or fb3
 };
 
-bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDocBase * doc, lString16 codeBase )
+bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, bool higher_importance, lxmlDocBase * doc, lString16 codeBase )
 {
     if ( !decl )
         return false;
@@ -1854,7 +1854,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 {
                     int dom_version;
                     if ( parse_integer( decl, dom_version ) ) {
-                        if ( gDOMVersionRequested >= dom_version ) {
+                        if ( domVersionRequested >= dom_version ) {
                             return false; // ignore the whole declaration
                         }
                     }
@@ -1999,7 +1999,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 break;
             case cssd_display:
                 n = parse_name( decl, css_d_names, -1 );
-                if (gDOMVersionRequested < 20180524 && n == css_d_list_item_block) {
+                if (domVersionRequested < 20180524 && n == css_d_list_item_block) {
                     n = css_d_list_item_legacy; // legacy rendering of list-item
                 }
                 break;
@@ -4405,6 +4405,7 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString16 co
     LVCssSelector * prev_selector;
     int err_count = 0;
     int rule_count = 0;
+    lUInt32 domVersionRequested = (_doc != NULL) ? _doc->getDOMVersionRequested() : 0;
     for (;*str;)
     {
         // new rule
@@ -4435,7 +4436,7 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString16 co
             }
             // parse declaration
             LVCssDeclRef decl( new LVCssDeclaration );
-            if ( !decl->parse( str, higher_importance, _doc, codeBase ) )
+            if ( !decl->parse( str, domVersionRequested, higher_importance, _doc, codeBase ) )
             {
                 err = true;
                 err_count++;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1884,28 +1884,36 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                             match = invert;
                         }
                         else if ( name == cr_only_if_legacy ) {
-                            match = ((bool)BLOCK_RENDERING_G(ENHANCED)) == invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENHANCED)) == invert;
                         }
                         else if ( name == cr_only_if_enhanced ) {
-                            match = ((bool)BLOCK_RENDERING_G(ENHANCED)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENHANCED)) != invert;
                         }
                         else if ( name == cr_only_if_float_floatboxes ) {
-                            match = ((bool)BLOCK_RENDERING_G(FLOAT_FLOATBOXES)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES)) != invert;
                         }
                         else if ( name == cr_only_if_box_inlineboxes ) {
-                            match = ((bool)BLOCK_RENDERING_G(BOX_INLINE_BLOCKS)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), BOX_INLINE_BLOCKS)) != invert;
                         }
                         else if ( name == cr_only_if_ensure_style_width ) {
-                            match = ((bool)BLOCK_RENDERING_G(ENSURE_STYLE_WIDTH)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENSURE_STYLE_WIDTH)) != invert;
                         }
                         else if ( name == cr_only_if_ensure_style_height ) {
-                            match = ((bool)BLOCK_RENDERING_G(ENSURE_STYLE_HEIGHT)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENSURE_STYLE_HEIGHT)) != invert;
                         }
                         else if ( name == cr_only_if_allow_style_w_h_absolute_units ) {
-                            match = ((bool)BLOCK_RENDERING_G(ALLOW_STYLE_W_H_ABSOLUTE_UNITS)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ALLOW_STYLE_W_H_ABSOLUTE_UNITS)) != invert;
                         }
                         else if ( name == cr_only_if_full_featured ) {
-                            match = (gRenderBlockRenderingFlags == BLOCK_RENDERING_FULL_FEATURED) != invert;
+                            if (doc)
+                                match = (doc->getRenderBlockRenderingFlags() == BLOCK_RENDERING_FULL_FEATURED) != invert;
                         }
                         else if ( name == cr_only_if_epub_document ) {
                             // 'doc' is NULL when parsing elements style= attribute,

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4239,7 +4239,7 @@ public:
             LVRendPageContext context( NULL, m_pbuffer->page_height );
             // We don't know if the upper LVRendPageContext wants lines or not,
             // so assume it does (the main flow does).
-            int rend_flags = gRenderBlockRenderingFlags; // global flags
+            int rend_flags = node->getDocument()->getRenderBlockRenderingFlags();
             // We want to avoid negative margins (if allowed in global flags) and
             // going back the flow y, as the transfered lines would not reflect
             // that, and we could get some small mismatches and glitches.

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -391,7 +391,6 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
         hash = hash * 75 + 2384761;
     hash = hash * 31 + fontMan->GetFallbackFontFaces().getHash();
     hash = hash * 31 + gRenderDPI;
-    hash = hash * 31 + gRenderBlockRenderingFlags;
     hash = hash * 31 + gRootFontSize;
     hash = hash * 31 + gInterlineScaleFactor;
     // If not yet rendered (initial loading with XML parsing), we can
@@ -2017,6 +2016,7 @@ tinyNodeCollection::tinyNodeCollection()
 ,_docFlags(DOC_FLAG_DEFAULTS)
 ,_fontMap(113)
 ,_hangingPunctuationEnabled(false)
+,_renderBlockRenderingFlags(BLOCK_RENDERING_FLAGS_DEFAULT)
 {
     memset( _textList, 0, sizeof(_textList) );
     memset( _elemList, 0, sizeof(_elemList) );
@@ -2058,6 +2058,7 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 ,_stylesheet(v._stylesheet)
 ,_fontMap(113)
 ,_hangingPunctuationEnabled(v._hangingPunctuationEnabled)
+,_renderBlockRenderingFlags(v._renderBlockRenderingFlags)
 {
     memset( _textList, 0, sizeof(_textList) );
     memset( _elemList, 0, sizeof(_elemList) );
@@ -2067,6 +2068,21 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 bool tinyNodeCollection::setHangingPunctiationEnabled(bool value) {
     if (_hangingPunctuationEnabled != value) {
         _hangingPunctuationEnabled = value;
+        return true;
+    }
+    return false;
+}
+
+bool tinyNodeCollection::setRenderBlockRenderingFlags(lUInt32 flags) {
+    if (_renderBlockRenderingFlags != flags) {
+        _renderBlockRenderingFlags = flags;
+        // Check coherency and ensure dependencies of flags
+        if (_renderBlockRenderingFlags & ~BLOCK_RENDERING_ENHANCED) // If any other flag is set,
+            _renderBlockRenderingFlags |= BLOCK_RENDERING_ENHANCED; // set ENHANGED
+        if (_renderBlockRenderingFlags & BLOCK_RENDERING_FLOAT_FLOATBOXES)
+            _renderBlockRenderingFlags |= BLOCK_RENDERING_PREPARE_FLOATBOXES;
+        if (_renderBlockRenderingFlags & BLOCK_RENDERING_PREPARE_FLOATBOXES)
+            _renderBlockRenderingFlags |= BLOCK_RENDERING_WRAP_FLOATS;
         return true;
     }
     return false;
@@ -5071,9 +5087,9 @@ static bool isFloatingNode( ldomNode * node )
 
 static bool isNotBoxWrappingNode( ldomNode * node )
 {
-    if ( BLOCK_RENDERING_G(PREPARE_FLOATBOXES) && node->getStyle()->float_ > css_f_none )
+    if ( BLOCK_RENDERING(node->getDocument()->getRenderBlockRenderingFlags(), PREPARE_FLOATBOXES) && node->getStyle()->float_ > css_f_none )
         return false; // floatBox
-    // isBoxingInlineBox() already checks for BLOCK_RENDERING_G(BOX_INLINE_BLOCKS)
+    // isBoxingInlineBox() already checks for BLOCK_RENDERING(rend_flags, BOX_INLINE_BLOCKS)
     return !node->isBoxingInlineBox();
 }
 
@@ -5391,7 +5407,7 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex, bool handleFloatin
         // remove starting empty
         removeChildren(startIndex, firstNonEmpty-1);
         abox->initNodeStyle();
-        if ( !BLOCK_RENDERING_G(FLOAT_FLOATBOXES) ) {
+        if ( !BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES) ) {
             // If we don't want floatBoxes floating, reset them to be
             // rendered inline among inlines
             abox->recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
@@ -5457,7 +5473,7 @@ bool ldomNode::hasNonEmptyInlineContent( bool ignoreFloats )
     if ( getRendMethod() == erm_invisible ) {
         return false;
     }
-    if ( ignoreFloats && BLOCK_RENDERING_G(FLOAT_FLOATBOXES) && getStyle()->float_ > css_f_none ) {
+    if ( ignoreFloats && BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES) && getStyle()->float_ > css_f_none ) {
         return false;
     }
     // With some other bool param, we might want to also check for
@@ -5572,7 +5588,7 @@ ldomNode * ldomNode::boxWrapChildren( int startIndex, int endIndex, lUInt16 elem
 // init table element render methods
 // states: 0=table, 1=colgroup, 2=rowgroup, 3=row, 4=cell
 // returns table cell count
-// When BLOCK_RENDERING_G(COMPLETE_INCOMPLETE_TABLES), we follow rules
+// When BLOCK_RENDERING(rend_flags, COMPLETE_INCOMPLETE_TABLES), we follow rules
 // from the "Generate missing child wrappers" section in:
 //   https://www.w3.org/TR/CSS22/tables.html#anonymous-boxes
 //   https://www.w3.org/TR/css-tables-3/#fixup (clearer than previous one)
@@ -5725,7 +5741,8 @@ int initTableRendMethods( ldomNode * enode, int state )
         // Check and deal with unproper children
         if ( !is_proper ) { // Unproper child met
             // printf("initTableRendMethods(%d): child %d is unproper\n", state, i);
-            if ( BLOCK_RENDERING_G(COMPLETE_INCOMPLETE_TABLES) ) {
+            lUInt32 rend_flags = enode->getDocument()->getRenderBlockRenderingFlags();
+            if ( BLOCK_RENDERING(rend_flags, COMPLETE_INCOMPLETE_TABLES) ) {
                 // We can insert a tabularBox element to wrap unproper elements
                 last_unproper = i;
                 if (first_unproper < 0)
@@ -5734,7 +5751,7 @@ int initTableRendMethods( ldomNode * enode, int state )
             else {
                 // Asked to not complete incomplete tables, or we can't insert
                 // tabularBox elements anymore
-                if ( !BLOCK_RENDERING_G(ENHANCED) ) {
+                if ( !BLOCK_RENDERING(rend_flags, ENHANCED) ) {
                     // Legacy behaviour was to just make invisible internal-table
                     // elements that were not found in their proper internal-table
                     // container, but let other non-internal-table elements be
@@ -5822,10 +5839,10 @@ bool hasInvisibleParent( ldomNode * node )
 
 bool ldomNode::isFloatingBox() const
 {
-    // BLOCK_RENDERING_G(FLOAT_FLOATBOXES) is what triggers rendering
+    // BLOCK_RENDERING(rend_flags, FLOAT_FLOATBOXES) is what triggers rendering
     // the floats floating. They are wrapped in a floatBox, possibly
-    // not floating, when BLOCK_RENDERING_G(WRAP_FLOATS)).
-    if ( BLOCK_RENDERING_G(FLOAT_FLOATBOXES) && getNodeId() == el_floatBox
+    // not floating, when BLOCK_RENDERING(rend_flags, WRAP_FLOATS)).
+    if ( BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES) && getNodeId() == el_floatBox
                 && getStyle()->float_ > css_f_none)
         return true;
     return false;
@@ -5835,11 +5852,11 @@ bool ldomNode::isFloatingBox() const
 /// its child no more inline-block/inline-table
 bool ldomNode::isBoxingInlineBox() const
 {
-    // BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) is what ensures inline-block
+    // BLOCK_RENDERING(rend_flags, BOX_INLINE_BLOCKS) is what ensures inline-block
     // are boxed and rendered as an inline block, but we may have them
     // wrapping a node that is no more inline-block (when some style
     // tweaks have changed the display: property).
-    if ( getNodeId() == el_inlineBox && BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) ) {
+    if ( getNodeId() == el_inlineBox && BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), BOX_INLINE_BLOCKS) ) {
         if (getChildCount() == 1) {
             css_display_t d = getChildNode(0)->getStyle()->display;
             if (d == css_d_inline_block || d == css_d_inline_table) {
@@ -5863,7 +5880,7 @@ bool ldomNode::isBoxingInlineBox() const
 bool ldomNode::isEmbeddedBlockBoxingInlineBox(bool inline_box_checks_done) const
 {
     if ( !inline_box_checks_done ) {
-        if ( getNodeId() != el_inlineBox || !BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) )
+        if ( getNodeId() != el_inlineBox || !BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), BOX_INLINE_BLOCKS) )
             return false;
         if (getChildCount() != 1)
             return false;
@@ -5927,6 +5944,7 @@ void ldomNode::initNodeRendMethod()
     bool hasInternalTableItems = false;
 
     int d = getStyle()->display;
+    lUInt32 rend_flags = getDocument()->getRenderBlockRenderingFlags();
 
     if ( hasInvisibleParent(this) ) { // (should be named isInvisibleOrHasInvisibleParent())
         // Note: we could avoid that up-to-root-node walk for each node
@@ -5958,7 +5976,7 @@ void ldomNode::initNodeRendMethod()
         //   https://github.com/w3c/csswg-drafts/issues/1477
         //   https://stackoverflow.com/questions/1371307/displayblock-inside-displayinline
         //
-        if ( !BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) ) {
+        if ( !BLOCK_RENDERING(rend_flags, BOX_INLINE_BLOCKS) ) {
             // No support for anything but inline elements, and possibly embedded floats
             recurseMatchingElements( resetRendMethodToInline, isNotBoxWrappingNode );
         }
@@ -6088,7 +6106,7 @@ void ldomNode::initNodeRendMethod()
         // call initTableRendMethods(this, 1/2/3) so that the "Generate missing
         // child wrappers" step is done before the "Generate missing parents" step
         // we might be doing below - to conform to the order of steps in the specs.
-    } else if ( d==css_d_inline_table && ( BLOCK_RENDERING_G(COMPLETE_INCOMPLETE_TABLES) || getNodeId()==el_table ) ) {
+    } else if ( d==css_d_inline_table && ( BLOCK_RENDERING(rend_flags, COMPLETE_INCOMPLETE_TABLES) || getNodeId()==el_table ) ) {
         // Only if we're able to complete incomplete tables, or if this
         // node is itself a <TABLE>. Otherwise, fallback to the following
         // catch-all 'else' and render its content as block.
@@ -6130,7 +6148,7 @@ void ldomNode::initNodeRendMethod()
         //   avoid having autoBoxing elements that would mess with a correct
         //   floating rendering.
         // Note that FLOAT_FLOATBOXES requires having PREPARE_FLOATBOXES.
-        bool handleFloating = BLOCK_RENDERING_G(PREPARE_FLOATBOXES);
+        bool handleFloating = BLOCK_RENDERING(rend_flags, PREPARE_FLOATBOXES);
 
         detectChildTypes( this, hasBlockItems, hasInline, hasInternalTableItems, hasFloating, handleFloating );
         const css_elem_def_props_t * ntype = getElementTypePtr();
@@ -6171,7 +6189,7 @@ void ldomNode::initNodeRendMethod()
                     setRendMethod( erm_block );
                 }
                 else {
-                    if ( !BLOCK_RENDERING_G(FLOAT_FLOATBOXES) ) {
+                    if ( !BLOCK_RENDERING(rend_flags, FLOAT_FLOATBOXES) ) {
                         // If we don't want floatBoxes floating, reset them to be
                         // rendered inline among inlines
                         recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
@@ -6328,7 +6346,7 @@ void ldomNode::initNodeRendMethod()
         }
     }
 
-    if ( hasInternalTableItems && BLOCK_RENDERING_G(COMPLETE_INCOMPLETE_TABLES) && getRendMethod() == erm_block ) {
+    if ( hasInternalTableItems && BLOCK_RENDERING(rend_flags, COMPLETE_INCOMPLETE_TABLES) && getRendMethod() == erm_block ) {
         // We have only block items, whether the original ones or the
         // autoBoxing nodes we created to wrap inlines, and all empty
         // inlines have been removed.
@@ -6568,7 +6586,7 @@ void ldomNode::initNodeRendMethod()
         }
     }
 
-    if ( d == css_d_ruby && BLOCK_RENDERING_G(ENHANCED) ) {
+    if ( d == css_d_ruby && BLOCK_RENDERING(rend_flags, ENHANCED) ) {
         // Ruby input can be quite loose and have various tag strategies (mono/group,
         // interleaved/tabular, double sided). Moreover, the specs have evolved between
         // 2001 and 2020 (<rbc> tag no more mentionned in 2020; <rtc> being just another
@@ -6932,7 +6950,7 @@ void ldomNode::initNodeRendMethod()
     }
 
     bool handled_as_float = false;
-    if (BLOCK_RENDERING_G(WRAP_FLOATS)) {
+    if (BLOCK_RENDERING(rend_flags, WRAP_FLOATS)) {
         // While loading the document, we want to put any element with float:left/right
         // inside an internal floatBox element with no margin in its style: this
         // floatBox's RenderRectAccessor will have the position and width/height
@@ -7022,7 +7040,7 @@ void ldomNode::initNodeRendMethod()
                 
                 // If we have float:, this just-created floatBox should be erm_block,
                 // unless the child has been kept inline
-                if ( !BLOCK_RENDERING_G(PREPARE_FLOATBOXES) && getRendMethod() == erm_inline)
+                if ( !BLOCK_RENDERING(rend_flags, PREPARE_FLOATBOXES) && getRendMethod() == erm_inline)
                     fbox->setRendMethod( erm_inline );
                 else
                     fbox->setRendMethod( erm_block );
@@ -7071,7 +7089,7 @@ void ldomNode::initNodeRendMethod()
     }
 
     // (If a node is both inline-block and float: left/right, float wins.)
-    if (BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) && !handled_as_float) {
+    if (BLOCK_RENDERING(rend_flags, BOX_INLINE_BLOCKS) && !handled_as_float) {
         // (Similar to what we do above for floats, but simpler.)
         // While loading the document, we want to put any element with
         // display: inline-block or inline-table inside an internal inlineBox
@@ -14797,7 +14815,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
                         if (style.get()->white_space >= css_ws_pre_line)
                             _nodeDisplayStyleHash += 29;
                         // Also account for style->float_, as it should create/remove new floatBox
-                        // elements wrapping floats when toggling BLOCK_RENDERING_G(ENHANCED)
+                        // elements wrapping floats when toggling BLOCK_RENDERING(rend_flags, ENHANCED)
                         if (style.get()->float_ > css_f_none)
                             _nodeDisplayStyleHash += 123;
                     }
@@ -14834,6 +14852,8 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
     // We just need to _renderedBlockCache.clear() when it changes.
     //if ( gHangingPunctuationEnabled )
     // res = res * 75 + 1761;
+
+    res = res * 31 + _renderBlockRenderingFlags;
 
     res = (res * 31 + globalHash) * 31 + docFlags;
 //    CRLog::info("Calculated style hash = %08x", res);
@@ -16868,7 +16888,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
 
     RenderRectAccessor fmt( this );
 
-    if ( BLOCK_RENDERING_G(ENHANCED) ) {
+    if ( BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), ENHANCED) ) {
         // In enhanced rendering mode, because of collpasing of vertical margins
         // and the fact that we did not update style margins to their computed
         // values, a children box with margins can overlap its parent box, if

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -391,7 +391,6 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     hash = hash * 31 + fontMan->GetFallbackFontFaces().getHash();
     hash = hash * 31 + gRenderDPI;
     hash = hash * 31 + gRootFontSize;
-    hash = hash * 31 + gInterlineScaleFactor;
     // If not yet rendered (initial loading with XML parsing), we can
     // ignore some global flags that have not yet produced any effect,
     // so they can possibly be updated between loading and rendering
@@ -2036,6 +2035,7 @@ tinyNodeCollection::tinyNodeCollection()
 ,_fontMap(113)
 ,_hangingPunctuationEnabled(false)
 ,_renderBlockRenderingFlags(BLOCK_RENDERING_FLAGS_DEFAULT)
+,_interlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE)
 {
     memset( _textList, 0, sizeof(_textList) );
     memset( _elemList, 0, sizeof(_elemList) );
@@ -2078,6 +2078,7 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 ,_fontMap(113)
 ,_hangingPunctuationEnabled(v._hangingPunctuationEnabled)
 ,_renderBlockRenderingFlags(v._renderBlockRenderingFlags)
+,_interlineScaleFactor(v._interlineScaleFactor)
 {
     memset( _textList, 0, sizeof(_textList) );
     memset( _elemList, 0, sizeof(_elemList) );
@@ -2111,6 +2112,14 @@ bool tinyNodeCollection::setDOMVersionRequested(lUInt32 version)
 {
     if (_DOMVersionRequested != version) {
         _DOMVersionRequested = version;
+        return true;
+    }
+    return false;
+}
+
+bool tinyNodeCollection::setInterlineScaleFactor(int value) {
+    if (_interlineScaleFactor != value) {
+        _interlineScaleFactor = value;
         return true;
     }
     return false;
@@ -14882,6 +14891,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
     // res = res * 75 + 1761;
 
     res = res * 31 + _renderBlockRenderingFlags;
+    res = res * 31 + _interlineScaleFactor;
 
     res = (res * 31 + globalHash) * 31 + docFlags;
 //    CRLog::info("Calculated style hash = %08x", res);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -82,7 +82,6 @@
 // to be (only a little bit) more HTML5 conformant
 
 extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
-int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
@@ -483,10 +482,10 @@ struct SimpleCacheFileHeader
     char _magic[CACHE_FILE_MAGIC_SIZE] = { 0 }; // magic
     lUInt32 _dirty;
     lUInt32 _dom_version;
-    SimpleCacheFileHeader( lUInt32 dirtyFlag ) {
+    SimpleCacheFileHeader( lUInt32 dirtyFlag, lUInt32 domVersion ) {
         memcpy( _magic, _compressCachedData ? COMPRESSED_CACHE_FILE_MAGIC : UNCOMPRESSED_CACHE_FILE_MAGIC, CACHE_FILE_MAGIC_SIZE );
         _dirty = dirtyFlag;
-        _dom_version = gDOMVersionRequested;
+        _dom_version = domVersion;
     }
 };
 
@@ -495,7 +494,7 @@ struct CacheFileHeader : public SimpleCacheFileHeader
     lUInt32 _fsize;
     CacheFileItem _indexBlock; // index array block parameters,
     // duplicate of one of index records which contains
-    bool validate()
+    bool validate(lUInt32 domVersionRequested)
     {
         if (memcmp(_magic, _compressCachedData ? COMPRESSED_CACHE_FILE_MAGIC : UNCOMPRESSED_CACHE_FILE_MAGIC, CACHE_FILE_MAGIC_SIZE) != 0) {
             CRLog::error("CacheFileHeader::validate: magic doesn't match");
@@ -506,15 +505,15 @@ struct CacheFileHeader : public SimpleCacheFileHeader
             printf("CRE: ignoring cache file (marked as dirty)\n");
             return false;
         }
-        if ( _dom_version != gDOMVersionRequested ) {
+        if ( _dom_version != domVersionRequested ) {
             CRLog::error("CacheFileHeader::validate: DOM version mismatch");
             printf("CRE: ignoring cache file (dom version mismatch)\n");
             return false;
         }
         return true;
     }
-    CacheFileHeader( CacheFileItem * indexRec, int fsize, lUInt32 dirtyFlag )
-    : SimpleCacheFileHeader(dirtyFlag), _indexBlock(0,0)
+    CacheFileHeader( CacheFileItem * indexRec, int fsize, lUInt32 dirtyFlag, lUInt32 domVersion )
+    : SimpleCacheFileHeader(dirtyFlag, domVersion), _indexBlock(0,0)
     {
         if ( indexRec ) {
             memcpy( &_indexBlock, indexRec, sizeof(CacheFileItem));
@@ -533,6 +532,7 @@ class CacheFile
     int _size;
     bool _indexChanged;
     bool _dirty;
+    lUInt32 _domVersion;
     lString16 _cachePath;
     LVStreamRef _stream; // file stream
     LVPtrVector<CacheFileItem, true> _index; // full file block index
@@ -556,7 +556,7 @@ public:
     // return current file size
     int getSize() { return _size; }
     // create uninitialized cache file, call open or create to initialize
-    CacheFile();
+    CacheFile(lUInt32 domVersion);
     // free resources
     ~CacheFile();
     // try open existing cache file
@@ -592,6 +592,8 @@ public:
 
     /// sets dirty flag value, returns true if value is changed
     bool setDirtyFlag( bool dirty );
+    /// sets DOM version value, returns true if value is changed
+    bool setDOMVersion( lUInt32 domVersion );
     // flushes index
     bool flush( bool clearDirtyFlag, CRTimerUtil & maxTime );
     int roundSector( int n )
@@ -611,8 +613,8 @@ public:
 
 
 // create uninitialized cache file, call open or create to initialize
-CacheFile::CacheFile()
-: _sectorSize( CACHE_FILE_SECTOR_SIZE ), _size(0), _indexChanged(false), _dirty(true), _map(1024), _cachePath(lString16::empty_str)
+CacheFile::CacheFile(lUInt32 domVersion)
+: _sectorSize( CACHE_FILE_SECTOR_SIZE ), _size(0), _indexChanged(false), _dirty(true), _domVersion(domVersion), _map(1024), _cachePath(lString16::empty_str)
 {
 }
 
@@ -638,7 +640,7 @@ bool CacheFile::setDirtyFlag( bool dirty )
         CRLog::info("CacheFile::setting Dirty flag");
     }
     _dirty = dirty;
-    SimpleCacheFileHeader hdr(_dirty?1:0);
+    SimpleCacheFileHeader hdr(_dirty?1:0, _domVersion);
     _stream->SetPos(0);
     lvsize_t bytesWritten = 0;
     _stream->Write(&hdr, sizeof(hdr), &bytesWritten );
@@ -646,6 +648,22 @@ bool CacheFile::setDirtyFlag( bool dirty )
         return false;
     _stream->Flush(true);
     //CRLog::trace("setDirtyFlag : hdr is saved with Dirty flag = %d", hdr._dirty);
+    return true;
+}
+
+bool CacheFile::setDOMVersion( lUInt32 domVersion ) {
+    if ( _domVersion == domVersion )
+        return false;
+    CRLog::info("CacheFile::setting DOM version value");
+    _domVersion = domVersion;
+    SimpleCacheFileHeader hdr(_dirty?1:0, _domVersion);
+    _stream->SetPos(0);
+    lvsize_t bytesWritten = 0;
+    _stream->Write(&hdr, sizeof(hdr), &bytesWritten );
+    if ( bytesWritten!=sizeof(hdr) )
+        return false;
+    _stream->Flush(true);
+    //CRLog::trace("setDOMVersion : hdr is saved with DOM version = %u", hdr._domVersionRequested);
     return true;
 }
 
@@ -684,14 +702,15 @@ bool CacheFile::validateContents()
 // reads index from file
 bool CacheFile::readIndex()
 {
-    CacheFileHeader hdr(NULL, _size, 0);
+    CacheFileHeader hdr(NULL, _size, 0, 0);
     _stream->SetPos(0);
     lvsize_t bytesRead = 0;
     _stream->Read(&hdr, sizeof(hdr), &bytesRead );
     if ( bytesRead!=sizeof(hdr) )
         return false;
     CRLog::info("Header read: DirtyFlag=%d", hdr._dirty);
-    if ( !hdr.validate() )
+    CRLog::info("Header read: DOM level=%u", hdr._dom_version);
+    if ( !hdr.validate(_domVersion) )
         return false;
     if ( (int)hdr._fsize > _size + 4096-1 ) {
         CRLog::error("CacheFile::readIndex: file size doesn't match with header");
@@ -799,7 +818,7 @@ bool CacheFile::updateHeader()
 {
     CacheFileItem * indexItem = NULL;
     indexItem = findBlock(CBT_INDEX, 0);
-    CacheFileHeader hdr(indexItem, _size, _dirty?1:0);
+    CacheFileHeader hdr(indexItem, _size, _dirty?1:0, _domVersion);
     _stream->SetPos(0);
     lvsize_t bytesWritten = 0;
     _stream->Write(&hdr, sizeof(hdr), &bytesWritten );
@@ -2088,12 +2107,21 @@ bool tinyNodeCollection::setRenderBlockRenderingFlags(lUInt32 flags) {
     return false;
 }
 
+bool tinyNodeCollection::setDOMVersionRequested(lUInt32 version)
+{
+    if (_DOMVersionRequested != version) {
+        _DOMVersionRequested = version;
+        return true;
+    }
+    return false;
+}
+
 #if BUILD_LITE!=1
 bool tinyNodeCollection::openCacheFile()
 {
     if ( _cacheFile )
         return true;
-    CacheFile * f = new CacheFile();
+    CacheFile * f = new CacheFile(_DOMVersionRequested);
     //lString16 cacheFileName("/tmp/cr3swap.tmp");
 
     lString16 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "noname" );
@@ -2143,7 +2171,7 @@ bool tinyNodeCollection::createCacheFile()
 {
     if ( _cacheFile )
         return true;
-    CacheFile * f = new CacheFile();
+    CacheFile * f = new CacheFile(_DOMVersionRequested);
     //lString16 cacheFileName("/tmp/cr3swap.tmp");
 
     lString16 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "noname" );
@@ -5021,7 +5049,7 @@ ldomElementWriter::ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUIn
     // Default (for elements not specified in fb2def.h) is to allow text
     // (except for the root node which must have children)
     _allowText = _typeDef ? _typeDef->allow_text : (_parent?true:false);
-    if (gDOMVersionRequested < 20180528) { // revert what was changed 20180528
+    if (_document->getDOMVersionRequested() < 20180528) { // revert what was changed 20180528
         // <hr>, <ul>, <ol>, <dl>, <output>, <section>, <svg> didn't allow text
         if ( id==el_hr || id==el_ul || id==el_ol || id==el_dl ||
                 id==el_output || id==el_section || id==el_svg ) {
@@ -5260,7 +5288,7 @@ static void resetRendMethodToInline( ldomNode * node )
     // hide other nodes)
     if (node->getStyle()->display != css_d_none)
         node->setRendMethod(erm_inline);
-    else if (gDOMVersionRequested < 20180528) // do that in all cases
+    else if (node->getDocument()->getDOMVersionRequested() < 20180528) // do that in all cases
         node->setRendMethod(erm_inline);
 }
 
@@ -8471,16 +8499,17 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
         //CRLog::trace("ldomXPointer::getRect() - p==NULL");
         return false;
     }
+    ldomDocument* doc = p->getDocument();
     //printf("getRect( p=%08X type=%d )\n", (unsigned)p, (int)p->getNodeType() );
-    else if ( !p->getDocument() ) {
+    if ( !doc ) {
         //CRLog::trace("ldomXPointer::getRect() - p->getDocument()==NULL");
         return false;
     }
-    ldomNode * mainNode = p->getDocument()->getRootNode();
+    ldomNode * mainNode = doc->getRootNode();
     for ( ; p; p = p->getParentNode() ) {
         int rm = p->getRendMethod();
         if ( rm == erm_final ) {
-            if ( gDOMVersionRequested < 20180524 && p->getStyle()->display == css_d_list_item_legacy ) {
+            if ( doc->getDOMVersionRequested() < 20180524 && p->getStyle()->display == css_d_list_item_legacy ) {
                 // This legacy rendering of list item is now erm_final, but
                 // can contain other real erm_final nodes.
                 // So, if we found an erm_final, and if we find this erm_final
@@ -13580,7 +13609,7 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
     // Fixed 20180503: this was done previously in any case, but now only
     // if _libRuDocumentDetected. We still allow the old behaviour if
     // requested to keep previously recorded XPATHs valid.
-    if ( _libRuDocumentDetected || gDOMVersionRequested < 20180503) {
+    if ( _libRuDocumentDetected || _document->getDOMVersionRequested() < 20180503) {
         // Patch for bad LIB.RU books - BR delimited paragraphs
         // in "Fine HTML" format, that appears as:
         //   <br>&nbsp; &nbsp; &nbsp; Viento fuerte, 1950
@@ -13632,7 +13661,7 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
 
     bool tag_accepted = true;
     bool insert_before_last_child = false;
-    if (gDOMVersionRequested >= 20200824) { // A little bit more HTML5 conformance
+    if (_document->getDOMVersionRequested() >= 20200824) { // A little bit more HTML5 conformance
         if ( id == el_image )
             id = el_img;
         if ( tagname && tagname[0] == '?' ) {
@@ -13692,7 +13721,7 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
         _curFosteredNode = _currNode;
     }
 
-    if (gDOMVersionRequested >= 20200824 && id == el_p) {
+    if (_document->getDOMVersionRequested() >= 20200824 && id == el_p) {
         // To avoid checking DOM ancestors with the numerous tags that close a P
         _lastP = _currNode;
     }
@@ -13923,7 +13952,7 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
         }
     }
 
-    if (gDOMVersionRequested >= 20200824) { // A little bit more HTML5 conformance
+    if (_document->getDOMVersionRequested() >= 20200824) { // A little bit more HTML5 conformance
         if ( _curNodeIsSelfClosing ) { // Internal call (not from XMLParser)
             _currNode = pop( _currNode, id );
             _curNodeIsSelfClosing = false;
@@ -13969,7 +13998,7 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
         return;
     }
 
-    if (gDOMVersionRequested >= 20200824) { // A little bit more HTML5 conformance
+    if (_document->getDOMVersionRequested() >= 20200824) { // A little bit more HTML5 conformance
         // We can get text before any node (it should then have <html><body> emited before it),
         // but we might get spaces between " <html> <head> <title>The title <br>The content".
         // Try to handle that correctly.
@@ -13990,14 +14019,14 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
     if (_currNode)
     {
         lUInt16 curNodeId = _currNode->getElement()->getNodeId();
-        if (gDOMVersionRequested < 20200824) {
+        if (_document->getDOMVersionRequested() < 20200824) {
             AutoClose( curNodeId, false );
         }
         if ( (_flags & XML_FLAG_NO_SPACE_TEXT)
              && IsEmptySpace(text, len) && !(flags & TXTFLG_PRE))
              return;
         bool insert_before_last_child = false;
-        if (gDOMVersionRequested >= 20200824) {
+        if (_document->getDOMVersionRequested() >= 20200824) {
             // If we're inserting text while in table sub-elements that
             // don't accept text, have it foster parented
             if ( curNodeId >= el_table && curNodeId <= el_tr && curNodeId != el_caption ) {
@@ -14112,7 +14141,7 @@ ldomDocumentWriterFilter::ldomDocumentWriterFilter(ldomDocument * document, bool
 , _curFosteredNode(NULL)
 , _lastP(NULL)
 {
-    if (gDOMVersionRequested >= 20200824) {
+    if (_document->getDOMVersionRequested() >= 20200824) {
         // We're not using the provided rules, but hardcoded ones in AutoOpenClosePop()
         return;
     }
@@ -14139,8 +14168,7 @@ ldomDocumentWriterFilter::ldomDocumentWriterFilter(ldomDocument * document, bool
 
 ldomDocumentWriterFilter::~ldomDocumentWriterFilter()
 {
-
-    if (gDOMVersionRequested >= 20200824) {
+    if (_document->getDOMVersionRequested() >= 20200824) {
         return;
     }
     for ( int i=0; i<MAX_ELEMENT_TYPE_ID; i++ ) {


### PR DESCRIPTION
Refactoring some globals variable in lvrend.h
* The "gHangingPunctuationEnabled" global variable has been transformed to the "_hangingPunctuationEnabled" property in the "tinyNodeCollection" class.
* The "gRenderBlockRenderingFlags" global variable has been transformed to the "_renderBlockRenderingFlags" property in the "tinyNodeCollection" class.
* The "gDOMVersionRequested" global variable has been transformed to the "_DOMVersionRequested" property in the "tinyNodeCollection" class.
* The "gInterlineScaleFactor" global variable has been transformed to the "_interlineScaleFactor" property in the "tinyNodeCollection" class.

Desktop/Qt build use at least two document instances. The second document is used as a preview in the settings dialog. So, if we use these globals (more related to gHangingPunctuationEnabled) and apply changes to this document when using the preview, then we prevent the changes from being applied to the main document, since the value of these global variables is checked when the changes are applied.
Also, in the Android build in the future, a preview may appear in the settings dialog :)