### PR TITLE
cr3.2.50 fixes tier2

### DIFF
--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -735,14 +735,6 @@ public class CoolReader extends BaseActivity {
 	@Override
 	protected void onPause() {
 		super.onPause();
-		// trying to fix strange NPE where Services.mCoverpageManager and Services.mHistory are null
-		// this fields cleared in CoolReader.onDestroy() => Services.stopServices()
-		// According to the documentation https://developer.android.com/reference/android/app/Activity#ActivityLifecycle
-		// Activity.onPause() is called before Activity.onDestroy()
-		// but in this methods next lines throw NPE on some devices (there is no more information about this situation):
-		//    mReaderView.onAppPause(); => ReaderView.savePositionBookmark() => { ... Services.getHistory().updateRecentDir(); ... }
-		//    Services.getCoverpageManager().removeCoverpageReadyListener(mHomeFrame);
-		// So this means Services.mCoverpageManager and Services.mHistory are null.
 		if (mReaderView != null) {
 			// save book info to "sync to" as in the actual sync operation the readerView is no longer available
 			BookInfo bookInfo = mReaderView.getBookInfo();
@@ -752,11 +744,7 @@ public class CoolReader extends BaseActivity {
 			}
 			mReaderView.onAppPause();
 		}
-		CoverpageManager coverpageManager = Services.getCoverpageManager();
-		if (coverpageManager != null)
-			coverpageManager.removeCoverpageReadyListener(mHomeFrame);
-		else
-			log.e("Services.getCoverpageManager() is null!");
+		Services.getCoverpageManager().removeCoverpageReadyListener(mHomeFrame);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
 			if (mSyncGoogleDriveEnabled && mGoogleDriveSync != null && !mGoogleDriveSync.isBusy()) {
 				mGoogleDriveSync.startSyncTo(false, true, false);

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -4988,8 +4988,9 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			log.d("LoadDocumentTask, GUI thread is finished successfully");
 			if (Services.getHistory() != null) {
 				Services.getHistory().updateBookAccess(mBookInfo, getTimeElapsed());
-				mActivity.waitForCRDBService(() -> mActivity.getDB().saveBookInfo(mBookInfo));
-				if (coverPageBytes != null && mBookInfo != null && mBookInfo.getFileInfo() != null) {
+				final BookInfo finalBookInfo = new BookInfo(mBookInfo);
+				mActivity.waitForCRDBService(() -> mActivity.getDB().saveBookInfo(finalBookInfo));
+				if (coverPageBytes != null && mBookInfo.getFileInfo() != null) {
 					// TODO: fix it
 					/*
 					DocumentFormat format = mBookInfo.getFileInfo().format;
@@ -5033,9 +5034,10 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			BackgroundThread.ensureGUI();
 			close();
 			log.v("LoadDocumentTask failed for " + mBookInfo, e);
+			final FileInfo finalFileInfo = new FileInfo(mBookInfo.getFileInfo());
 			mActivity.waitForCRDBService(() -> {
 				if (Services.getHistory() != null)
-					Services.getHistory().removeBookInfo(mActivity.getDB(), mBookInfo.getFileInfo(), true, false);
+					Services.getHistory().removeBookInfo(mActivity.getDB(), finalFileInfo, true, false);
 			});
 			mBookInfo = null;
 			log.d("LoadDocumentTask is finished with exception " + e.getMessage());

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -4986,7 +4986,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		public void done() {
 			BackgroundThread.ensureGUI();
 			log.d("LoadDocumentTask, GUI thread is finished successfully");
-			if (Services.getHistory() != null) {
+			if (!Services.isStopped()) {
 				Services.getHistory().updateBookAccess(mBookInfo, getTimeElapsed());
 				final BookInfo finalBookInfo = new BookInfo(mBookInfo);
 				mActivity.waitForCRDBService(() -> mActivity.getDB().saveBookInfo(finalBookInfo));
@@ -5036,7 +5036,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			log.v("LoadDocumentTask failed for " + mBookInfo, e);
 			final FileInfo finalFileInfo = new FileInfo(mBookInfo.getFileInfo());
 			mActivity.waitForCRDBService(() -> {
-				if (Services.getHistory() != null)
+				if (!Services.isStopped())
 					Services.getHistory().removeBookInfo(mActivity.getDB(), finalFileInfo, true, false);
 			});
 			mBookInfo = null;
@@ -5291,7 +5291,9 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 						if (mylastSavePositionTaskId == lastSavePositionTaskId) {
 							if (bookInfo != null) {
 								log.v("saving last position");
-								if (Services.getHistory() != null) {
+								if (!Services.isStopped()) {
+									// this delayed task can be completed after calling CoolReader.onDestroy(),
+									// which in turn calls Services.stopServices().
 									savePositionBookmark(bmk);
 									Services.getHistory().updateBookAccess(bookInfo, getTimeElapsed());
 								}
@@ -5390,18 +5392,11 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		if (bmk != null && mBookInfo != null && isBookLoaded()) {
 			//setBookPosition();
 			if (lastSavedBookmark == null || !lastSavedBookmark.getStartPos().equals(bmk.getStartPos())) {
-				History history = Services.getHistory();
-				if (history != null)
-					history.updateRecentDir();
-				else
-					log.e("Services.getHistory() is null!");
-				CRDBService.LocalBinder db = mActivity.getDB();
-				if (db != null) {
-					db.saveBookInfo(mBookInfo);
-					db.flush();
+				if (!Services.isStopped()) {
+					Services.getHistory().updateRecentDir();
+					mActivity.getDB().saveBookInfo(mBookInfo);
+					mActivity.getDB().flush();
 					lastSavedBookmark = bmk;
-				} else {
-					log.e("getDB() return null!");
 				}
 			}
 		}
@@ -5436,13 +5431,15 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		mActivity.einkRefresh();
 		BackgroundThread.ensureGUI();
 		if (isBookLoaded() && mBookInfo != null) {
-			log.v("saving last immediately");
-			log.d("bookmark count 1 = " + mBookInfo.getBookmarkCount());
-			Services.getHistory().updateBookAccess(mBookInfo, getTimeElapsed());
-			log.d("bookmark count 2 = " + mBookInfo.getBookmarkCount());
-			mActivity.getDB().saveBookInfo(mBookInfo);
-			log.d("bookmark count 3 = " + mBookInfo.getBookmarkCount());
-			mActivity.getDB().flush();
+			if (!Services.isStopped()) {
+				log.v("saving last immediately");
+				log.d("bookmark count 1 = " + mBookInfo.getBookmarkCount());
+				Services.getHistory().updateBookAccess(mBookInfo, getTimeElapsed());
+				log.d("bookmark count 2 = " + mBookInfo.getBookmarkCount());
+				mActivity.getDB().saveBookInfo(mBookInfo);
+				log.d("bookmark count 3 = " + mBookInfo.getBookmarkCount());
+				mActivity.getDB().flush();
+			}
 		}
 		//scheduleSaveCurrentPositionBookmark(0);
 		//post( new SavePositionTask() );

--- a/android/src/org/coolreader/crengine/Services.java
+++ b/android/src/org/coolreader/crengine/Services.java
@@ -5,36 +5,64 @@ import android.os.Handler;
 public class Services {
 
 	public static final Logger log = L.create("sv");
-	
+
 	private static Engine mEngine;
 	private static Scanner mScanner;
 	private static History mHistory;
 	private static CoverpageManager mCoverpageManager;
-    private static FileSystemFolders mFSFolders;
+	private static FileSystemFolders mFSFolders;
 
-	public static Engine getEngine() { return mEngine; }
-	public static Scanner getScanner() { return mScanner; }
-	public static History getHistory() { return mHistory; }
-    public static CoverpageManager getCoverpageManager() { return mCoverpageManager; }
-    public static FileSystemFolders getFileSystemFolders() { return mFSFolders; }
+	public static Engine getEngine() {
+		if (null != mEngine)
+			return mEngine;
+		throw new RuntimeException("Services.getEngine(): trying to get null object");
+	}
+
+	public static Scanner getScanner() {
+		if (null != mScanner)
+			return mScanner;
+		throw new RuntimeException("Services.getScanner(): trying to get null object");
+	}
+
+	public static History getHistory() {
+		if (null != mHistory)
+			return mHistory;
+		throw new RuntimeException("Services.getHistory(): trying to get null object");
+	}
+
+	public static CoverpageManager getCoverpageManager() {
+		if (null != mCoverpageManager)
+			return mCoverpageManager;
+		throw new RuntimeException("Services.getCoverpageManager(): trying to get null object");
+	}
+
+	public static FileSystemFolders getFileSystemFolders() {
+		if (null != mFSFolders)
+			return mFSFolders;
+		throw new RuntimeException("Services.getFileSystemFolders(): trying to get null object");
+	}
+
+	public static boolean isStopped() {
+		return null == mEngine || null == mScanner || null == mHistory || null == mCoverpageManager || null == mFSFolders;
+	}
 
 	public static void startServices(BaseActivity activity) {
 		log.i("First activity is created");
 		// testing background thread
 		//mSettings = activity.settings();
-		
+
 		BackgroundThread.instance().setGUIHandler(new Handler());
-				
+
 		mEngine = Engine.getInstance(activity);
 
-       	mScanner = new Scanner(activity, mEngine);
-       	mScanner.initRoots(Engine.getMountedRootsMap());
+		mScanner = new Scanner(activity, mEngine);
+		mScanner.initRoots(Engine.getMountedRootsMap());
 
-       	mHistory = new History(mScanner);
+		mHistory = new History(mScanner);
 		mScanner.setDirScanEnabled(activity.settings().getBool(ReaderView.PROP_APP_BOOK_PROPERTY_SCAN_ENABLED, true));
 		mCoverpageManager = new CoverpageManager();
 
-        mFSFolders = new FileSystemFolders(mScanner);
+		mFSFolders = new FileSystemFolders(mScanner);
 	}
 
 	// called after user grant permissions for external storage


### PR DESCRIPTION
* Rework commit c525d9b59b765ef39dd3afadaa72a7ec35d3f29c that is based on an unconfirmed hypothesis that Services.stopServices() is called too early, which it shouldn't. Therefore, in this commit we are trying to confirm or disprove the hypothesis that when CoolReader.onPause() is called, Services.getHistory() may return null. Thus, in the next version, if this hypothesis is confirmed, we will receive the corresponding RuntimeException.
* Fixed NPE in ReaderView.LoadDocumentTask.fail().