### PR TITLE
Fixed SEGFAULT described in issue #167.

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4385,11 +4385,11 @@ void ldomDocument::printWarning(const char * msg, int warning_id) {
 
 ldomDocument::~ldomDocument()
 {
-    ldomNode::unregisterDocument(this);
-    fontMan->UnregisterDocumentFonts(_docIndex);
 #if BUILD_LITE!=1
     updateMap(); // NOLINT: Call to virtual function during destruction
 #endif
+    fontMan->UnregisterDocumentFonts(_docIndex);
+    ldomNode::unregisterDocument(this);
 }
 
 #if BUILD_LITE!=1


### PR DESCRIPTION
This fixes issue #167.
This is because the call to ldomNode::unregisterDocument(this) in the ldomDocument destructor was too early, and as a result, function getDocument() of the ldomNode instances return NULL when calling ldomDocument::updateMap().

Similar stack trace with debug build:
```
signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
Abort message: 'CoolReader Fatal Error #1313: Access to null node'
    eax 00000000  ebx 00007811  ecx 0000783e  edx 00000006
    edi f1c0633e  esi c7abdec0
    ebp f3fe1ad0  esp c7abde68  eip f3fe1ad9

#00 pc 00000ad9  [vdso] (__kernel_vsyscall+9)
#01 pc 00092328  /apex/com.android.runtime/lib/bionic/libc.so (syscall+40) (BuildId: 76290498408016ad14f4b98c3ab6c65c)
#02 pc 000ad651  /apex/com.android.runtime/lib/bionic/libc.so (abort+193) (BuildId: 76290498408016ad14f4b98c3ab6c65c)
#03 pc 00007923  /system/lib/liblog.so (__android_log_assert+307) (BuildId: 93a4440437c37798a143e598876eda6e)
#04 pc 001ccfd7  cr3androidFatalErrorHandler(int, char const*) at coolreader/android/jni/cr3engine.cpp:694
#05 pc 0020fcdb  crFatalError(int, char const*) at coolreader/crengine/src/lvmemman.cpp:158
#06 pc 0023787b  ldomNode::getNodeId() const at coolreader/crengine/src/lvtinydom.cpp:16384
#07 pc 0023d579  ldomNode::isBoxingNode(bool) const at coolreader/crengine/src/lvtinydom.cpp:17331
#08 pc 002511a0  ldomXPointer::toStringV2() at coolreader/crengine/src/lvtinydom.cpp:9451
#09 pc 001e1d44  ldomXPointer::toString(XPointerMode) at coolreader/crengine/include/lvtinydom.h:1595
#10 pc 0029027f  LVTocItem::getPath() at coolreader/crengine/src/lvtinydom.cpp:18505
#11 pc 0028050a  LVTocItem::serialize(SerialBuf&) at coolreader/crengine/src/lvtinydom.cpp:18531
#12 pc 002805dc  LVTocItem::serialize(SerialBuf&) at coolreader/crengine/src/lvtinydom.cpp:18535
#13 pc 0027fb8d  ldomDocument::saveChanges(CRTimerUtil&, LVDocViewCallback*) at coolreader/crengine/src/lvtinydom.cpp:14683
#14 pc 00282dba  ldomDocument::updateMap(CRTimerUtil&, LVDocViewCallback*) at coolreader/crengine/src/lvtinydom.cpp:15115
#15 pc 00291e19  ldomDocument::updateMap(LVDocViewCallback*) at coolreader/crengine/include/lvtinydom.h:2505
#16 pc 00230139  ~ldomDocument at coolreader/crengine/src/lvtinydom.cpp:4389
#17 pc 00230331  ~ldomDocument at coolreader/crengine/src/lvtinydom.cpp:4385
#18 pc 00393c23  LVDocView::Clear() at coolreader/crengine/src/lvdocview.cpp:542
#19 pc 00394817  LVDocView::LoadDocument(char32_t const*, bool) at coolreader/crengine/src/lvdocview.cpp:3835
#20 pc 001d9fd0  DocViewNative::loadDocument(lString32) at coolreader/android/jni/docview.cpp:878
#21 pc 001df94a  Java_org_coolreader_crengine_DocView_loadDocumentInternal at coolreader/android/jni/docview.cpp:1349
```