### PR TITLE
String refactoring cleanup

### DIFF
--- a/cr3qt/src/crqtutil.cpp
+++ b/cr3qt/src/crqtutil.cpp
@@ -11,8 +11,7 @@ lString32 qt2cr(QString str)
 
 QString cr2qt(lString32 str)
 {
-    lString8 s8 = UnicodeToUtf8(str);
-    return QString::fromUtf8( s8.c_str(), s8.length() );
+    return QString::fromUcs4(str.c_str(), str.length());
 }
 
 class CRPropsImpl : public Props

--- a/cr3qt/src/filepropsdlg.cpp
+++ b/cr3qt/src/filepropsdlg.cpp
@@ -67,8 +67,8 @@ QString FilePropsDialog::getDocText( const char * path, const char * delim )
     for ( int i=0; i<100; i++ ) {
         lString8 p = lString8(path) + "[" + fmt::decimal(i+1) + "]";
         //CRLog::trace("checking doc path %s", p.c_str() );
-        lString32 p16 = Utf8ToUnicode(p);
-        ldomXPointer ptr = doc->createXPointer( p16 );
+        lString32 p32 = Utf8ToUnicode(p);
+        ldomXPointer ptr = doc->createXPointer( p32 );
         if ( ptr.isNull() )
             break;
         lString32 s = ptr.getText( L' ' );

--- a/cr3qt/src/filepropsdlg.cpp
+++ b/cr3qt/src/filepropsdlg.cpp
@@ -71,7 +71,7 @@ QString FilePropsDialog::getDocText( const char * path, const char * delim )
         ldomXPointer ptr = doc->createXPointer( p32 );
         if ( ptr.isNull() )
             break;
-        lString32 s = ptr.getText( L' ' );
+        lString32 s = ptr.getText( U' ' );
         if ( s.empty() )
             continue;
         if ( !res.empty() && delim!=NULL )

--- a/crengine/include/crtrace.h
+++ b/crengine/include/crtrace.h
@@ -28,8 +28,8 @@ public:
         return *this;
     }
 
-    crtrace& operator << (const lString32& ls16) {
-        buffer_.append(UnicodeToUtf8(ls16));
+    crtrace& operator << (const lString32& ls32) {
+        buffer_.append(UnicodeToUtf8(ls32));
         return *this;
     }
 

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -644,39 +644,11 @@ public:
     lString16 & insert(size_type p0, const value_type * str);
     lString16 & insert(size_type p0, const value_type * str, size_type count);
     lString16 & insert(size_type p0, const lString16 & str);
-    lString16 & insert(size_type p0, const lString16 & str, size_type offset, size_type count);
     lString16 & insert(size_type p0, size_type count, value_type ch);
-    lString16 & replace(size_type p0, size_type n0, const value_type * str);
-    lString16 & replace(size_type p0, size_type n0, const value_type * str, size_type count);
-    lString16 & replace(size_type p0, size_type n0, const lString16 & str);
-    lString16 & replace(size_type p0, size_type n0, const lString16 & str, size_type offset, size_type count);
-    /// replace range of string with character ch repeated count times
-    lString16 & replace(size_type p0, size_type n0, size_type count, value_type ch);
-    /// make string uppercase
-    lString16 & uppercase();
-    /// make string lowercase
-    lString16 & lowercase();
-    /// make string capitalized
-    lString16 & capitalize();
-    /// make string use full width chars
-    lString16 & fullWidthChars();
     /// compare with another string
     int compare(const lString16& str) const { return lStr_cmp(pchunk->buf16, str.pchunk->buf16); }
-    /// compare subrange with another string
-    int compare(size_type p0, size_type n0, const lString16& str) const;
-    /// compare subrange with substring of another string
-    int compare(size_type p0, size_type n0, const lString16& str, size_type pos, size_type n) const;
     int compare(const value_type *s) const  { return lStr_cmp(pchunk->buf16, s); }
     int compare(const lChar8 *s) const  { return lStr_cmp(pchunk->buf16, s); }
-    int compare(size_type p0, size_type n0, const value_type *s) const;
-    int compare(size_type p0, size_type n0, const value_type *s, size_type pos) const;
-
-    /// split string into two strings using delimiter
-    bool split2( const lString16 & delim, lString16 & value1, lString16 & value2 );
-    /// split string into two strings using delimiter
-    bool split2( const lChar16 * delim, lString16 & value1, lString16 & value2 );
-    /// split string into two strings using delimiter
-    bool split2( const lChar8 * delim, lString16 & value1, lString16 & value2 );
 
     /// returns n characters beginning with pos
     lString16 substr(size_type pos, size_type n) const;
@@ -688,22 +660,6 @@ public:
     bool replaceParam(int index, const lString16 & replaceStr);
     /// replaces first found occurence of "$N" pattern with itoa of integer, where N=index
     bool replaceIntParam(int index, int replaceNumber);
-
-    /// find position of substring inside string, -1 if not found
-    int pos(lString16 subStr) const;
-    /// find position of substring inside string starting from specified position, -1 if not found
-    int pos(const lString16 & subStr, int start) const;
-    /// find position of substring inside string, -1 if not found
-    int pos(const lChar16 * subStr) const;
-    /// find position of substring inside string (8bit ASCII only), -1 if not found
-    int pos(const lChar8 * subStr) const;
-    /// find position of substring inside string starting from specified position, -1 if not found
-    int pos(const lChar16 * subStr, int start) const;
-    /// find position of substring inside string (8bit ASCII only) starting from specified position, -1 if not found
-    int pos(const lChar8 * subStr, int start) const;
-
-    /// find position of substring inside string, right to left, return -1 if not found
-    int rpos(lString16 subStr) const;
 
     /// append single character
     lString16 & operator << (value_type ch) { return append(1, ch); }
@@ -778,8 +734,6 @@ public:
     lString16 & trimNonAlpha();
     /// trims spaces at beginning and end of string
     lString16 & trim();
-    /// trims duplicate space characters inside string and (optionally) at end and beginning of string
-    lString16 & trimDoubleSpaces( bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens=false );
     /// converts to integer
     int atoi() const;
     /// converts to integer, returns true if success

--- a/crengine/include/lvstring32hashedcollection.h
+++ b/crengine/include/lvstring32hashedcollection.h
@@ -18,7 +18,7 @@
 class SerialBuf;
 
 /// hashed wide string collection
-class lString16HashedCollection : public lString32Collection
+class lString32HashedCollection : public lString32Collection
 {
 private:
     int hashSize;
@@ -38,9 +38,9 @@ public:
     /// deserialize from byte array (pointer will be incremented by number of bytes read)
     bool deserialize( SerialBuf & buf );
 
-    lString16HashedCollection( lString16HashedCollection & v );
-    lString16HashedCollection( lUInt32 hashSize );
-    ~lString16HashedCollection();
+    lString32HashedCollection( lString32HashedCollection & v );
+    lString32HashedCollection( lUInt32 hashSize );
+    ~lString32HashedCollection();
     int add( const lChar32 * s );
     int find( const lChar32 * s );
 };

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1372,7 +1372,7 @@ protected:
     lUInt16       _nextUnknownElementId; // Next Id for unknown element
     lUInt16       _nextUnknownAttrId;    // Next Id for unknown attribute
     lUInt16       _nextUnknownNsId;      // Next Id for unknown namespace
-    lString16HashedCollection _attrValueTable;
+    lString32HashedCollection _attrValueTable;
     LVHashTable<lUInt32,lInt32> _idNodeMap; // id to data index map
     LVHashTable<lString32,LVImageSourceRef> _urlImageMap; // url to image source map
     lUInt16 _idAttrId; // Id for "id" attribute name

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -965,7 +965,7 @@ class CHMTOCReader {
     ldomDocumentFragmentWriter * _appender;
     ldomDocument * _doc;
     LVTocItem * _toc;
-    lString16HashedCollection _fileList;
+    lString32HashedCollection _fileList;
     lString32 lastFile;
     lString32 _defEncodingName;
     bool _fakeToc;

--- a/crengine/src/crgui.cpp
+++ b/crengine/src/crgui.cpp
@@ -1034,7 +1034,7 @@ void CRMenu::Draw( LVDrawBuf & buf, lvRect & rc, CRRectSkinRef skin, CRRectSkinR
             rc2.top += rc2.height()*3/8;
             int hh = rc2.height();
             buf.SetTextColor( skin->getTextColor() );
-            _valueFont->DrawTextString( &buf, rc2.right - w - ITEM_MARGIN, rc2.top + hh/2 - _valueFont->getHeight()/2, s.c_str(), s.length(), L'?', NULL, false, 0 );
+            _valueFont->DrawTextString( &buf, rc2.right - w - ITEM_MARGIN, rc2.top + hh/2 - _valueFont->getHeight()/2, s.c_str(), s.length(), U'?', NULL, false, 0 );
         } else {
             valueSkin->drawText( buf, valueRect, s );
         }
@@ -2012,7 +2012,7 @@ bool CRKeyboardLayoutList::openFromFile( const char  * layoutFile )
             lString32 value;
             if ( splitLine( line, cs32("="), name, value ) ) {
                 if (name == "enabled") {
-					//if ( value == L"0" )
+					//if ( value == U"0" )
 					//	; //TODO:set disabled flag
 					continue;
 				}

--- a/crengine/src/crskin.cpp
+++ b/crengine/src/crskin.cpp
@@ -984,7 +984,7 @@ void CRSkinnedItem::drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text
             tabText = text.substr( tabPos+1 );
             text = text.substr( 0, tabPos );
         } else {
-            text[tabPos] = L' ';
+            text[tabPos] = U' ';
         }
     }
     lString32 cr("\n");
@@ -1036,9 +1036,9 @@ void CRSkinnedItem::drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text
             x += dx;
 
 
-        font->DrawTextString( &buf, x, y, s.c_str(), s.length(), L'?', NULL, false, 0 );
+        font->DrawTextString( &buf, x, y, s.c_str(), s.length(), U'?', NULL, false, 0 );
         if ( !tabText.empty() ) {
-            font->DrawTextString( &buf, txtrc.right-ttw, y, tabText.c_str(), tabText.length(), L'?', NULL, false, 0 );
+            font->DrawTextString( &buf, txtrc.right-ttw, y, tabText.c_str(), tabText.length(), U'?', NULL, false, 0 );
             tabText.clear();
         }
         y = y + lh;

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1392,7 +1392,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         LVStreamRef stream = m_arc->OpenStream(navHref.c_str(), LVOM_READ);
         lString32 codeBase = LVExtractPath( navHref );
         if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
-            codeBase.append(1, L'/');
+            codeBase.append(1, U'/');
         appender.setCodeBase(codeBase);
         if ( !stream.isNull() ) {
             ldomDocument * navDoc = LVParseXMLStream( stream );
@@ -1480,7 +1480,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         LVStreamRef stream = m_arc->OpenStream(ncxHref.c_str(), LVOM_READ);
         lString32 codeBase = LVExtractPath( ncxHref );
         if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
-            codeBase.append(1, L'/');
+            codeBase.append(1, U'/');
         appender.setCodeBase(codeBase);
         if ( !stream.isNull() ) {
             ldomDocument * ncxdoc = LVParseXMLStream( stream );
@@ -1528,7 +1528,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         LVStreamRef stream = m_arc->OpenStream(pageMapHref.c_str(), LVOM_READ);
         lString32 codeBase = LVExtractPath( pageMapHref );
         if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
-            codeBase.append(1, L'/');
+            codeBase.append(1, U'/');
         appender.setCodeBase(codeBase);
         if ( !stream.isNull() ) {
             ldomDocument * pagemapdoc = LVParseXMLStream( stream );

--- a/crengine/src/hist.cpp
+++ b/crengine/src/hist.cpp
@@ -649,10 +649,10 @@ lString32 CRFileHistRecord::getLastTimeString( bool longFormat )
 #define POS_TEXT_TAG         "POSTEXT"
 #define COMMENT_TEXT_TAG     "COMMENTTEXT"
 
-static lString8 encodeText(lString32 text16) {
-    if (text16.empty())
+static lString8 encodeText(lString32 text32) {
+    if (text32.empty())
         return lString8::empty_str;
-    lString8 text = UnicodeToUtf8(text16);
+    lString8 text = UnicodeToUtf8(text32);
     lString8 buf;
     for (int i=0; i<text.length(); i++) {
         char ch = text[i];

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -835,7 +835,7 @@ static lString32 getSectionHeader(ldomNode * section) {
     ldomNode * child = section->getChildElementNode(0, U"title");
     if (!child)
 		return header;
-	header = child->getText(L' ', 1024);
+	header = child->getText(U' ', 1024);
 	return header;
 }
 
@@ -1886,7 +1886,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		if (!pageinfo.empty()) {
 			piw = m_infoFont->getTextWidth(pageinfo.c_str(), pageinfo.length());
 			m_infoFont->DrawTextString(drawbuf, info.right - piw, iy,
-					pageinfo.c_str(), pageinfo.length(), L' ', NULL, false);
+					pageinfo.c_str(), pageinfo.length(), U' ', NULL, false);
 			info.right -= piw + info.height() / 2;
 		}
 		if (phi & PGHDR_CLOCK) {
@@ -1894,7 +1894,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 			m_last_clock = clock;
 			int w = m_infoFont->getTextWidth(clock.c_str(), clock.length()) + 2;
 			m_infoFont->DrawTextString(drawbuf, info.right - w, iy,
-					clock.c_str(), clock.length(), L' ', NULL, false);
+					clock.c_str(), clock.length(), U' ', NULL, false);
 			info.right -= w + info.height() / 2;
 		}
 		int authorsw = 0;
@@ -1914,7 +1914,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		}
 		if (phi & PGHDR_AUTHOR && !authors.empty()) {
 			if (!title.empty())
-				authors += L'.';
+				authors += U'.';
 			authorsw = m_infoFont->getTextWidth(authors.c_str(),
 					authors.length());
 		}
@@ -1937,7 +1937,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 	text = fitTextWidthWithEllipsis(text, m_infoFont, newcr.width());
 	if (!text.empty()) {
 		m_infoFont->DrawTextString(drawbuf, info.left, iy, text.c_str(),
-				text.length(), L' ', NULL, false);
+				text.length(), U' ', NULL, false);
 	}
 	drawbuf->SetClipRect(&oldcr);
 	//--------------
@@ -3850,11 +3850,11 @@ bool LVDocView::LoadDocument(const lChar32 * fname, bool metadataOnly) {
     CRLog::debug("LoadDocument(%s) textMode=%s", LCSTR(lString32(fname)), getTextFormatOptions()==txt_format_pre ? "pre" : "autoformat");
 
 	// split file path and name
-	lString32 filename16(fname);
+	lString32 filename32(fname);
 
 	lString32 arcPathName;
 	lString32 arcItemPathName;
-	bool isArchiveFile = LVSplitArcName(filename16, arcPathName,
+	bool isArchiveFile = LVSplitArcName(filename32, arcPathName,
 			arcItemPathName);
 
 	int savedRenderFlags = m_props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, BLOCK_RENDERING_FLAGS_LEGACY);
@@ -3878,7 +3878,7 @@ bool LVDocView::LoadDocument(const lChar32 * fname, bool metadataOnly) {
 		stream = m_container->OpenStream(arcItemPathName.c_str(), LVOM_READ);
 		if (stream.isNull()) {
 			CRLog::error("Cannot open archive file item stream %s", LCSTR(
-					filename16));
+					filename32));
 			return false;
 		}
 
@@ -3892,7 +3892,7 @@ bool LVDocView::LoadDocument(const lChar32 * fname, bool metadataOnly) {
 				(int) stream->GetSize()));
 		m_doc_props->setString(DOC_PROP_FILE_NAME, arcItemPathName);
 		m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
-		CRFileHistRecord* record = m_hist.getRecord( filename16, stream->GetSize() );
+		CRFileHistRecord* record = m_hist.getRecord( filename32, stream->GetSize() );
 		lUInt32 newDOMVersion;
 		lUInt32 domVersionRequested = m_props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent);
 		bool convertBookmarks = needToConvertBookmarks(record, domVersionRequested) && !metadataOnly;
@@ -3917,10 +3917,10 @@ bool LVDocView::LoadDocument(const lChar32 * fname, bool metadataOnly) {
 		return false;
 	}
 
-	lString32 fn = LVExtractFilename(filename16);
-	lString32 dir = LVExtractPath(filename16);
+	lString32 fn = LVExtractFilename(filename32);
+	lString32 dir = LVExtractPath(filename32);
 
-	CRLog::info("Loading document %s : fn=%s, dir=%s", LCSTR(filename16),
+	CRLog::info("Loading document %s : fn=%s, dir=%s", LCSTR(filename32),
 			LCSTR(fn), LCSTR(dir));
 #if 0
 	int i;
@@ -3954,7 +3954,7 @@ bool LVDocView::LoadDocument(const lChar32 * fname, bool metadataOnly) {
 			(int) stream->GetSize()));
 	m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 
-	CRFileHistRecord* record = m_hist.getRecord( filename16, stream->GetSize() );
+	CRFileHistRecord* record = m_hist.getRecord( filename32, stream->GetSize() );
 	int newDOMVersion;
 	lUInt32 domVersionRequested = m_props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent);
 	bool convertBookmarks = needToConvertBookmarks(record, domVersionRequested) && !metadataOnly;
@@ -4881,7 +4881,7 @@ bool LVDocView::ParseDocument() {
 			if (rootNode)
 				el = rootNode->findChildElement(path);
 			if (el != NULL) {
-                lString32 s = el->getText(L' ', 1024);
+                lString32 s = el->getText(U' ', 1024);
 				if (!s.empty()) {
 					m_doc_props->setString(DOC_PROP_TITLE, s);
 				}
@@ -5170,7 +5170,7 @@ bool LVDocView::getBookmarkPosText(ldomXPointer bm, lString32 & titleText,
         posText += txt;
 		el = el->getParentNode();
 	} else {
-        posText = el->getText(L' ', 1024);
+        posText = el->getText(U' ', 1024);
 	}
     bool inTitle = false;
 	do {
@@ -6930,13 +6930,13 @@ bool SimpleTitleFormatter::measure() {
     return _width < _maxWidth && _height < _maxHeight;
 }
 bool SimpleTitleFormatter::splitLines(const char * delimiter) {
-    lString32 delim16(delimiter);
+    lString32 delim32(delimiter);
     int bestpos = -1;
     int bestdist = -1;
     int start = 0;
     bool skipDelimiter = *delimiter == '|';
     for (;;) {
-        int p = _text.pos(delim16, start);
+        int p = _text.pos(delim32, start);
         if (p < 0)
             break;
         int dist = _text.length() / 2 - p;
@@ -6950,8 +6950,8 @@ bool SimpleTitleFormatter::splitLines(const char * delimiter) {
     }
     if (bestpos < 0)
         return false;
-    _lines.add(_text.substr(0, bestpos + (skipDelimiter ? 0 : delim16.length())).trim());
-    _lines.add(_text.substr(bestpos + delim16.length()).trim());
+    _lines.add(_text.substr(0, bestpos + (skipDelimiter ? 0 : delim32.length())).trim());
+    _lines.add(_text.substr(bestpos + delim32.length()).trim());
     return measure();
 }
 bool SimpleTitleFormatter::format(int fontSize) {

--- a/crengine/src/lvfont.cpp
+++ b/crengine/src/lvfont.cpp
@@ -22,7 +22,7 @@ int LVFont::getVisualAligmentWidth() {
     if (_visual_alignment_width == -1) {
         //lChar32 chars[] = { getHyphChar(), ',', '.', '!', ':', ';', 0 };
         lChar32 chars[] = {getHyphChar(), ',', '.', '!', ':', ';',
-                           (lChar32) L'\xff0c', (lChar32) L'\x3302', (lChar32) L'\xff01', 0};
+                           (lChar32) U'\xff0c', (lChar32) U'\x3302', (lChar32) U'\xff01', 0};
         //                  (lChar32)U'，', (lChar32)U'。', (lChar32)U'！', 0 };
         //                  65292 12290 65281
         //                  ff0c 3002 ff01

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -1930,7 +1930,7 @@ LVImageSourceRef LVCreateNodeImageSource( ldomNode * node )
     if (stream.isNull())
         return ref;
 //    if ( CRLog::isDebugEnabled() ) {
-//        lUInt16 attr_id = node->getDocument()->getAttrNameIndex(L"id");
+//        lUInt16 attr_id = node->getDocument()->getAttrNameIndex(U"id");
 //        lString32 id = node->getAttributeValue(attr_id);
 //        CRLog::debug("Opening node image id=%s", LCSTR(id));
 //    }
@@ -2554,7 +2554,7 @@ void LVDrawBatteryIcon( LVDrawBuf * drawbuf, const lvRect & batteryRc, int perce
         if ( charging )
             txt = "+++";
         else
-            txt = lString32::itoa(percent); // + L"%";
+            txt = lString32::itoa(percent); // + U"%";
         int w = font->getTextWidth(txt.c_str(), txt.length());
         int h = font->getHeight();
         int x = (rc.left + rc.right - w)/2;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -9586,7 +9586,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     if ( pstyle->pseudo_elem_before_style ) {
         if ( pstyle->pseudo_elem_before_style->display != css_d_none
                 && pstyle->pseudo_elem_before_style->content.length() > 0
-                && pstyle->pseudo_elem_before_style->content[0] != L'X' ) {
+                && pstyle->pseudo_elem_before_style->content[0] != U'X' ) {
             // Not "display: none" and with "content:" different than "none":
             // this pseudo element can be generated
             requires_pseudo_element_before = true;
@@ -9597,7 +9597,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     if ( pstyle->pseudo_elem_after_style ) {
         if ( pstyle->pseudo_elem_after_style->display != css_d_none
                 && pstyle->pseudo_elem_after_style->content.length() > 0
-                && pstyle->pseudo_elem_after_style->content[0] != L'X' ) {
+                && pstyle->pseudo_elem_after_style->content[0] != U'X' ) {
             // Not "display: none" and with "content:" different than "none":
             // this pseudo element can be generated
             requires_pseudo_element_after = true;

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -106,7 +106,7 @@ const lString32 & cs32(const char * str) {
             return values_32[index];
         } else if (p == NULL) {
 #if DEBUG_STATIC_STRING_ALLOC == 1
-            CRLog::trace("allocating static string16 %s", str);
+            CRLog::trace("allocating static string32 %s", str);
 #endif
             const_ptrs_32[index] = str;
             size_32++;
@@ -122,7 +122,7 @@ const lString32 & cs32(const char * str) {
     return lString32::empty_str;
 }
 
-/// get reference to atomic constant wide string for string literal e.g. cs32(L"abc") -- fast and memory effective
+/// get reference to atomic constant wide string for string literal e.g. cs32(U"abc") -- fast and memory effective
 const lString32 & cs32(const lChar32 * str) {
     int index = (((int)((ptrdiff_t)str)) * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK;
     for (;;) {
@@ -131,7 +131,7 @@ const lString32 & cs32(const lChar32 * str) {
             return values_32[index];
         } else if (p == NULL) {
 #if DEBUG_STATIC_STRING_ALLOC == 1
-            CRLog::trace("allocating static string16 %s", LCSTR(str));
+            CRLog::trace("allocating static string32 %s", LCSTR(str));
 #endif
             const_ptrs_32[index] = str;
             size_32++;
@@ -4260,8 +4260,8 @@ lString32 ByteToUnicode( const lString8 & str, const lChar32 * table )
     buf.reserve( str.length() );
     for (int i=0; i < str.length(); i++) {
         lChar32 ch = (unsigned char)str[i];
-        lChar32 ch16 = ((ch & 0x80) && table) ? table[ (ch&0x7F) ] : ch;
-        buf += ch16;
+        lChar32 ch32 = ((ch & 0x80) && table) ? table[ (ch&0x7F) ] : ch;
+        buf += ch32;
     }
     return buf;
 }
@@ -5483,7 +5483,7 @@ void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int
     }
     start = hwStart;
     end = hwEnd;
-    //CRLog::debug("Word bounds: '%s'", LCSTR(lString16(str+start, end-start)));
+    //CRLog::debug("Word bounds: '%s'", LCSTR(lString32(str+start, end-start)));
 }
 
 void  lString16::limit( size_type sz )

--- a/crengine/src/lvstring32hashedcollection.cpp
+++ b/crengine/src/lvstring32hashedcollection.cpp
@@ -17,7 +17,7 @@
 static const char * str_hash_magic="STRS";
 
 /// serialize to byte array (pointer will be incremented by number of bytes written)
-void lString16HashedCollection::serialize( SerialBuf & buf )
+void lString32HashedCollection::serialize( SerialBuf & buf )
 {
     if ( buf.error() )
         return;
@@ -33,7 +33,7 @@ void lString16HashedCollection::serialize( SerialBuf & buf )
 }
 
 /// deserialize from byte array (pointer will be incremented by number of bytes read)
-bool lString16HashedCollection::deserialize( SerialBuf & buf )
+bool lString32HashedCollection::deserialize( SerialBuf & buf )
 {
     if ( buf.error() )
         return false;
@@ -53,7 +53,7 @@ bool lString16HashedCollection::deserialize( SerialBuf & buf )
     return !buf.error();
 }
 
-lString16HashedCollection::lString16HashedCollection( lString16HashedCollection & v )
+lString32HashedCollection::lString32HashedCollection( lString32HashedCollection & v )
 : lString32Collection( v )
 , hashSize( v.hashSize )
 , hash( NULL )
@@ -70,7 +70,7 @@ lString16HashedCollection::lString16HashedCollection( lString16HashedCollection 
     }
 }
 
-void lString16HashedCollection::addHashItem( int hashIndex, int storageIndex )
+void lString32HashedCollection::addHashItem( int hashIndex, int storageIndex )
 {
     if ( hash[ hashIndex ].index == -1 ) {
         hash[hashIndex].index = storageIndex;
@@ -82,7 +82,7 @@ void lString16HashedCollection::addHashItem( int hashIndex, int storageIndex )
     }
 }
 
-void lString16HashedCollection::clearHash()
+void lString32HashedCollection::clearHash()
 {
     if ( hash ) {
         for ( int i=0; i<hashSize; i++) {
@@ -98,7 +98,7 @@ void lString16HashedCollection::clearHash()
     hash = NULL;
 }
 
-lString16HashedCollection::lString16HashedCollection( lUInt32 hash_size )
+lString32HashedCollection::lString32HashedCollection( lUInt32 hash_size )
 : hashSize(hash_size), hash(NULL)
 {
 
@@ -107,12 +107,12 @@ lString16HashedCollection::lString16HashedCollection( lUInt32 hash_size )
         hash[i].clear();
 }
 
-lString16HashedCollection::~lString16HashedCollection()
+lString32HashedCollection::~lString32HashedCollection()
 {
     clearHash();
 }
 
-int lString16HashedCollection::find( const lChar32 * s )
+int lString32HashedCollection::find( const lChar32 * s )
 {
     if ( !hash || !length() )
         return -1;
@@ -133,7 +133,7 @@ int lString16HashedCollection::find( const lChar32 * s )
     return -1;
 }
 
-void lString16HashedCollection::reHash( int newSize )
+void lString32HashedCollection::reHash( int newSize )
 {
     if (hashSize == newSize)
         return;
@@ -151,7 +151,7 @@ void lString16HashedCollection::reHash( int newSize )
     }
 }
 
-int lString16HashedCollection::add( const lChar32 * s )
+int lString32HashedCollection::add( const lChar32 * s )
 {
     if ( !hash || hashSize < length()*2 ) {
         int sz = 16;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1076,8 +1076,8 @@ bool parse_content_property( const char * & str, lString32 & parsed_content)
     // data: its length (+1 to avoid NULLs in strings) and that data.
     // parsed_content may contain multiple values, in the format
     //   'X' for 'none' (or 'normal', = none with pseudo elements)
-    //   's' + <len> + string16 (string content) for ""
-    //   'a' + <len> + string16 (attribute name) for attr()
+    //   's' + <len> + string32 (string content) for ""
+    //   'a' + <len> + string32 (attribute name) for attr()
     //   'Q' for 'open-quote'
     //   'q' for 'close-quote'
     //   'N' for 'no-open-quote'
@@ -1106,22 +1106,22 @@ bool parse_content_property( const char * & str, lString32 & parsed_content)
             continue; // continue parsing
         }
         else if ( substr_icompare("open-quote", str) ) {
-            parsed_content << L'Q';
+            parsed_content << U'Q';
             needs_processing_when_applying = true;
             continue;
         }
         else if ( substr_icompare("close-quote", str) ) {
-            parsed_content << L'q';
+            parsed_content << U'q';
             needs_processing_when_applying = true;
             continue;
         }
         else if ( substr_icompare("no-open-quote", str) ) {
-            parsed_content << L'N';
+            parsed_content << U'N';
             needs_processing_when_applying = true;
             continue;
         }
         else if ( substr_icompare("no-close-quote", str) ) {
-            parsed_content << L'n';
+            parsed_content << U'n';
             needs_processing_when_applying = true;
             continue;
         }
@@ -1138,7 +1138,7 @@ bool parse_content_property( const char * & str, lString32 & parsed_content)
                     str++;
                     lString32 attr = Utf8ToUnicode(attr8);
                     attr.trim();
-                    parsed_content << L'a';
+                    parsed_content << U'a';
                     parsed_content << lChar32(attr.length() + 1); // (+1 to avoid storing \x00)
                     parsed_content << attr;
                     continue;
@@ -1158,7 +1158,7 @@ bool parse_content_property( const char * & str, lString32 & parsed_content)
                 }
                 if ( *str == ')' ) {
                     str++;
-                    parsed_content << L'u';
+                    parsed_content << U'u';
                     continue;
                 }
                 // No closing ')': invalid
@@ -1226,27 +1226,27 @@ bool parse_content_property( const char * & str, lString32 & parsed_content)
                 // (declaration or rule) in which the string was found."
             }
             if ( *str == quote_ch ) {
-                lString32 str16 = Utf8ToUnicode(str8);
-                parsed_content << L's';
-                parsed_content << lChar32(str16.length() + 1); // (+1 to avoid storing \x00)
-                parsed_content << str16;
+                lString32 str32 = Utf8ToUnicode(str8);
+                parsed_content << U's';
+                parsed_content << lChar32(str32.length() + 1); // (+1 to avoid storing \x00)
+                parsed_content << str32;
                 str++;
                 continue;
             }
         }
         else {
             // Not supported
-            parsed_content << L'z';
+            parsed_content << U'z';
             next_token(str);
         }
     }
     if ( has_none ) {
         // Forget all other tokens parsed
         parsed_content.clear();
-        parsed_content << L'X';
+        parsed_content << U'X';
     }
     else if ( needs_processing_when_applying ) {
-        parsed_content.insert(0, 1, L'$');
+        parsed_content.insert(0, 1, U'$');
     }
     if (*str) // something (;, } or !important) follows
         return true;
@@ -1268,7 +1268,7 @@ void update_style_content_property( css_style_rec_t * style, ldomNode * node ) {
     // But we need to resolve quotes, according to their nesting level,
     // and transform them into a litteral string 's'.
 
-    if ( style->content.empty() || style->content[0] != L'$' ) {
+    if ( style->content.empty() || style->content[0] != U'$' ) {
         // No update needed
         return;
     }
@@ -1328,12 +1328,12 @@ void update_style_content_property( css_style_rec_t * style, ldomNode * node ) {
         }
         else if ( ctype == 'Q' ) { // open-quote
             quote = lang_cfg->getOpeningQuote(visible);
-            res << L's' << quote.length() << quote;
+            res << U's' << quote.length() << quote;
             i += 1;
         }
         else if ( ctype == 'q' ) { // close-quote
             quote = lang_cfg->getClosingQuote(visible);
-            res << L's' << quote.length() << quote;
+            res << U's' << quote.length() << quote;
             i += 1;
         }
         else if ( ctype == 'N' ) { // no-open-quote

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1296,7 +1296,7 @@ public:
                             // Note: with a mix of normal spaces and non-break-spaces,
                             // we seem to behave just as Firefox.
                             // Note: for the empty lines or indentation we might add
-                            // with 'txform->AddSourceLine(L" "...)', we need to
+                            // with 'txform->AddSourceLine(U" "...)', we need to
                             // provide LTEXT_FLAG_PREFORMATTED if we don't want them
                             // to be collapsed.
                             m_flags[pos] = LCHAR_IS_COLLAPSED_SPACE | LCHAR_ALLOW_WRAP_AFTER;
@@ -2150,7 +2150,7 @@ public:
 //        // debug dump
 //        lString32 buf;
 //        for ( int i=0; i<m_length; i++ ) {
-//            buf << L" " << lChar32(m_text[i]) << L" " << lString32::itoa(m_widths[i]);
+//            buf << U" " << lChar32(m_text[i]) << U" " << lString32::itoa(m_widths[i]);
 //        }
 //        TR("%s", LCSTR(buf));
     }
@@ -2876,7 +2876,7 @@ public:
                                 // This is a bit hacky, but no other solution: just
                                 // replace that ignorable char with a space in the
                                 // src text
-                                *((lChar32 *) (m_srcs[wstart]->t.text + m_charindex[wstart])) = L' ';
+                                *((lChar32 *) (m_srcs[wstart]->t.text + m_charindex[wstart])) = U' ';
                             }
                         }
                         else { // Last or single para with no word

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -310,7 +310,7 @@ public:
         return _text;
     }
 
-    lString32 getText16()
+    lString32 getText32()
     {
         return Utf8ToUnicode(_text);
     }
@@ -3965,7 +3965,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
             // settings) says hyphenation is allowed.
             // We do that here while we output the text to avoid the need
             // for temporary storage of a string with soft-hyphens added.
-            const lChar32 * text16 = txt.c_str();
+            const lChar32 * text32 = txt.c_str();
             int txtlen = txt.length();
             lUInt8 * flags = (lUInt8*)calloc(txtlen, sizeof(*flags));
             lUInt16 widths[HYPH_MAX_WORD_SIZE] = { 0 }; // array needed by hyphenate()
@@ -3977,7 +3977,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
                 // (or the previous word if wordpos happens to be a space or some
                 // punctuation) by looking only for alpha chars in m_text.
                 int start, end;
-                lStr_findWordBounds( text16, txtlen, wordpos, start, end );
+                lStr_findWordBounds( text32, txtlen, wordpos, start, end );
                 if ( end <= HYPH_MIN_WORD_LEN_TO_HYPHENATE ) {
                     // Too short word at start, we're done
                     break;
@@ -3999,7 +3999,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
                 // Have hyphenate() set flags inside 'flags'
                 // (Fetching the lang_cfg for each text node is not really cheap, but
                 // it's easier than having to pass it to each writeNodeEx())
-                TextLangMan::getTextLangCfg(node)->getHyphMethod()->hyphenate(text16+start, len, widths, flags+start, 0, 0xFFFF, 1);
+                TextLangMan::getTextLangCfg(node)->getHyphMethod()->hyphenate(text32+start, len, widths, flags+start, 0, 0xFFFF, 1);
                 // Continue with previous word
                 wordpos = start - 1;
             }
@@ -5155,7 +5155,7 @@ static lString32 getSectionHeader( ldomNode * section )
     ldomNode * child = section->getChildElementNode(0, U"title");
     if ( !child )
         return header;
-    header = child->getText(L' ', 1024);
+    header = child->getText(U' ', 1024);
     return header;
 }
 
@@ -11946,7 +11946,7 @@ bool ldomXPointerEx::isSentenceStart()
             case '.':
             case '?':
             case '!':
-            case L'\x2026': // horizontal ellypsis
+            case U'\x2026': // horizontal ellypsis
                 return false;
         }
     }
@@ -11957,7 +11957,7 @@ bool ldomXPointerEx::isSentenceStart()
         case '.':
         case '?':
         case '!':
-        case L'\x2026': // horizontal ellypsis
+        case U'\x2026': // horizontal ellypsis
             return true;
         default:
             return false;
@@ -11985,7 +11985,7 @@ bool ldomXPointerEx::isSentenceEnd()
         case '.':
         case '?':
         case '!':
-        case L'\x2026': // horizontal ellypsis
+        case U'\x2026': // horizontal ellypsis
             return true;
         default:
             break;
@@ -16542,7 +16542,7 @@ lString32 ldomNode::getText( lChar32 blockDelimiter, int maxSize ) const
         return Utf8ToUnicode(getDocument()->_textStorage.getText( _data._ptext_addr ));
 #endif
     case NT_TEXT:
-        return _data._text_ptr->getText16();
+        return _data._text_ptr->getText32();
     }
     return lString32::empty_str;
 }

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5496,7 +5496,7 @@ void ExpandTabs(lString32 & buf, const lChar32 * str, int len)
             int delta = 8 - (x & 7);
             x += delta;
             while ( delta-- )
-                buf << L' ';
+                buf << U' ';
         } else {
             buf << ch;
             x++;
@@ -5929,7 +5929,7 @@ lString32 LVReadTextFile( LVStreamRef stream )
     while ( !reader.Eof() ) {
         lString32 line = reader.ReadLine( 4096, flags );
         if ( !buf.empty() )
-            buf << L'\n';
+            buf << U'\n';
         if ( !line.empty() ) {
             buf << line;
         }

--- a/crengine/src/odtfmt.cpp
+++ b/crengine/src/odtfmt.cpp
@@ -52,7 +52,7 @@
 #define ODT_TAG_NAME(itm) odt_el_##itm##_name
 #define ODT_TAG_ID(itm) odt_el_##itm
 #define ODT_TAG_CHILD(itm) { ODT_TAG_ID(itm), ODT_TAG_NAME(itm) }
-#define ODT_TAG_CHILD2(itm, name) { ODT_TAG_ID(itm), L ## name }
+#define ODT_TAG_CHILD2(itm, name) { ODT_TAG_ID(itm), U ## name }
 #define ODT_LAST_ITEM { -1, NULL }
 
 enum {
@@ -339,8 +339,8 @@ private:
         ldomNode* notes = m_writer->OnTagOpen(U"", U"body");
         m_writer->OnAttribute(U"", U"name", notesKind);
 #else
-        ldomNode* notes = m_writer->OnTagOpen(L"", U"div");
-        m_writer->OnAttribute(L"", U"style", U"page-break-before: always");
+        ldomNode* notes = m_writer->OnTagOpen(U"", U"div");
+        m_writer->OnAttribute(U"", U"style", U"page-break-before: always");
 #endif
         m_writer->OnTagBody();
         return notes;
@@ -351,7 +351,7 @@ private:
 #ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
         writer.OnTagClose(U"", U"body");
 #else
-        writer.OnTagClose(L"", U"div");
+        writer.OnTagClose(U"", U"div");
 #endif
         writer.OnStop();
         parent->moveItemsTo(m_body->getParentNode(), index, index);
@@ -502,10 +502,10 @@ void odt_documentHandler::startParagraph()
     m_writer->OnTagBody();
 #ifndef DOCX_FB2_DOM_STRUCTURE
     if(m_state == odt_el_noteBody) {
-        m_writer->OnTagOpen(L"", U"sup");
+        m_writer->OnTagOpen(U"", U"sup");
         m_writer->OnTagBody();
         m_writer->OnText(m_noteRefText.c_str(), m_noteRefText.length(), 0);
-        m_writer->OnTagClose(L"", U"sup");
+        m_writer->OnTagClose(U"", U"sup");
     }
 #endif
     m_paragraphStarted = true;

--- a/crengine/src/private/lvbitmapfont.cpp
+++ b/crengine/src/private/lvbitmapfont.cpp
@@ -75,7 +75,7 @@ lUInt32 LBitmapFont::getTextWidth( const lChar32 * text, int len, TextLangCfg * 
                     widths,
                     flags,
                     2048, // max_width,
-                    L' ',  // def_char
+                    U' ',  // def_char
                     lang_cfg
                  );
     if ( res>0 && res<MAX_LINE_CHARS )

--- a/crengine/src/private/lvfontboldtransform.cpp
+++ b/crengine/src/private/lvfontboldtransform.cpp
@@ -87,7 +87,7 @@ lUInt32 LVFontBoldTransform::getTextWidth(const lChar32 *text, int len, TextLang
             widths,
             flags,
             2048, // max_width,
-            L' ',  // def_char
+            U' ',  // def_char
             0
     );
     if (res > 0 && res < MAX_LINE_CHARS)

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -1742,7 +1742,7 @@ lUInt32 LVFreeTypeFace::getTextWidth(const lChar32 *text, int len, TextLangCfg *
             widths,
             flags,
             MAX_LINE_WIDTH,
-            L' ',  // def_char
+            U' ',  // def_char
             lang_cfg,
             0
     );

--- a/crengine/src/private/lvwin32font.cpp
+++ b/crengine/src/private/lvwin32font.cpp
@@ -171,7 +171,7 @@ lUInt32 LVWin32DrawFont::getTextWidth( const lChar32 * text, int len, TextLangCf
                     widths,
                     flags,
                     MAX_LINE_WIDTH,
-                    L' ',  // def_char
+                    U' ',  // def_char
                     lang_cfg
                  );
     if ( res>0 && res<MAX_LINE_CHARS )
@@ -311,7 +311,7 @@ int LVWin32DrawFont::DrawTextString( LVDrawBuf * buf, int x, int y,
     // substitute soft hyphens with zero width spaces
     if (addHyphen)
         str += UNICODE_SOFT_HYPHEN_CODE;
-    //str += L"       ";
+    //str += U"       ";
     lChar32 * pstr = str.modify();
     for (int i=0; i<len-1; i++)
     {
@@ -542,7 +542,7 @@ lUInt32 LVWin32Font::getTextWidth( const lChar32 * text, int len, TextLangCfg * 
                     widths,
                     flags,
                     MAX_LINE_WIDTH,
-                    L' ',  // def_char
+                    U' ',  // def_char
                     lang_cfg
                  );
     if ( res>0 && res<MAX_LINE_CHARS )

--- a/crengine/src/private/lvwin32fontman.cpp
+++ b/crengine/src/private/lvwin32fontman.cpp
@@ -178,7 +178,7 @@ int CALLBACK LVWin32FontEnumFontFamExProc(
             for (int i=0; chars[i]; i++)
             {
                 LVFont::glyph_info_t glyph;
-                if (!fnt.getGlyphInfo( chars[i], &glyph, L' ' )) //def_char
+                if (!fnt.getGlyphInfo( chars[i], &glyph, U' ' )) //def_char
                     return 1;
             }
             fontman->RegisterFont( lf ); //&lpelfe->elfLogFont

--- a/crengine/src/rtfimp.cpp
+++ b/crengine/src/rtfimp.cpp
@@ -430,9 +430,9 @@ void LVRtfParser::CommitText()
 
 void LVRtfParser::AddChar8( lUInt8 ch )
 {
-    lChar32 ch16 = m_stack.byteToUnicode(ch);
-    if ( ch16 )
-        AddChar( ch16 );
+    lChar32 ch32 = m_stack.byteToUnicode(ch);
+    if ( ch32 )
+        AddChar( ch32 );
 }
 
 // m_buf_pos points to first byte of char
@@ -463,7 +463,7 @@ static int charToHex( lUInt8 ch )
 /// parses input stream
 bool LVRtfParser::Parse()
 {
-    //m_conv_table = GetCharsetByte2UnicodeTable( L"cp1251" );
+    //m_conv_table = GetCharsetByte2UnicodeTable( U"cp1251" );
 
     bool errorFlag = false;
     m_callback->OnStart(this);


### PR DESCRIPTION
Continued refactoring of string classes, forgotten parts.
* Removed declaration of some unimplemented functions of the lString16 class, implementation added for other functions. The lString16HashedCollection class has been renamed to lString32HashedCollection.
* Replaced some forgotten string constants L'', L"" with U'', U"", and renamed some lString32 variable names with prefix 16. Mainly based on https://github.com/koreader/crengine/issues/389#issuecomment-717259113

Also see PR #183.