### PR TITLE
Indents in bookinfo form & fix for Google Drive Sync

### DIFF
--- a/android/res/layout/book_info_edit_dialog.xml
+++ b/android/res/layout/book_info_edit_dialog.xml
@@ -1,249 +1,309 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_marginRight="?android:attr/scrollbarSize"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:stretchColumns="*" >
- 
-	<LinearLayout
-	  android:orientation="vertical"
-	  android:layout_width="fill_parent"
-	  android:layout_height="wrap_content">
 
-	    <!-- Dummy item to prevent AutoCompleteTextView from receiving focus -->
-	    <LinearLayout
-	    	android:id="@+id/linearLayout_focus"
-	    	android:focusable="true"
-	    	android:focusableInTouchMode="true"
-	    	android:layout_width="0px"
-	    	android:layout_height="0px"
-			android:orientation="horizontal" />
-	    <LinearLayout 
-	        android:id="@+id/base_dlg_button_panel"
-            android:orientation="horizontal"
-	        android:layout_width="fill_parent"
-	        android:layout_height="wrap_content"
-	        android:minHeight="?android:attr/listPreferredItemHeight"
-	        android:gravity="center_vertical"
-	        android:background="?attr/tabbarBackground"
-	        >
-	        <ImageButton android:id="@+id/base_dlg_btn_back"
-	            android:layout_width="wrap_content"
-	            android:layout_height="wrap_content"
-	            android:layout_centerVertical="true"
-                android:minWidth="?android:attr/listPreferredItemHeight"
-	            android:src="?attr/cr3_button_prev_drawable"
-	            android:focusable="false"
-	            android:focusableInTouchMode="false"
-	            android:background="@null"
-	            android:contentDescription="@string/dlg_button_back"/>
-            <ImageButton android:id="@+id/btn_open_book"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+    <LinearLayout
+            android:id="@+id/base_dlg_button_panel"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/tabbarBackground"
+            android:gravity="center_vertical"
+            android:minHeight="?android:attr/listPreferredItemHeight"
+            android:orientation="horizontal">
+
+        <ImageButton
+                android:id="@+id/base_dlg_btn_back"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
+                android:background="@null"
+                android:contentDescription="@string/dlg_button_back"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:minWidth="?android:attr/listPreferredItemHeight"
+                android:src="?attr/cr3_button_prev_drawable" />
+
+        <ImageButton
+                android:id="@+id/btn_open_book"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
-                android:minWidth="?android:attr/listPreferredItemHeight"
-                android:src="?attr/cr3_button_book_open_drawable"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
-                android:background="@null"
-	            android:contentDescription="@string/dlg_button_open_book"/>
-            <ImageButton android:id="@+id/book_folder_open"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
-                android:minWidth="?android:attr/listPreferredItemHeight"
-                android:src="?attr/cr3_button_folder_go_drawable"
+                android:background="@null"
+                android:contentDescription="@string/dlg_button_open_book"
                 android:focusable="false"
                 android:focusableInTouchMode="false"
-                android:background="@null"
-	            android:contentDescription="@string/dlg_button_open_folder"/>
-            <ImageButton android:id="@+id/book_recent_delete"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerVertical="true"
-                android:gravity="right"
                 android:minWidth="?android:attr/listPreferredItemHeight"
-                android:src="@drawable/cr3_button_recent_book_delete"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
-                android:background="@null"
-	            android:contentDescription="@string/dlg_button_recent_delete"/>
-            <ImageButton android:id="@+id/book_delete"
-	            android:layout_width="wrap_content"
-	            android:layout_height="wrap_content"
-	            android:layout_centerVertical="true"
-                android:gravity="right"
-                android:minWidth="?android:attr/listPreferredItemHeight"
-	            android:src="@drawable/cr3_button_book_delete"
-	            android:focusable="false"
-	            android:focusableInTouchMode="false"
-	            android:background="@null"
-	            android:contentDescription="@string/dlg_button_book_delete"/>
-	    </LinearLayout>
-        <LinearLayout 
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            >
-            <LinearLayout 
-                android:orientation="vertical"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="2dip"
-                android:gravity="center_vertical"
-                >
-      	        <ImageView android:id="@+id/book_cover"
-		            android:layout_width="wrap_content"
-		            android:layout_height="wrap_content"
-		            android:layout_gravity="center_vertical|center_horizontal"
-		            android:padding="3dip"
-		            android:scaleType="fitCenter"
-		            android:minHeight="120dip"
-	                android:minWidth="100dip"
-	                android:maxHeight="200dip"
-	                android:maxWidth="150dip"
-	                android:drawable="?attr/cr3_browser_book_drawable"
-		            />
-                <ImageView android:id="@+id/book_progress"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="3dip"
-                    android:padding="3dip"
-                    android:scaleType="fitCenter"
-                    android:minHeight="15dip"
-                    android:minWidth="100dip"
-                    android:maxHeight="15dip"
-                    android:maxWidth="150dip"
-                    />
-      	    </LinearLayout>
-	        <LinearLayout 
-	            android:orientation="vertical"
-	            android:layout_width="fill_parent"
-	            android:layout_height="wrap_content"
-                android:layout_marginLeft="2dip"
-	            android:gravity="center_vertical"
-	            >
-	            <RadioGroup android:id="@+id/book_state"
-	                android:layout_width="match_parent"
-	                android:layout_height="wrap_content" >
-        	        <RadioButton android:id="@+id/book_state_new" android:text="@string/book_state_none" android:layout_width="match_parent" android:layout_height="wrap_content"/>
-                    <RadioButton android:id="@+id/book_state_toread" android:text="@string/book_state_toread" android:layout_width="match_parent" android:layout_height="wrap_content"/>
-                    <RadioButton android:id="@+id/book_state_reading" android:text="@string/book_state_reading" android:layout_width="match_parent" android:layout_height="wrap_content"/>
-                    <RadioButton android:id="@+id/book_state_finished" android:text="@string/book_state_finished" android:layout_width="match_parent" android:layout_height="wrap_content"/>
-                </RadioGroup>
-		    </LinearLayout>
-	        	        
-   	    </LinearLayout>
-        <TextView 
-            style="@style/TextAppearance.Medium"
-            android:singleLine="true"
-            android:text="@string/book_info_rating" 
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-        <RatingBar
-            android:id="@+id/book_rating"
-            android:isIndicator="false"
-            android:numStars="5"
-            android:stepSize="1"
-            android:rating="3"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-	    <TextView 
-		    android:id="@+id/lbl_book_title"
-		    style="@style/TextAppearance.Medium"
-		    android:singleLine="true"
-		    android:text="@string/book_info_book_title" 
-		    android:layout_width="wrap_content"
-		    android:layout_height="wrap_content"/>
-		<EditText 
-		    android:id="@+id/book_title" 
-		    android:layout_width="fill_parent" 
-		    android:layout_height="wrap_content"
-		    android:text="Book title" 
-		    style="@style/TextAppearance.Widget.EditText"
-	        android:editable="true" 
-	        android:singleLine="true"
-		/>
-	
-	    <TextView 
-	        android:id="@+id/lbl_book_author"
-	        style="@style/TextAppearance.Medium"
-	        android:singleLine="true"
-	        android:text="@string/book_info_book_authors" 
-	        android:layout_width="wrap_content"
-	        android:layout_height="wrap_content"/>
-        <LinearLayout 
-            android:id="@+id/book_authors_list" 
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            >
-		   <EditText 
-		        android:layout_width="fill_parent" 
-		        android:layout_height="wrap_content"
-		        android:text="Book title" 
-		        style="@style/TextAppearance.Widget.EditText"
-		        android:editable="true" 
-		        android:singleLine="true"
-		    />
-	   </LinearLayout>
-		
-	    <TableLayout 
-	        android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-	        <TableRow >
-			   	<TextView 
-			        android:id="@+id/lbl_book_series_name"
-			        style="@style/TextAppearance.Medium"
-			        android:singleLine="true"
-			        android:text="@string/book_info_book_series_name" 
-                    android:layout_weight="3"
-			        android:layout_width="wrap_content"
-			        android:layout_height="wrap_content"/>
-                <TextView 
-                    android:id="@+id/lbl_book_series_number"
-                    style="@style/TextAppearance.Medium"
-                    android:singleLine="true"
-                    android:text="#" 
-                    android:layout_weight="1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
-		    </TableRow>
-            <TableRow >
-                <EditText 
-                    android:id="@+id/book_series_name" 
-                    android:layout_width="fill_parent" 
-                    android:layout_height="wrap_content"
-                    android:layout_weight="3"
-                    android:text="Series" 
-                    style="@style/TextAppearance.Widget.EditText"
-                    android:editable="true" 
-                    android:singleLine="true"
-                />
-                <EditText 
-			        android:id="@+id/book_series_number" 
-			        android:layout_width="fill_parent" 
-			        android:layout_height="wrap_content"
-                    android:layout_weight="1"
-			        android:text="10" 
-			        style="@style/TextAppearance.Widget.EditText"
-			        android:editable="true" 
-			        android:singleLine="true"
-			    />
-			</TableRow>
-	    </TableLayout>
+                android:src="?attr/cr3_button_book_open_drawable" />
 
-		<EditText
-				android:id="@+id/book_description"
-				style="@style/TextAppearance.Widget.EditText"
-				android:layout_width="match_parent"
-				android:layout_height="wrap_content"
-				android:editable="false"
-				android:inputType="none"
-				android:singleLine="false" />
-	</LinearLayout>
-</ScrollView>
+        <ImageButton
+                android:id="@+id/book_folder_open"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:background="@null"
+                android:contentDescription="@string/dlg_button_open_folder"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:minWidth="?android:attr/listPreferredItemHeight"
+                android:src="?attr/cr3_button_folder_go_drawable" />
+
+        <ImageButton
+                android:id="@+id/book_recent_delete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:background="@null"
+                android:contentDescription="@string/dlg_button_recent_delete"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:gravity="right"
+                android:minWidth="?android:attr/listPreferredItemHeight"
+                android:src="@drawable/cr3_button_recent_book_delete" />
+
+        <ImageButton
+                android:id="@+id/book_delete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:background="@null"
+                android:contentDescription="@string/dlg_button_book_delete"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:gravity="right"
+                android:minWidth="?android:attr/listPreferredItemHeight"
+                android:src="@drawable/cr3_button_book_delete" />
+    </LinearLayout>
+
+    <ScrollView
+			android:id="@+id/book_scrollview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="?android:attr/scrollbarSize"
+            android:layout_marginRight="?android:attr/scrollbarSize"
+            android:stretchColumns="*">
+
+        <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="4dp"
+                android:layout_marginStart="4dp"
+                android:orientation="vertical">
+
+            <!-- Dummy item to prevent AutoCompleteTextView from receiving focus -->
+            <LinearLayout
+                    android:id="@+id/linearLayout_focus"
+                    android:layout_width="0px"
+                    android:layout_height="0px"
+                    android:focusable="true"
+                    android:focusableInTouchMode="true"
+                    android:orientation="horizontal" />
+
+            <LinearLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="2dip"
+                        android:gravity="center_vertical"
+                        android:orientation="vertical">
+
+                    <ImageView
+                            android:id="@+id/book_cover"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical|center_horizontal"
+                            android:drawable="?attr/cr3_browser_book_drawable"
+                            android:maxWidth="150dip"
+                            android:maxHeight="200dip"
+                            android:minWidth="100dip"
+                            android:minHeight="120dip"
+                            android:padding="3dip"
+                            android:scaleType="fitCenter" />
+
+                    <ImageView
+                            android:id="@+id/book_progress"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="bottom|center_horizontal"
+                            android:layout_marginTop="3dip"
+                            android:maxWidth="150dip"
+                            android:maxHeight="15dip"
+                            android:minWidth="100dip"
+                            android:minHeight="15dip"
+                            android:padding="3dip"
+                            android:scaleType="fitCenter" />
+                </LinearLayout>
+
+                <LinearLayout
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="2dip"
+                        android:gravity="center_vertical"
+                        android:orientation="vertical">
+
+                    <RadioGroup
+                            android:id="@+id/book_state"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
+
+                        <RadioButton
+                                android:id="@+id/book_state_new"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/book_state_none" />
+
+                        <RadioButton
+                                android:id="@+id/book_state_toread"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/book_state_toread" />
+
+                        <RadioButton
+                                android:id="@+id/book_state_reading"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/book_state_reading" />
+
+                        <RadioButton
+                                android:id="@+id/book_state_finished"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/book_state_finished" />
+                    </RadioGroup>
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <TextView
+                    style="@style/TextAppearance.Medium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginStart="4dp"
+                    android:singleLine="true"
+                    android:text="@string/book_info_rating" />
+
+            <RatingBar
+                    android:id="@+id/book_rating"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:isIndicator="false"
+                    android:numStars="5"
+                    android:rating="3"
+                    android:stepSize="1" />
+
+            <TextView
+                    android:id="@+id/lbl_book_title"
+                    style="@style/TextAppearance.Medium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginStart="4dp"
+                    android:singleLine="true"
+                    android:text="@string/book_info_book_title" />
+
+            <EditText
+                    android:id="@+id/book_title"
+                    style="@style/TextAppearance.Widget.EditText"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:editable="true"
+                    android:singleLine="true"
+                    android:text="Book title" />
+
+            <TextView
+                    android:id="@+id/lbl_book_author"
+                    style="@style/TextAppearance.Medium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginStart="4dp"
+                    android:singleLine="true"
+                    android:text="@string/book_info_book_authors" />
+
+            <LinearLayout
+                    android:id="@+id/book_authors_list"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="vertical">
+
+                <EditText
+                        style="@style/TextAppearance.Widget.EditText"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:editable="true"
+                        android:singleLine="true"
+                        android:text="Book title" />
+            </LinearLayout>
+
+            <TableLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content">
+
+                <TableRow>
+
+                    <TextView
+                            android:id="@+id/lbl_book_series_name"
+                            style="@style/TextAppearance.Medium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="4dp"
+                            android:layout_marginStart="4dp"
+                            android:layout_weight="3"
+                            android:singleLine="true"
+                            android:text="@string/book_info_book_series_name" />
+
+                    <TextView
+                            android:id="@+id/lbl_book_series_number"
+                            style="@style/TextAppearance.Medium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:singleLine="true"
+                            android:text="#" />
+                </TableRow>
+
+                <TableRow>
+
+                    <EditText
+                            android:id="@+id/book_series_name"
+                            style="@style/TextAppearance.Widget.EditText"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="3"
+                            android:editable="true"
+                            android:singleLine="true"
+                            android:text="Series" />
+
+                    <EditText
+                            android:id="@+id/book_series_number"
+                            style="@style/TextAppearance.Widget.EditText"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:editable="true"
+                            android:singleLine="true"
+                            android:text="10" />
+                </TableRow>
+            </TableLayout>
+
+            <EditText
+                    android:id="@+id/book_description"
+                    style="@style/TextAppearance.Widget.EditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:editable="false"
+                    android:inputType="none"
+                    android:singleLine="false" />
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/android/src/org/coolreader/crengine/BookInfoEditDialog.java
+++ b/android/src/org/coolreader/crengine/BookInfoEditDialog.java
@@ -225,7 +225,8 @@ public class BookInfoEditDialog extends BaseDialog {
 		}
 	}
 
-    ScrollView scrollView;
+    LinearLayout mainView;
+	ScrollView scrollView;
     EditText edTitle;
     EditText edSeriesName;
     EditText edSeriesNumber;
@@ -239,30 +240,31 @@ public class BookInfoEditDialog extends BaseDialog {
 
         mInflater = LayoutInflater.from(getContext());
         FileInfo file = mBookInfo.getFileInfo();
-        scrollView = (ScrollView)mInflater.inflate(R.layout.book_info_edit_dialog, null);
+        mainView = (LinearLayout) mInflater.inflate(R.layout.book_info_edit_dialog, null);
 
-        ImageButton btnBack = scrollView.findViewById(R.id.base_dlg_btn_back);
+        ImageButton btnBack = mainView.findViewById(R.id.base_dlg_btn_back);
         btnBack.setOnClickListener(v -> onNegativeButtonClick());
-        ImageButton btnOpenBook = scrollView.findViewById(R.id.btn_open_book);
+        ImageButton btnOpenBook = mainView.findViewById(R.id.btn_open_book);
         btnOpenBook.setOnClickListener(v -> onPositiveButtonClick());
-        ImageButton btnDeleteBook = scrollView.findViewById(R.id.book_delete);
+        ImageButton btnDeleteBook = mainView.findViewById(R.id.book_delete);
         btnDeleteBook.setOnClickListener(v -> {
 			mActivity.askDeleteBook(mBookInfo.getFileInfo());
 			dismiss();
 		});
 
-        edTitle = scrollView.findViewById(R.id.book_title);
-        edSeriesName = scrollView.findViewById(R.id.book_series_name);
-        edSeriesNumber = scrollView.findViewById(R.id.book_series_number);
-        edDescription = scrollView.findViewById(R.id.book_description);
+        scrollView = mainView.findViewById(R.id.book_scrollview);
+        edTitle = mainView.findViewById(R.id.book_title);
+        edSeriesName = mainView.findViewById(R.id.book_series_name);
+        edSeriesNumber = mainView.findViewById(R.id.book_series_number);
+        edDescription = mainView.findViewById(R.id.book_description);
 
-        rbBookRating = scrollView.findViewById(R.id.book_rating);
-        rgState = scrollView.findViewById(R.id.book_state);
+        rbBookRating = mainView.findViewById(R.id.book_rating);
+        rgState = mainView.findViewById(R.id.book_state);
         int state = file.getReadingState();
         int[] stateButtons = new int[] {R.id.book_state_new, R.id.book_state_toread, R.id.book_state_reading, R.id.book_state_finished};
         rgState.check(state >= 0 && state < stateButtons.length ? stateButtons[state] : R.id.book_state_new);
 
-        final ImageView image = scrollView.findViewById(R.id.book_cover);
+        final ImageView image = mainView.findViewById(R.id.book_cover);
         image.setOnClickListener(v -> {
 			// open book
 			onPositiveButtonClick();
@@ -279,7 +281,7 @@ public class BookInfoEditDialog extends BaseDialog {
 			image.setImageDrawable(drawable);
 		});
 
-        final ImageView progress = scrollView.findViewById(R.id.book_progress);
+        final ImageView progress = mainView.findViewById(R.id.book_progress);
         int percent = -1;
         Bookmark bmk = mBookInfo.getLastPosition();
         if (bmk != null)
@@ -308,12 +310,12 @@ public class BookInfoEditDialog extends BaseDialog {
             edDescription.setText(file.description);
         else
             edDescription.setVisibility(View.INVISIBLE);
-        LinearLayout llBookAuthorsList = scrollView.findViewById(R.id.book_authors_list);
+        LinearLayout llBookAuthorsList = mainView.findViewById(R.id.book_authors_list);
         authors = new AuthorList(llBookAuthorsList, file.authors);
         rbBookRating.setRating(file.getRate());
 
-    	ImageButton btnRemoveRecent = scrollView.findViewById(R.id.book_recent_delete);
-    	ImageButton btnOpenFolder = scrollView.findViewById(R.id.book_folder_open);
+    	ImageButton btnRemoveRecent = mainView.findViewById(R.id.book_recent_delete);
+    	ImageButton btnOpenFolder = mainView.findViewById(R.id.book_folder_open);
         if (mIsRecentBooksItem) {
         	btnRemoveRecent.setOnClickListener(v -> {
 				mActivity.askDeleteRecent(mBookInfo.getFileInfo());
@@ -329,7 +331,7 @@ public class BookInfoEditDialog extends BaseDialog {
         	parent.removeView(btnOpenFolder);
         }
 
-        setView(scrollView);
+        setView(mainView);
 	}
 
 	private void save() {

--- a/android/src/org/coolreader/crengine/OptionsDialog.java
+++ b/android/src/org/coolreader/crengine/OptionsDialog.java
@@ -17,6 +17,7 @@ import android.widget.BaseAdapter;
 import android.widget.CheckBox;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.RadioButton;
@@ -1868,7 +1869,6 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 			listView.add(new ListOption(mOwner, getString(R.string.options_css_margin_bottom), prefix + ".margin-bottom").add(marginBottomOptions, marginTopBottomOptionNames).setIconIdByAttr(R.attr.cr3_option_text_margin_bottom_drawable, R.drawable.cr3_option_text_margin_bottom));
 			listView.add(new ListOption(mOwner, getString(R.string.options_css_margin_left), prefix + ".margin-left").add(marginLeftOptions, marginLeftRightOptionNames).setIconIdByAttr(R.attr.cr3_option_text_margin_left_drawable, R.drawable.cr3_option_text_margin_left));
 			listView.add(new ListOption(mOwner, getString(R.string.options_css_margin_right), prefix + ".margin-right").add(marginRightOptions, marginLeftRightOptionNames).setIconIdByAttr(R.attr.cr3_option_text_margin_right_drawable, R.drawable.cr3_option_text_margin_right));
-			
 
 			dlg.setTitle(label);
 			dlg.setView(listView);

--- a/android/src/org/coolreader/crengine/OptionsDialog.java
+++ b/android/src/org/coolreader/crengine/OptionsDialog.java
@@ -17,7 +17,6 @@ import android.widget.BaseAdapter;
 import android.widget.CheckBox;
 import android.widget.ImageButton;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.RadioButton;

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/android/src/org/coolreader/db/MainDB.java
+++ b/android/src/org/coolreader/db/MainDB.java
@@ -1425,7 +1425,7 @@ public class MainDB extends BaseDB {
 		fileInfo.flags = rs.getInt(i++);
 		fileInfo.language = rs.getString(i++);
 		fileInfo.description = rs.getString(i++);
-		fileInfo.crc32 = rs.getInt(i++);
+		fileInfo.crc32 = rs.getLong(i++);
 		fileInfo.domVersion = rs.getInt(i++);
 		fileInfo.blockRenderingFlags = rs.getInt(i++);
 		fileInfo.isArchive = fileInfo.arcname != null;


### PR DESCRIPTION
* Added indents in bookinfo edit dialog.
Before:
![Screenshot_1602852336-r](https://user-images.githubusercontent.com/36960933/96259957-60b42e00-0fcf-11eb-9ffe-35f5171ce6cd.png)

And after:
![Screenshot_1602852378-r](https://user-images.githubusercontent.com/36960933/96259984-6ad62c80-0fcf-11eb-9105-a477d639dab0.png)

Looks more accurate.

**Added**:
Fixed incorrect loading of the CRC32 value from the database, which could lead to an unnecessary request about the need to load another book when syncing with Google Drive.