### PR TITLE
Added a check for the negative width and height of the document when …

### DIFF
--- a/cr3qt/personaltypes.py
+++ b/cr3qt/personaltypes.py
@@ -89,15 +89,38 @@ def qdump__lString16(d, value):
     size = pchunk['size']
     refCount = pchunk['refCount']
     buf16 = pchunk['buf16']
-    wcharType = d.createType('wchar_t')
+    char16Type = d.createType('char16_t')
     length_int = length.integer()
     size_int = size.integer()
     d.check(length_int >= 0 and size_int >= 0)
-    #buf16str = buf16.cast(wcharType.pointer())
-    #d.putCharArrayHelper(buf16str, size_int, wcharType, d.currentItemFormat(), False)
-    bytelen = length_int*wcharType.size()
+    #buf16str = buf16.cast(char16Type.pointer())
+    #d.putCharArrayHelper(buf16str, size_int, char16Type, d.currentItemFormat(), False)
+    bytelen = length_int*char16Type.size()
     elided, shown = d.computeLimit(bytelen, 512)
     mem = d.readMemory(buf16, shown)
+    d.putValue(mem, 'ucs2', elided=elided)
+    d.putNumChild(3)
+    if d.isExpanded():
+        with Children(d):
+            d.putSubItem('len', length)
+            d.putSubItem('size', size)
+            d.putSubItem('refCount', refCount)
+
+def qdump__lString32(d, value):
+    pchunk = value['pchunk'].dereference()
+    length = pchunk['len']
+    size = pchunk['size']
+    refCount = pchunk['refCount']
+    buf32 = pchunk['buf32']
+    char32Type = d.createType('char32_t')
+    length_int = length.integer()
+    size_int = size.integer()
+    d.check(length_int >= 0 and size_int >= 0)
+    #buf32str = buf32.cast(char32Type.pointer())
+    #d.putCharArrayHelper(buf32str, size_int, char32Type, d.currentItemFormat(), False)
+    bytelen = length_int*char32Type.size()
+    elided, shown = d.computeLimit(bytelen, 512)
+    mem = d.readMemory(buf32, shown)
     d.putValue(mem, 'ucs4', elided=elided)
     d.putNumChild(3)
     if d.isExpanded():

--- a/crengine/include/crsetup.h
+++ b/crengine/include/crsetup.h
@@ -329,9 +329,8 @@
 #define SCREEN_SIZE_MIN 80
 #endif
 
-// By default full frame 4K
 #ifndef SCREEN_SIZE_MAX
-#define SCREEN_SIZE_MAX 4096
+#define SCREEN_SIZE_MAX 32767
 #endif
 
 #endif//CRSETUP_H_INCLUDED

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -117,6 +117,15 @@ static css_font_family_t DEFAULT_FONT_FAMILY = css_ff_sans_serif;
 #define MAX_STATUS_FONT_SIZE 255
 #endif
 
+// Fallback defines, see crsetup.h
+#ifndef SCREEN_SIZE_MIN
+#define SCREEN_SIZE_MIN 80
+#endif
+
+#ifndef SCREEN_SIZE_MAX
+#define SCREEN_SIZE_MAX 32767
+#endif
+
 #if defined(__SYMBIAN32__)
 #include <e32std.h>
 #define DEFAULT_PAGE_MARGIN 2
@@ -3666,10 +3675,14 @@ void LVDocView::SetRotateAngle( cr_rotate_angle_t angle )
 void LVDocView::Resize(int dx, int dy) {
 	//LVCHECKPOINT("Resize");
 	CRLog::trace("LVDocView:Resize(%dx%d)", dx, dy);
-	if (dx < 80 || dx > 32767)
-		dx = 80;
-	if (dy < 80 || dy > 32767)
-		dy = 80;
+	if (dx < SCREEN_SIZE_MIN)
+		dx = SCREEN_SIZE_MIN;
+	else if (dx > SCREEN_SIZE_MAX)
+		dx = SCREEN_SIZE_MAX;
+	if (dy < SCREEN_SIZE_MIN)
+		dy = SCREEN_SIZE_MIN;
+	else if (dy > SCREEN_SIZE_MAX)
+		dy = SCREEN_SIZE_MAX;
 #if CR_INTERNAL_PAGE_ORIENTATION==1
 	if ( m_rotateAngle==CR_ROTATE_ANGLE_90 || m_rotateAngle==CR_ROTATE_ANGLE_270 ) {
 		CRLog::trace("Screen is rotated, swapping dimensions");

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4525,12 +4525,12 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
         _def_font = def_font;
         changed = true;
     }
-    if ( _page_height != dy ) {
+    if ( _page_height != dy && dy > 0 ) {
         CRLog::trace("ldomDocument::setRenderProps() - page height is changed: %d != %d", _page_height, dy);
         _page_height = dy;
         changed = true;
     }
-    if ( _page_width != width ) {
+    if ( _page_width != width && width > 0 ) {
         CRLog::trace("ldomDocument::setRenderProps() - page width is changed");
         _page_width = width;
         changed = true;


### PR DESCRIPTION
Desktop/Qt5/Win32 related: added a check for the negative width and height of the document when rendering, this eliminates freezing (infinite recursion) when trying to display a preview with insufficient size of program settings window.
Also changed the check of the minimum and maximum values ​​in LVDocView::Resize().