### PR TITLE
Added support for the '@charset' rule to the css-rules parsing code, …

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -207,6 +207,7 @@ class LVStyleSheet {
 
     int _selector_count;
     LVArray <int> _selector_count_stack;
+    lString8 _charset;
 
     LVPtrVector <LVCssSelector> _selectors;
     LVPtrVector <LVPtrVector <LVCssSelector> > _stack;
@@ -266,6 +267,8 @@ public:
     LVStyleSheet( LVStyleSheet & sheet );
     /// parse stylesheet, compile and add found rules to sheet
     bool parse( const char * str, bool higher_importance=false, lString32 codeBase=lString32::empty_str );
+    /// parse @charset rule
+    bool parseCharsetRule( const char * &str );
     /// apply stylesheet to node style
     void apply( const ldomNode * node, css_style_rec_t * style );
     /// calculate hash


### PR DESCRIPTION
Added support for the [`@charset`](https://developer.mozilla.org/en-US/docs/Web/CSS/@charset) rule to the css-rules parsing code, just so that no parsing error is generated, but then this rule is ignored.

This fixes the incorrect rendering of some epub/html files containing css files with such rules, for example, http://www.gutenberg.org/ebooks/11, or simplified test file [test2.zip](https://github.com/buggins/coolreader/files/5425090/test2.zip).

The crux of the problem is that if a '`@charset`' rule exists, the rule following it is completely ignored as if there was a parsing error.

Before:
![before](https://user-images.githubusercontent.com/36960933/96917880-7c7d6f80-14ba-11eb-9a03-fccae2eebb45.png)

In Mozilla Firefox:
![firefox-s](https://user-images.githubusercontent.com/36960933/96917916-899a5e80-14ba-11eb-87d7-6ee7c7b2d95f.png)

After:
![after](https://user-images.githubusercontent.com/36960933/96917944-93bc5d00-14ba-11eb-9739-a2a36c3573e8.png)
