### PR TITLE
Bugfixes

### DIFF
--- a/android/src/org/coolreader/crengine/BookInfoEditDialog.java
+++ b/android/src/org/coolreader/crengine/BookInfoEditDialog.java
@@ -426,6 +426,17 @@ public class BookInfoEditDialog extends BaseDialog {
 		} else if (KeyEvent.KEYCODE_PAGE_UP == keyCode) {
 			scrollView.pageScroll(View.FOCUS_UP);
 			return true;
+		} else if (KeyEvent.KEYCODE_BACK == keyCode) {
+			return true;
+		}
+		return super.onKeyDown(keyCode, event);
+	}
+
+	@Override
+	public boolean onKeyUp(int keyCode, KeyEvent event) {
+		if (KeyEvent.KEYCODE_BACK == keyCode) {
+			dismiss();
+			return true;
 		}
 		return super.onKeyDown(keyCode, event);
 	}

--- a/android/src/org/coolreader/crengine/BrowserViewLayout.java
+++ b/android/src/org/coolreader/crengine/BrowserViewLayout.java
@@ -155,11 +155,10 @@ public class BrowserViewLayout extends ViewGroup {
 			L.v("BrowserViewLayout.onKeyUp(" + keyCode + ") duration = " + duration);
 			if (duration > 700 && duration < 10000) {
 				activity.finish();
-				return true;
 			} else {
 				contentView.showParentDirectory();
-				return true;
 			}
+			return true;
 		}
 		if (contentView.onKeyUp(keyCode, event))
 			return true;

--- a/android/src/org/coolreader/crengine/CRToolBar.java
+++ b/android/src/org/coolreader/crengine/CRToolBar.java
@@ -408,7 +408,7 @@ public class CRToolBar extends ViewGroup {
 	    		View separator = new View(activity);
 	    		separator.setBackgroundResource(activity.getCurrentTheme().getBrowserStatusBackground());
 	    		addView(separator);
-	    		separator.layout(bottom - windowDividerHeight, top, right, bottom);
+	    		separator.layout(left, bottom - windowDividerHeight, right, bottom);
         	}
     		//popup.
     		if (lastButtonIndex > 0)

--- a/android/src/org/coolreader/crengine/FileBrowser.java
+++ b/android/src/org/coolreader/crengine/FileBrowser.java
@@ -732,25 +732,29 @@ public class FileBrowser extends LinearLayout implements FileInfoChangeListener 
 	
 	private class ItemGroupsLoadingCallback implements CRDBService.ItemGroupsLoadingCallback {
 		private final FileInfo baseDir;
-		public ItemGroupsLoadingCallback(FileInfo baseDir) {
+		private final FileInfo itemToSelect;
+		public ItemGroupsLoadingCallback(FileInfo baseDir, FileInfo itemToSelect) {
 			this.baseDir = baseDir;
+			this.itemToSelect = itemToSelect;
 		}
 		@Override
 		public void onItemGroupsLoaded(FileInfo parent) {
 			baseDir.setItems(parent);
-			showDirectoryInternal(baseDir, null);
+			showDirectoryInternal(baseDir, itemToSelect);
 		}
 	};
 	
 	private class FileInfoLoadingCallback implements CRDBService.FileInfoLoadingCallback {
 		private final FileInfo baseDir;
-		public FileInfoLoadingCallback(FileInfo baseDir) {
+		private final FileInfo itemToSelect;
+		public FileInfoLoadingCallback(FileInfo baseDir, FileInfo itemToSelect) {
 			this.baseDir = baseDir;
+			this.itemToSelect = itemToSelect;
 		}
 		@Override
 		public void onFileInfoListLoaded(ArrayList<FileInfo> list) {
 			baseDir.setItems(list);
-			showDirectoryInternal(baseDir, null);
+			showDirectoryInternal(baseDir, itemToSelect);
 		}
 	};
 	
@@ -818,60 +822,60 @@ public class FileBrowser extends LinearLayout implements FileInfoChangeListener 
 			if (fileOrDir.isBooksByGenreRoot()) {
 				// Display genres list
 				log.d("Show genres list");
-				mActivity.getDB().loadGenresList(fileOrDir, !mHideEmptyGenres, new ItemGroupsLoadingCallback(fileOrDir));
+				mActivity.getDB().loadGenresList(fileOrDir, !mHideEmptyGenres, new ItemGroupsLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksByAuthorRoot()) {
 				// refresh authors list
 				log.d("Updating authors list");
-				mActivity.getDB().loadAuthorsList(fileOrDir, new ItemGroupsLoadingCallback(fileOrDir));
+				mActivity.getDB().loadAuthorsList(fileOrDir, new ItemGroupsLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksBySeriesRoot()) {
 				// refresh authors list
 				log.d("Updating series list");
-				mActivity.getDB().loadSeriesList(fileOrDir, new ItemGroupsLoadingCallback(fileOrDir));
+				mActivity.getDB().loadSeriesList(fileOrDir, new ItemGroupsLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksByRatingRoot()) {
 				log.d("Updating rated books list");
-				mActivity.getDB().loadBooksByRating(1, 10, new FileInfoLoadingCallback(fileOrDir));
+				mActivity.getDB().loadBooksByRating(1, 10, new FileInfoLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksByStateFinishedRoot()) {
 				log.d("Updating books by state=finished");
-				mActivity.getDB().loadBooksByState(FileInfo.STATE_FINISHED, new FileInfoLoadingCallback(fileOrDir));
+				mActivity.getDB().loadBooksByState(FileInfo.STATE_FINISHED, new FileInfoLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksByStateReadingRoot()) {
 				log.d("Updating books by state=reading");
-				mActivity.getDB().loadBooksByState(FileInfo.STATE_READING, new FileInfoLoadingCallback(fileOrDir));
+				mActivity.getDB().loadBooksByState(FileInfo.STATE_READING, new FileInfoLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksByStateToReadRoot()) {
 				log.d("Updating books by state=toRead");
-				mActivity.getDB().loadBooksByState(FileInfo.STATE_TO_READ, new FileInfoLoadingCallback(fileOrDir));
+				mActivity.getDB().loadBooksByState(FileInfo.STATE_TO_READ, new FileInfoLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksByTitleRoot()) {
 				// refresh authors list
 				log.d("Updating title list");
-				mActivity.getDB().loadTitleList(fileOrDir, new ItemGroupsLoadingCallback(fileOrDir));
+				mActivity.getDB().loadTitleList(fileOrDir, new ItemGroupsLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksByGenreDir()) {
 				log.d("Updating genres book list");
-				mActivity.getDB().loadGenresBooks(fileOrDir.getGenreCode(), !mHideEmptyGenres, new FileInfoLoadingCallback(fileOrDir));
+				mActivity.getDB().loadGenresBooks(fileOrDir.getGenreCode(), !mHideEmptyGenres, new FileInfoLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksByAuthorDir()) {
 				log.d("Updating author book list");
-				mActivity.getDB().loadAuthorBooks(fileOrDir.getAuthorId(), new FileInfoLoadingCallback(fileOrDir));
+				mActivity.getDB().loadAuthorBooks(fileOrDir.getAuthorId(), new FileInfoLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 			if (fileOrDir.isBooksBySeriesDir()) {
 				log.d("Updating series book list");
-				mActivity.getDB().loadSeriesBooks(fileOrDir.getSeriesId(), new FileInfoLoadingCallback(fileOrDir));
+				mActivity.getDB().loadSeriesBooks(fileOrDir.getSeriesId(), new FileInfoLoadingCallback(fileOrDir, itemToSelect));
 				return;
 			}
 		} else {
@@ -1291,9 +1295,7 @@ public class FileBrowser extends LinearLayout implements FileInfoChangeListener 
 		if ( !BackgroundThread.isGUIThread() )
 			throw new IllegalStateException("showDirectoryInternal should be called from GUI thread!");
 		int index = dir!=null ? dir.getItemIndex(file) : -1;
-		if ( dir!=null && !dir.isRootDir() )
-			index++;
-		
+
 		String title = "";
 		if (dir != null) {
 			title = dir.filename;


### PR DESCRIPTION
* Fixed the problem of not returning to the previous position of an element in the genre list (and other pseudo-directories)    when navigating back in the internal file manager.

Oldest bugs:
* Fixed a bug in the dialog for editing book information: if this dialog was opened from the internal file manager, then pressing the soft on-screen "back" button (and maybe a hardware "back" key) after closing this dialog also forces the file manager to go to the parent folder.
* Fixed incorrect background in toolbar popup menu:
Before/After:
![Screenshot_1605326742](https://user-images.githubusercontent.com/36960933/99139658-4c0d9900-2654-11eb-8b98-225655e5a622.gif)

