### PR TITLE
Android api 29

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         applicationId "org.coolreader"
         minSdkVersion 3
-        targetSdkVersion 28
+        targetSdkVersion 29
         // When new version released, version code must be incremented at least by 8
         // for compatibility with ABI versioning of split apk (see below).
         versionCode 32470

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,7 +65,8 @@
             android:label="@string/app_name"
             android:process="org.coolreader"
             android:resizeableActivity="true"
-            android:usesCleartextTraffic="true" >
+            android:usesCleartextTraffic="true"
+            android:requestLegacyExternalStorage="true" >
         <!--
                    android:configChanges="orientation|keyboardHidden|locale|screenSize"
         -->

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -617,6 +617,7 @@
     <string name="googledrive_sync_failed_with">Произошел сбой при синхронизация с Google Диском: %s</string>
     <string name="googledrive_sync_failed">Произошел сбой при синхронизация с Google Диском!</string>
     <string name="googledrive_sync_aborted">Синхронизация с Google Диском прервана!</string>
+    <string name="googledrive_sync_failed_disabled">Более 3 сбоев синхронизации подряд, автосинхронизация отключена.</string>
     <string name="googledrive_localfile_is_newer_confirm">Локальный файл \"%s\" новее чем удаленный файл на Google Диске, скачать удаленный файл или загрузить локальный на Диск?</string>
     <string name="googledrive_load_remote">Скачать удаленный</string>
     <string name="googledrive_upload_local">Загрузить локальный на Диск</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -652,6 +652,7 @@
     <string name="googledrive_sync_failed_with">Synchronization with Google Drive failed with error: %s</string>
     <string name="googledrive_sync_failed">Synchronization with Google Drive failed!</string>
     <string name="googledrive_sync_aborted">Synchronization with Google Drive aborted!</string>
+    <string name="googledrive_sync_failed_disabled">More than 3 sync failures in a row, auto sync disabled.</string>
     <string name="googledrive_localfile_is_newer_confirm">Local file \"%s\" is newer that remote on Google Drive, whatever load remote file or upload local to Drive?</string>
     <string name="googledrive_load_remote">Load remote</string>
     <string name="googledrive_upload_local">Upload local to Drive</string>

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -91,6 +91,7 @@ public class CoolReader extends BaseActivity {
 	private boolean mSyncGoogleDriveEnabledCurrentBooks = false;
 	private int mCloudSyncBookmarksKeepAlive = 14;
 	private int mSyncGoogleDriveAutoSavePeriod = 0;
+	private int mSyncGoogleDriveErrorsCount = 0;
 	private Synchronizer mGoogleDriveSync;
 	private Timer mGoogleDriveAutoSaveTimer = null;
 	// can be add more synchronizers
@@ -399,6 +400,8 @@ public class CoolReader extends BaseActivity {
 						if (null != mReaderView)
 							mReaderView.hideSyncProgress();
 					}
+					if (mSyncGoogleDriveEnabled)
+						mSyncGoogleDriveErrorsCount = 0;
 				}
 
 				@Override
@@ -410,6 +413,14 @@ public class CoolReader extends BaseActivity {
 						showToast(R.string.googledrive_sync_failed_with, errorString);
 					else
 						showToast(R.string.googledrive_sync_failed);
+					if (mSyncGoogleDriveEnabled) {
+						mSyncGoogleDriveErrorsCount++;
+						if (mSyncGoogleDriveErrorsCount >= 3) {
+							showToast(R.string.googledrive_sync_failed_disabled);
+							log.e("More than 3 sync failures in a row, auto sync disabled.");
+							mSyncGoogleDriveEnabled = false;
+						}
+					}
 				}
 
 				@Override


### PR DESCRIPTION
Switch to Android target API 29 (Android 10).
Seems to work.

**Added**:
Disabled automatic synchronization with Google Drive in case of more than 3 synchronization failures in a row until the next launch of the program.