### PR TITLE
Make Find dialog non-modal

### DIFF
--- a/cr3qt/src/searchdlg.cpp
+++ b/cr3qt/src/searchdlg.cpp
@@ -14,11 +14,9 @@
 bool SearchDialog::showDlg( QWidget * parent, CR3View * docView )
 {
     SearchDialog * dlg = new SearchDialog( parent, docView );
-    dlg->setModal( true );
     dlg->show();
     dlg->raise();
     dlg->activateWindow();
-    //dlg->
     return true;
 }
 

--- a/cr3qt/src/searchdlg.cpp
+++ b/cr3qt/src/searchdlg.cpp
@@ -11,12 +11,16 @@
 #include "searchdlg.h"
 #include "ui_searchdlg.h"
 
+SearchDialog* SearchDialog::_instance = NULL;
+
 bool SearchDialog::showDlg( QWidget * parent, CR3View * docView )
 {
-    SearchDialog * dlg = new SearchDialog( parent, docView );
-    dlg->show();
-    dlg->raise();
-    dlg->activateWindow();
+    if (NULL == _instance) {
+        _instance = new SearchDialog( parent, docView );
+    }
+    _instance->show();
+    _instance->raise();
+    _instance->activateWindow();
     return true;
 }
 
@@ -25,6 +29,7 @@ SearchDialog::SearchDialog(QWidget *parent, CR3View * docView) :
     ui(new Ui::SearchDialog),
     _docview( docView )
 {
+    setAttribute(Qt::WA_DeleteOnClose, true);
     ui->setupUi(this);
     ui->cbCaseSensitive->setCheckState(Qt::Unchecked);
     ui->rbForward->toggle();
@@ -45,6 +50,13 @@ void SearchDialog::changeEvent(QEvent *e)
     default:
         break;
     }
+}
+
+void SearchDialog::closeEvent(QCloseEvent* e) {
+    QDialog::closeEvent(e);
+    // this dialog instance will be deleted by Qt because
+    // we set the WA_DeleteOnClose attribute for this window to true.
+    SearchDialog::_instance = NULL;
 }
 
 bool SearchDialog::findText( lString32 pattern, int origin, bool reverse, bool caseInsensitive )

--- a/cr3qt/src/searchdlg.h
+++ b/cr3qt/src/searchdlg.h
@@ -13,19 +13,19 @@ class CR3View;
 class SearchDialog : public QDialog {
     Q_OBJECT
 public:
-    SearchDialog(QWidget *parent, CR3View * docView);
-    ~SearchDialog();
-
     static bool showDlg( QWidget * parent, CR3View * docView );
-
     bool findText( lString32 pattern, int origin, bool reverse, bool caseInsensitive );
 protected:
+    SearchDialog(QWidget *parent, CR3View * docView);
+    ~SearchDialog();
     void changeEvent(QEvent *e);
+    void closeEvent(QCloseEvent* e);
 
 private:
     Ui::SearchDialog *ui;
     CR3View * _docview;
     lString32 _lastPattern;
+    static SearchDialog* _instance;
 private slots:
     void on_btnFindNext_clicked();
     void on_btnClose_clicked();

--- a/cr3qt/src/searchdlg.ui
+++ b/cr3qt/src/searchdlg.ui
@@ -2,9 +2,6 @@
 <ui version="4.0">
  <class>SearchDialog</class>
  <widget class="QDialog" name="SearchDialog">
-  <property name="windowModality">
-   <enum>Qt::ApplicationModal</enum>
-  </property>
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
I find that the modality on this dialog is unnecessarily restrictive. When non-modal the dialog operates just fine and stays on top, and allows me to make multiple searches and **copy text from the document** without having to constantly close and re-open the dialog.

My use case is I make a list of bookmarks for important passages for a book on a piece of paper, then search for the bookmarks later and copy quotes from the book into a document where I write down my analysis. If the window is modal I cannot select the text.

Another thing is when the window is modal and you search for something it may be found on a line at the top of the screen, such that you cannot see the context above. When the dialog is modal you cannot scroll up to see the context: you must close the dialog which is a hassle.

PS: Thank you for this great reader :)