### PR TITLE
Minor fixes

### DIFF
--- a/android/jni/cr3engine.cpp
+++ b/android/jni/cr3engine.cpp
@@ -319,7 +319,7 @@ static bool GetBookProperties(const char *name,  BookProperties * pBookProps)
     }
     if ( DetectFb3Format( stream ) ) {
         CRLog::trace("GetBookProperties() : fb3 format detected");
-        pBookProps->format = doc_format_fb2;
+        pBookProps->format = doc_format_fb3;
         return GetFB3BookProperties( name, stream, pBookProps );
     }
 	if ( DetectDocXFormat( stream ) ) {

--- a/android/src/org/coolreader/crengine/FileInfo.java
+++ b/android/src/org/coolreader/crengine/FileInfo.java
@@ -7,6 +7,7 @@ import org.coolreader.plugins.OnlineStoreBook;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -1203,11 +1204,12 @@ public class FileInfo {
 				return false;
 		} else if (!language.equals(other.language))
 			return false;
-		if (genres == null) {
-			if (other.genres != null)
-				return false;
-		} else if (!genres.equals(other.genres))
+		// do not compare genres of books, because in the absence of certain genres in the handbook,
+		// the 'genres' field obtained from the database will not be equal to the field obtained when parsing the book file.
+		/*
+		if (!eqGenre(genres, other.genres))
 			return false;
+		*/
 		if (description == null) {
 			if (other.description != null)
 				return false;
@@ -1288,11 +1290,12 @@ public class FileInfo {
 				return false;
 		} else if (!language.equals(other.language))
 			return false;
-		if (genres == null) {
-			if (other.genres != null)
-				return false;
-		} else if (!genres.equals(other.genres))
+		// do not compare genres of books, because in the absence of certain genres in the handbook,
+		// the 'genres' field obtained from the database will not be equal to the field obtained when parsing the book file.
+		/*
+		if (!eqGenre(genres, other.genres))
 			return false;
+		*/
 		if (description == null) {
 			if (other.description != null)
 				return false;
@@ -1325,6 +1328,23 @@ public class FileInfo {
 		if (crc32 != other.crc32)
 			return false;
 		return true;
+	}
+
+	private static boolean eqGenre(String g1, String g2) {
+		if (g1 == null) {
+			if (g2 != null && g2.length() != 0)
+				return false;
+		}
+		if (g1.equals(g2))
+			return true;
+		String[] g1_array = g1.split("\\|");
+		String[] g2_array = g2.split("\\|");
+		if (g1_array.length == g2_array.length) {
+			Arrays.sort(g1_array);
+			Arrays.sort(g2_array);
+			return Arrays.equals(g1_array, g2_array);
+		}
+		return false;
 	}
 
 	@Override

--- a/cr3qt/src/recentdlg.cpp
+++ b/cr3qt/src/recentdlg.cpp
@@ -29,15 +29,19 @@ RecentBooksDlg::RecentBooksDlg(QWidget *parent, CR3View * docView ) :
     m_ui->tableWidget->setEditTriggers( QAbstractItemView::NoEditTriggers );
     //m_ui->tableWidget->setVerticalHeader( NULL );
     //m_ui->tableWidget->setHorizontalHeader(new QHeaderView(;
-    docView->getDocView()->savePosition(); // to move current file to top
-    LVPtrVector<CRFileHistRecord> & files = docView->getDocView()->getHistory()->getRecords();
+    LVDocView* lvdocview = docView->getDocView();
+    lvdocview->savePosition(); // to move current file to top
+    LVPtrVector<CRFileHistRecord> & files = lvdocview->getHistory()->getRecords();
     // skip Null
-    m_ui->tableWidget->setRowCount(files.length()-1);
+    int firstItem = lvdocview->isDocumentOpened() ? 1 : 0;
+    int rowCount = files.length() - firstItem;
+    if (rowCount < 0)
+        rowCount = 0;
+    m_ui->tableWidget->setRowCount(rowCount);
     m_ui->tableWidget->setWordWrap(false);
     m_ui->tableWidget->setSelectionMode(QAbstractItemView::SingleSelection);
     m_ui->tableWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_ui->tableWidget->setSortingEnabled(true);
-    int firstItem = docView->getDocView()->isDocumentOpened() ? 1 : 0;
     for ( int i=firstItem; i<files.length(); i++ ) {
         CRFileHistRecord * book = files.get( i );
         lString32 author = book->getAuthor();

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -4300,8 +4300,8 @@ lString8 UnicodeToLocal( const lString32 & str )
    if (str.empty())
       return dst;
    lString16 utf16 = UnicodeToUtf16(str);
-   char def_char[]="?";
-   int usedDefChar = false;
+   CHAR def_char = '?';
+   BOOL usedDefChar = FALSE;
    int len = WideCharToMultiByte(
       CP_ACP,
       WC_COMPOSITECHECK | WC_DISCARDNS
@@ -4310,7 +4310,7 @@ lString8 UnicodeToLocal( const lString32 & str )
       utf16.length(),
       NULL,
       0,
-      def_char,
+      &def_char,
       &usedDefChar
       );
    if (len)
@@ -4324,7 +4324,7 @@ lString8 UnicodeToLocal( const lString32 & str )
          utf16.length(),
          dst.modify(),
          len,
-         def_char,
+         &def_char,
          &usedDefChar
          );
    }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1198,7 +1198,7 @@ bool parse_content_property( const char * & str, lString32 & parsed_content)
                         // Serialize it as UTF-8
                         lString32 c;
                         c << (lChar32)codepoint;
-                        str8 << UnicodeToLocal(c);
+                        str8 << UnicodeToUtf8(c);
                     }
                     else if ( *str == '\r' && *(str+1) == '\n' ) {
                         // Ignore \ at end of CRLF line

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -73,7 +73,9 @@
 #define FLT_ALLOC_SIZE 4
 
 // lvfreetypeface.cpp
+#if USE_HARFBUZZ==1
 extern bool isHBScriptCursive( hb_script_t script );
+#endif
 
 formatted_line_t * lvtextAllocFormattedLine( )
 {


### PR DESCRIPTION
* Android: FileInfo.equals(): do not compare genres of books, because in the absence of certain genres in the handbook, the 'genres' field obtained from the database will not be equal to the field obtained when parsing the book file.
* Android: optimized database structure to exclude duplicate genre entries in the book description.
* Win32 fixes: do not use UnicodeToLocal() where UnicodeToUtf8() should be used, otherwise, when parsing css, characters are not contained in CP_ACP encoding (https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte) will be replaced with some default char, in this case '?', which is not allowed.
And without this fix on Win32, unnecessary сhar '?' appears before the footnote number, see PR #200.
* Desktop/Qt5: fixed SIGSEGV when opening recent files dialog if no document is currently open.