### PR TITLE
cr3.2.50 fixes

### DIFF
--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -15,6 +15,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -628,6 +628,7 @@
     <string name="confirmation_title">Подтверждение</string>
     <string name="sync_confirmation_other_book">На другом устройстве была открыта другая книга (%s), переключиться на неё?</string>
     <string name="sync_confirmation_new_reading_position">Для этой книги найдена новая позиция чтения, обновить?</string>
+    <string name="sync_info_no_such_document">Документ \"%s\" не найден на этом устройстве!</string>
     <string name="autosave_period">Период автосохранения</string>
     <string name="autosave_period_off">"Отключено"</string>
     <string name="autosave_period_1min">"1 минута"</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -663,6 +663,7 @@
     <string name="confirmation_title">Confirmation</string>
     <string name="sync_confirmation_other_book">Another book (%s) was opened on another device, switch to it?</string>
     <string name="sync_confirmation_new_reading_position">New reading position found for this book, update?</string>
+    <string name="sync_info_no_such_document">No document \"%s\" was found on this device!</string>
     <string name="autosave_period">Autosave period</string>
     <string name="autosave_period_off">Off</string>
     <string name="autosave_period_1min">1 minute</string>

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -129,15 +129,15 @@ public class CoolReader extends BaseActivity {
 		log.i("CoolReader.onCreate() entered");
 		super.onCreate(savedInstanceState);
 
+		isFirstStart = true;
+		justCreated = true;
+
 		// Can request only one set of permissions at a time
 		// Then request all permission at a time.
 		requestStoragePermissions();
 
 		// apply settings
 		onSettingsChanged(settings(), null);
-
-		isFirstStart = true;
-		justCreated = true;
 
 		mEngine = Engine.getInstance(this);
 
@@ -495,6 +495,20 @@ public class CoolReader extends BaseActivity {
 					}
 				}
 
+				@Override
+				public void onFileNotFound(FileInfo fileInfo) {
+					if (null == fileInfo)
+						return;
+					String docInfo = "Unknown";
+					if (null != fileInfo.title && !fileInfo.authors.isEmpty())
+						docInfo = fileInfo.title;
+					if (null != fileInfo.authors && !fileInfo.authors.isEmpty())
+						docInfo = fileInfo.authors + ", " + docInfo;
+					if (null != fileInfo.filename && !fileInfo.filename.isEmpty())
+						docInfo += " (" + fileInfo.filename + ")";
+					showToast(R.string.sync_info_no_such_document, docInfo);
+				}
+
 			});
 		}
 	}
@@ -526,8 +540,6 @@ public class CoolReader extends BaseActivity {
 						}
 					}, mSyncGoogleDriveAutoSavePeriod * 60000, mSyncGoogleDriveAutoSavePeriod * 60000);
 				}
-				if (!mSyncGoogleDriveEnabledPrev)		// Enables just now
-					mGoogleDriveSync.startSyncFrom(true, true, false);
 			} else {
 				if (null != mGoogleDriveAutoSaveTimer) {
 					mGoogleDriveAutoSaveTimer.cancel();
@@ -1066,10 +1078,20 @@ public class CoolReader extends BaseActivity {
 			String value = (String) entry.getValue();
 			applyAppSetting(key, value);
 		}
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+			if (mSyncGoogleDriveEnabled && !mSyncGoogleDriveEnabledPrev && null != mGoogleDriveSync) {
+				// if cloud sync has just been enabled in options dialog
+				if (!justCreated) {
+					// Only after onStart()!
+					mGoogleDriveSync.startSyncFrom(true, false, false);
+					mSyncGoogleDriveEnabledPrev = mSyncGoogleDriveEnabled;
+				}
+			}
+		}
 		// Show/Hide soft navbar after OptionDialog is closed.
 		applyFullscreen(getWindow());
 		if (changedProps.size() > 0) {
-			// After all, sync to the cloud with delay
+			// After all, sync new settings to the cloud with delay
 			BackgroundThread.instance().postGUI(() -> {
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
 					if (mSyncGoogleDriveEnabled && mSyncGoogleDriveEnabledSettings && null != mGoogleDriveSync) {

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -32,6 +32,7 @@ import org.coolreader.crengine.BookmarksDlg;
 import org.coolreader.crengine.BrowserViewLayout;
 import org.coolreader.crengine.CRRootView;
 import org.coolreader.crengine.CRToolBar;
+import org.coolreader.crengine.CoverpageManager;
 import org.coolreader.crengine.DeviceInfo;
 import org.coolreader.crengine.Engine;
 import org.coolreader.crengine.ErrorDialog;
@@ -722,6 +723,14 @@ public class CoolReader extends BaseActivity {
 	@Override
 	protected void onPause() {
 		super.onPause();
+		// trying to fix strange NPE where Services.mCoverpageManager and Services.mHistory are null
+		// this fields cleared in CoolReader.onDestroy() => Services.stopServices()
+		// According to the documentation https://developer.android.com/reference/android/app/Activity#ActivityLifecycle
+		// Activity.onPause() is called before Activity.onDestroy()
+		// but in this methods next lines throw NPE on some devices (there is no more information about this situation):
+		//    mReaderView.onAppPause(); => ReaderView.savePositionBookmark() => { ... Services.getHistory().updateRecentDir(); ... }
+		//    Services.getCoverpageManager().removeCoverpageReadyListener(mHomeFrame);
+		// So this means Services.mCoverpageManager and Services.mHistory are null.
 		if (mReaderView != null) {
 			// save book info to "sync to" as in the actual sync operation the readerView is no longer available
 			BookInfo bookInfo = mReaderView.getBookInfo();
@@ -731,7 +740,11 @@ public class CoolReader extends BaseActivity {
 			}
 			mReaderView.onAppPause();
 		}
-		Services.getCoverpageManager().removeCoverpageReadyListener(mHomeFrame);
+		CoverpageManager coverpageManager = Services.getCoverpageManager();
+		if (coverpageManager != null)
+			coverpageManager.removeCoverpageReadyListener(mHomeFrame);
+		else
+			log.e("Services.getCoverpageManager() is null!");
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
 			if (mSyncGoogleDriveEnabled && mGoogleDriveSync != null && !mGoogleDriveSync.isBusy()) {
 				mGoogleDriveSync.startSyncTo(false, true, false);

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -14,6 +14,7 @@ import java.util.concurrent.Callable;
 import org.coolreader.CoolReader;
 import org.coolreader.R;
 import org.coolreader.crengine.InputDialog.InputHandler;
+import org.coolreader.db.CRDBService;
 import org.koekak.android.ebookdownloader.SonyBookSelector;
 
 import android.content.ContentValues;
@@ -5377,10 +5378,19 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		if (bmk != null && mBookInfo != null && isBookLoaded()) {
 			//setBookPosition();
 			if (lastSavedBookmark == null || !lastSavedBookmark.getStartPos().equals(bmk.getStartPos())) {
-				Services.getHistory().updateRecentDir();
-				mActivity.getDB().saveBookInfo(mBookInfo);
-				mActivity.getDB().flush();
-				lastSavedBookmark = bmk;
+				History history = Services.getHistory();
+				if (history != null)
+					history.updateRecentDir();
+				else
+					log.e("Services.getHistory() is null!");
+				CRDBService.LocalBinder db = mActivity.getDB();
+				if (db != null) {
+					db.saveBookInfo(mBookInfo);
+					db.flush();
+					lastSavedBookmark = bmk;
+				} else {
+					log.e("getDB() return null!");
+				}
 			}
 		}
 	}

--- a/android/src/org/coolreader/crengine/Services.java
+++ b/android/src/org/coolreader/crengine/Services.java
@@ -28,7 +28,7 @@ public class Services {
 		mEngine = Engine.getInstance(activity);
 
        	mScanner = new Scanner(activity, mEngine);
-       	mScanner.initRoots(mEngine.getMountedRootsMap());
+       	mScanner.initRoots(Engine.getMountedRootsMap());
 
        	mHistory = new History(mScanner);
 		mScanner.setDirScanEnabled(activity.settings().getBool(ReaderView.PROP_APP_BOOK_PROPERTY_SCAN_ENABLED, true));
@@ -40,7 +40,7 @@ public class Services {
 	// called after user grant permissions for external storage
 	public static void refreshServices(BaseActivity activity) {
 		mEngine.initAgain();
-		mScanner.initRoots(mEngine.getMountedRootsMap());
+		mScanner.initRoots(Engine.getMountedRootsMap());
 	}
 
 	public static void stopServices() {
@@ -61,5 +61,6 @@ public class Services {
 		mHistory = null;
 		mScanner = null;
 		mCoverpageManager = null;
+		mFSFolders = null;
 	}
 }

--- a/android/src/org/coolreader/sync2/BookmarksContentHandler.java
+++ b/android/src/org/coolreader/sync2/BookmarksContentHandler.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/BookmarksContentHandler.java
+++ b/android/src/org/coolreader/sync2/BookmarksContentHandler.java
@@ -131,7 +131,7 @@ class BookmarksContentHandler implements ContentHandler {
 		String tag = "";
 		if (!m_tagStack.empty())
 			tag = m_tagStack.pop();
-		if (tag != qName) {
+		if (!tag.equals(qName)) {
 			throw new SAXException("end element '" + qName + "' not equal to start element '" + tag + "'");
 		}
 		switch (tag) {

--- a/android/src/org/coolreader/sync2/FileMetadata.java
+++ b/android/src/org/coolreader/sync2/FileMetadata.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/FileMetadataList.java
+++ b/android/src/org/coolreader/sync2/FileMetadataList.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/OnOperationCompleteListener.java
+++ b/android/src/org/coolreader/sync2/OnOperationCompleteListener.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/OnSignInListener.java
+++ b/android/src/org/coolreader/sync2/OnSignInListener.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/OnSignOutListener.java
+++ b/android/src/org/coolreader/sync2/OnSignOutListener.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/OnSyncStatusListener.java
+++ b/android/src/org/coolreader/sync2/OnSyncStatusListener.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/OnSyncStatusListener.java
+++ b/android/src/org/coolreader/sync2/OnSyncStatusListener.java
@@ -39,4 +39,6 @@ public interface OnSyncStatusListener {
 	void onBookmarksLoaded(BookInfo bookInfo, boolean forced);
 
 	void onCurrentBookInfoLoaded(FileInfo fileInfo, boolean forced);
+
+	void onFileNotFound(FileInfo fileInfo);
 }

--- a/android/src/org/coolreader/sync2/RemoteAccess.java
+++ b/android/src/org/coolreader/sync2/RemoteAccess.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/SyncOperation.java
+++ b/android/src/org/coolreader/sync2/SyncOperation.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/Synchronizer.java
+++ b/android/src/org/coolreader/sync2/Synchronizer.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/Synchronizer.java
+++ b/android/src/org/coolreader/sync2/Synchronizer.java
@@ -1019,16 +1019,21 @@ public class Synchronizer {
 						return;
 					m_currentOperationIndex++;
 					setSyncProgress(m_currentOperationIndex, m_totalOperationsCount);
-					Date now = new Date();
-					SyncOperation op = DeleteOldBookmarksSyncOperation.this;
-					for (FileMetadata meta : metalist) {
-						if (meta.fileName.endsWith(".bmk.xml.gz")) {
-							if (meta.modifiedDate.getTime() + 86400000*(long)m_bookmarksKeepAlive < now.getTime()) {
-								log.d("scheduling to remove file \"" + meta.fileName +  "\".");
-								String fileName = REMOTE_FOLDER_PATH + "/" + meta.fileName;
-								SyncOperation deleteFileOp = new DeleteFileSyncOperation(fileName);
-								insertOperation(op, deleteFileOp);
-								op = deleteFileOp;
+					if (null == metalist) {
+						// `metalist` can be null, which means that the folder you are looking for was not found.
+						log.d(REMOTE_FOLDER_PATH + " don't exist yet...");
+					} else {
+						Date now = new Date();
+						SyncOperation op = DeleteOldBookmarksSyncOperation.this;
+						for (FileMetadata meta : metalist) {
+							if (meta.fileName.endsWith(".bmk.xml.gz")) {
+								if (meta.modifiedDate.getTime() + 86400000 * (long) m_bookmarksKeepAlive < now.getTime()) {
+									log.d("scheduling to remove file \"" + meta.fileName + "\".");
+									String fileName = REMOTE_FOLDER_PATH + "/" + meta.fileName;
+									SyncOperation deleteFileOp = new DeleteFileSyncOperation(fileName);
+									insertOperation(op, deleteFileOp);
+									op = deleteFileOp;
+								}
 							}
 						}
 					}

--- a/android/src/org/coolreader/sync2/Synchronizer.java
+++ b/android/src/org/coolreader/sync2/Synchronizer.java
@@ -1450,6 +1450,9 @@ public class Synchronizer {
 							// this book not found in db
 							// find in filesystem?
 							log.e("file \"" + fileInfo.filename + "\" not found in database!");
+							if (null != m_onStatusListener) {
+								m_onStatusListener.onFileNotFound(fileInfo);
+							}
 						} else {
 							if (fileList.size() > 1) {
 								// multiple files found that matches this fileInfo

--- a/android/src/org/coolreader/sync2/googledrive/GoogleDriveRemoteAccess.java
+++ b/android/src/org/coolreader/sync2/googledrive/GoogleDriveRemoteAccess.java
@@ -4,7 +4,7 @@
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
- *   the Free Software Foundation, either version 3 of the License, or
+ *   the Free Software Foundation, either version 2 of the License, or
  *   (at your option) any later version.
  *
  *   This program is distributed in the hope that it will be useful,

--- a/android/src/org/coolreader/sync2/googledrive/GoogleDriveRemoteAccess.java
+++ b/android/src/org/coolreader/sync2/googledrive/GoogleDriveRemoteAccess.java
@@ -595,12 +595,12 @@ public class GoogleDriveRemoteAccess implements RemoteAccess {
 				meta = getFileMetadata(file);
 			} else
 				Log.d(TAG, "dir is NULL.");
-			if (null != completeListener)
-				completeListener.onCompleted(meta, meta != null);
 			synchronized (m_cacheLocker) {
-				// clear cache
+				// clear folders list cache before calling `complete' handler.
 				m_folderListCache.update(parentPath, null);
 			}
+			if (null != completeListener)
+				completeListener.onCompleted(meta, meta != null);
 		}).addOnFailureListener(e -> {
 			Log.d(TAG, "mkdir_impl() failed, e=" + e.toString());
 			if (null != completeListener) {
@@ -883,11 +883,11 @@ public class GoogleDriveRemoteAccess implements RemoteAccess {
 		}).addOnSuccessListener(file -> {
 			m_needSignInRepeat = false;
 			boolean result = null != file;
-			if (null != completeListener)
-				completeListener.onCompleted(result, result);
 			synchronized (m_cacheLocker) {
 				m_folderListCache.update(parentPath, null);
 			}
+			if (null != completeListener)
+				completeListener.onCompleted(result, result);
 		}).addOnFailureListener(e -> {
 			if (null != completeListener) {
 				completeListener.onCompleted(false, false);
@@ -909,11 +909,11 @@ public class GoogleDriveRemoteAccess implements RemoteAccess {
 		}).addOnSuccessListener(file -> {
 			m_needSignInRepeat = false;
 			boolean result = null != file;
-			if (null != completeListener)
-				completeListener.onCompleted(result, result);
 			synchronized (m_cacheLocker) {
 				m_folderListCache.update(parentPath, null);
 			}
+			if (null != completeListener)
+				completeListener.onCompleted(result, result);
 		}).addOnFailureListener(e -> {
 			if (null != completeListener) {
 				completeListener.onCompleted(false, false);

--- a/android/src/org/coolreader/tts/TTSControlService.java
+++ b/android/src/org/coolreader/tts/TTSControlService.java
@@ -64,12 +64,15 @@ public class TTSControlService extends Service {
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
 		log.d("Received start id " + startId + ": " + intent);
-
 		String title = "";
-		Bundle data = intent.getExtras();
-		if (null != data)
-			title = data.getString("bookTitle");
-
+		if (null != intent) {
+			// According to the documentation, intent can be null:
+			// https://developer.android.com/reference/android/app/Service#onStartCommand(android.content.Intent,%20int,%20int)
+			// https://developer.android.com/reference/android/app/Service#START_STICKY
+			Bundle data = intent.getExtras();
+			if (null != data)
+				title = data.getString("bookTitle");
+		}
 		// switch this service to foreground
 		Notification notification = buildNotification(title, null, TTSStatus.PAUSED);
 		if (null != notification) {


### PR DESCRIPTION
Bug fixes for CoolReader 3.2.50:
* Fixed NPE in TTSControlService.onStartCommand(), according to the documentation, intent can be null:
      https://developer.android.com/reference/android/app/Service#onStartCommand(android.content.Intent,%20int,%20int)
      https://developer.android.com/reference/android/app/Service#START_STICKY
* Fixed incorrect string comparison in org.coolreader.sync2.BookmarksContentHandler.
* Google Drive binding implementation fix: clear folders list cache before calling `complete' handler.
* Fixed NPE in Synchronizer.java: GoogleDriveRemoteAccess.list() can return null as FileMetadataList if the folder you want to retrieve does not exist.
* Trying to fix NPE in CoolReader.onPause().
Trying to fix strange NPE where Services.mCoverpageManager and Services.mHistory are null. This fields cleared in CoolReader.onDestroy() => Services.stopServices(). According to the documentation (https://developer.android.com/reference/android/app/Activity#ActivityLifecycle) Activity.onPause() is called before Activity.onDestroy() but in this method next lines throw NPE on some devices (there is no more information about this 
situation):
1. `mReaderView.onAppPause(); => ReaderView.savePositionBookmark() => { ... Services.getHistory().updateRecentDir(); ... }`
2. `Services.getCoverpageManager().removeCoverpageReadyListener(mHomeFrame);`
So this means Services.mCoverpageManager and Services.mHistory there are null.

New feature:
* During cloud synchronization, a message (toast) is displayed if the current document is not found in the database on this device (the last opened document on another device).