### PR TITLE
Don't render 'WORD JOINER' character if no such glyph

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -26,6 +26,7 @@
 /// Unicode spaces
 #define UNICODE_NO_BREAK_SPACE            0x00A0
 #define UNICODE_ZERO_WIDTH_NO_BREAK_SPACE 0xfeff
+#define UNICODE_WORD_JOINER      0x2060
 // All chars from U+2000 to U+200B allow wrap after, except U+2007
 #define UNICODE_EN_QUAD          0x2000
 #define UNICODE_FIGURE_SPACE     0x2007

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -2825,7 +2825,7 @@ int lString8::pos(const lString8 & subStr, int startPos) const
 }
 
 int lString32::pos(lChar32 ch) const {
-    for (int i = 0; i <= length(); i++)
+    for (int i = 0; i < length(); i++)
     {
         if (pchunk->buf32[i] == ch)
         {
@@ -2839,7 +2839,7 @@ int lString32::pos(lChar32 ch, int start) const
 {
     if (length() - start < 1)
         return -1;
-    for (int i = start; i <= length(); i++)
+    for (int i = start; i < length(); i++)
     {
         if (pchunk->buf32[i] == ch)
         {

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -69,7 +69,7 @@ extern lString8 familyName(FT_Face face);
 
 inline int myabs(int n) { return n < 0 ? -n : n; }
 
-static lChar32 getReplacementChar(lUInt32 code) {
+static lChar32 getReplacementChar(lUInt32 code, bool * can_be_ignored = NULL) {
     switch (code) {
         case UNICODE_SOFT_HYPHEN_CODE:
             return '-';
@@ -80,8 +80,12 @@ static lChar32 getReplacementChar(lUInt32 code) {
         case UNICODE_NO_BREAK_SPACE:
             return ' ';
         case UNICODE_WORD_JOINER:
+            if (can_be_ignored)
+                *can_be_ignored = true;
             return UNICODE_ZERO_WIDTH_SPACE;
         case UNICODE_ZERO_WIDTH_SPACE:
+            if (can_be_ignored)
+                *can_be_ignored = true;
             // If the font lacks a zero-width breaking space glyph (like
             // some Kindle built-ins) substitute a different zero-width
             // character instead of one with width.
@@ -865,15 +869,16 @@ FT_UInt LVFreeTypeFace::getCharIndex(lUInt32 code, lChar32 def_char) {
         }
     }
     if ( ch_glyph_index==0 ) {
-        lUInt32 replacement = getReplacementChar( code );
+        bool can_be_ignored = false;
+        lUInt32 replacement = getReplacementChar( code, &can_be_ignored );
         if ( replacement )
             ch_glyph_index = FT_Get_Char_Index( _face, replacement );
-        if ( ch_glyph_index==0 && UNICODE_WORD_JOINER == code )
-            // if neither char index nor replacement char for 0x2060 (WORD JOINER) is found,
-            // just skip it so as not to draw the replacement char
-            ;
-        else if ( ch_glyph_index==0 && def_char )
+        if ( ch_glyph_index==0 && def_char && !can_be_ignored ) {
+            // if neither the index of this character nor the index of the replacement character is found,
+            // and if this character can be safely ignored,
+            // we simply skip it so as not to draw the unnecessary replacement character.
             ch_glyph_index = FT_Get_Char_Index( _face, def_char );
+        }
     }
     return ch_glyph_index;
 }

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -79,6 +79,8 @@ static lChar32 getReplacementChar(lUInt32 code) {
             return 0x0435; // CYRILLIC SMALL LETTER IE
         case UNICODE_NO_BREAK_SPACE:
             return ' ';
+        case UNICODE_WORD_JOINER:
+            return UNICODE_ZERO_WIDTH_SPACE;
         case UNICODE_ZERO_WIDTH_SPACE:
             // If the font lacks a zero-width breaking space glyph (like
             // some Kindle built-ins) substitute a different zero-width
@@ -866,7 +868,11 @@ FT_UInt LVFreeTypeFace::getCharIndex(lUInt32 code, lChar32 def_char) {
         lUInt32 replacement = getReplacementChar( code );
         if ( replacement )
             ch_glyph_index = FT_Get_Char_Index( _face, replacement );
-        if ( ch_glyph_index==0 && def_char )
+        if ( ch_glyph_index==0 && UNICODE_WORD_JOINER == code )
+            // if neither char index nor replacement char for 0x2060 (WORD JOINER) is found,
+            // just skip it so as not to draw the replacement char
+            ;
+        else if ( ch_glyph_index==0 && def_char )
             ch_glyph_index = FT_Get_Char_Index( _face, def_char );
     }
     return ch_glyph_index;


### PR DESCRIPTION
* Fix index out of range in lString32::pos(lChar32) introduced in cc51fc6ff1336bc87ebaf146ee04b18207331d4a
* Do not render the Unicode character 'WORD JOINER' (U + 2060) as a replacement character if the font does not have a corresponding glyph for it in SHAPING_MODE_HARFBUZZ_LIGHT and SHAPING_MODE_FREETYPE shaping modes. Otherwise, it results in a question mark appearing in footnote number.
This symbol is embedded in the text after the d2369334b610f75504bc80cc0697cc19314710f0 commit.
See https://github.com/koreader/crengine/pull/385, https://github.com/koreader/koreader/issues/6718#issuecomment-699600019
![Screenshot_20201122_163648-m](https://user-images.githubusercontent.com/36960933/99903945-21b97c80-2ce1-11eb-9b08-66ca8ee09695.png)
