### PR TITLE
Convert USE_FREETYPE to a boolean macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - sudo ln -s /usr/include/freetype2/ft2build.h /usr/include/ # https://github.com/matplotlib/matplotlib/issues/3029#issuecomment-43318941
   - mkdir qtbuild
   - cd qtbuild
-  - cmake -DGUI=QT5 -DCMAKE_CXX_FLAGS="-DUSE_FREETYPE2" -DCMAKE_BUILD_TYPE=Release -DMAX_IMAGE_SCALE_MUL=2 -DDOC_DATA_COMPRESSION_LEVEL=3 -DDOC_BUFFER_SIZE=0x1400000 -DCMAKE_INSTALL_PREFIX=/usr ..
+  - cmake -DGUI=QT5 -DCMAKE_CXX_FLAGS="-DUSE_FREETYPE=1" -DCMAKE_BUILD_TYPE=Release -DMAX_IMAGE_SCALE_MUL=2 -DDOC_DATA_COMPRESSION_LEVEL=3 -DDOC_BUFFER_SIZE=0x1400000 -DCMAKE_INSTALL_PREFIX=/usr ..
   - make -j$(nproc)
   - make DESTDIR=appdir -j$(nproc) install ; find appdir/
   - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"

--- a/cr3gui/src/cr3main.cpp
+++ b/cr3gui/src/cr3main.cpp
@@ -157,7 +157,7 @@ void ShutdownCREngine()
     CRLog::setLogger( NULL );
 }
 
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
 bool getDirectoryFonts( lString16Collection & pathList, lString16Collection & ext, lString16Collection & fonts, bool absPath )
 {
     int foundCount = 0;
@@ -235,7 +235,7 @@ bool InitCREngine( const char * exename, lString16Collection & fontDirs )
     if (!fontMan->GetFontCount()) {
 
     lString16Collection fontExt;
-    #if (USE_FREETYPE==1)
+    #ifdef USE_FREETYPE
         fontExt.add(".ttf");
         fontExt.add(".otf");
         fontExt.add(".pfa");
@@ -243,7 +243,7 @@ bool InitCREngine( const char * exename, lString16Collection & fontDirs )
     #else
         fontExt.add(".lbf");
     #endif
-    #if (USE_FREETYPE==1)
+    #ifdef USE_FREETYPE
         lString16Collection fonts;
         fontDirs.add( fontDir );
         static const char * msfonts[] = {
@@ -301,7 +301,7 @@ bool InitCREngine( const char * exename, lString16Collection & fontDirs )
     if (!fontMan->GetFontCount())
     {
         //error
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
         printf("Fatal Error: Cannot open font file(s) .ttf \nCannot work without font\n" );
 #else
         printf("Fatal Error: Cannot open font file(s) font#.lbf \nCannot work without font\nUse FontConv utility to generate .lbf fonts from TTF\n" );

--- a/cr3gui/src/cr3main.h
+++ b/cr3gui/src/cr3main.h
@@ -21,7 +21,7 @@ bool initHyph(const char * fname);
 
 void ShutdownCREngine();
 
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
 bool getDirectoryFonts( lString16Collection & pathList, lString16 ext, lString16Collection & fonts, bool absPath );
 #endif
 

--- a/cr3gui/src/cr3win.cpp
+++ b/cr3gui/src/cr3win.cpp
@@ -452,7 +452,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
     {
         //error
         char str[1000];
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
         sprintf(str, "Cannot open font file(s) fonts/*.ttf \nCannot work without font\nPlace some TTF files to font\\ directory" );
 #else
         sprintf(str, "Cannot open font file(s) font#.lbf \nCannot work without font\nUse FontConv utility to generate .lbf fonts from TTF" );

--- a/cr3qt/src/main.cpp
+++ b/cr3qt/src/main.cpp
@@ -43,7 +43,7 @@ void InitCREngineLog( const char * cfgfile );
 bool InitCREngine( const char * exename, lString32Collection & fontDirs );
 void ShutdownCREngine();
 lString8 readFileToString( const char * fname );
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
 bool getDirectoryFonts( lString32Collection & pathList, lString32Collection & ext, lString32Collection & fonts, bool absPath );
 #endif
 
@@ -285,7 +285,7 @@ void ShutdownCREngine()
 #endif
 }
 
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
 bool getDirectoryFonts( lString32Collection & pathList, lString32Collection & ext, lString32Collection & fonts, bool absPath )
 {
     int foundCount = 0;
@@ -421,7 +421,7 @@ bool InitCREngine( const char * exename, lString32Collection & fontDirs )
     // fonts are in files font1.lbf, font2.lbf, ... font32.lbf
     // use fontconfig
 
-#if USE_FREETYPE==1
+#ifdef USE_FREETYPE
     lString32Collection fontExt;
     fontExt.add(cs32(".ttf"));
     fontExt.add(cs32(".otf"));
@@ -442,7 +442,7 @@ bool InitCREngine( const char * exename, lString32Collection & fontDirs )
 	    }
 	}
     //}
-#endif  // USE_FREETYPE==1
+#endif  // USE_FREETYPE=1
 
     // init hyphenation manager
     //char hyphfn[1024];
@@ -456,7 +456,7 @@ bool InitCREngine( const char * exename, lString32Collection & fontDirs )
     if (!fontMan->GetFontCount())
     {
         //error
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
         printf("Fatal Error: Cannot open font file(s) .ttf \nCannot work without font\n" );
 #else
         printf("Fatal Error: Cannot open font file(s) font#.lbf \nCannot work without font\nUse FontConv utility to generate .lbf fonts from TTF\n" );

--- a/cr3wx/src/cr3.cpp
+++ b/cr3wx/src/cr3.cpp
@@ -547,7 +547,7 @@ wxBitmap cr3Frame::getIcon16x16(const lChar32 *name )
     return wxNullBitmap;
 } // ~wxLogNull called, old log sink restored
 
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
 bool getDirectoryFonts( lString32Collection & pathList, lString32 ext, lString32Collection & fonts, bool absPath )
 {
     int foundCount = 0;
@@ -688,12 +688,12 @@ cr3app::OnInit()
     if (!fontMan->GetFontCount()) {
 
 
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
     lString32 fontExt = U".ttf";
 #else
     lString32 fontExt = U".lbf";
 #endif
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
     lString32Collection fonts;
     lString32Collection fontDirs;
     fontDirs.add( fontDir );
@@ -778,7 +778,7 @@ cr3app::OnInit()
     if (!fontMan->GetFontCount())
     {
         //error
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
         printf("Fatal Error: Cannot open font file(s) .ttf \nCannot work without font\n" );
 #else
         printf("Fatal Error: Cannot open font file(s) font#.lbf \nCannot work without font\nUse FontConv utility to generate .lbf fonts from TTF\n" );

--- a/crengine/Tools/Fb2Linux/fb2v.cpp
+++ b/crengine/Tools/Fb2Linux/fb2v.cpp
@@ -270,7 +270,7 @@ int main( int argc, const char * argv[] )
     // init bitmap font manager
     InitFontManager( fontDir );
 
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
         LVContainerRef dir = LVOpenDirectory( LocalToUnicode(fontDir).c_str() );
         if ( !dir.isNull() )
         for ( int i=0; i<dir->GetObjectCount(); i++ ) {

--- a/crengine/Tools/Fb2Test/Fb2Test.cpp
+++ b/crengine/Tools/Fb2Test/Fb2Test.cpp
@@ -382,7 +382,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 
     // Load font definitions into font manager
     // fonts are in files font1.lbf, font2.lbf, ... font32.lbf
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
         LVContainerRef dir = LVOpenDirectory( LocalToUnicode(fontDir).c_str() );
         if ( !dir.isNull() )
         for ( i=0; i<dir->GetObjectCount(); i++ ) {
@@ -424,7 +424,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
     {
         //error
         char str[1000];
-#if (USE_FREETYPE==1)
+#ifdef USE_FREETYPE
         sprintf(str, "Cannot open font file(s) fonts/*.ttf \nCannot work without font\nPlace some TTF files to font\\ directory" );
 #else
         sprintf(str, "Cannot open font file(s) font#.lbf \nCannot work without font\nUse FontConv utility to generate .lbf fonts from TTF" );

--- a/crengine/include/crsetup.h
+++ b/crengine/include/crsetup.h
@@ -40,7 +40,6 @@
 #define USE_LIBJPEG                          0
 #define USE_LIBPNG                           0
 #define USE_GIF                              0
-#define USE_FREETYPE                         0
 #define USE_HARFBUZZ                         0
 #define USE_FRIBIDI                          0
 #define USE_LIBUNIBREAK                      0
@@ -124,7 +123,6 @@
 #define MAX_IMAGE_SCALE_MUL                  1
 #endif
 #if defined(CYGWIN)
-#define USE_FREETYPE                         0
 #define USE_HARFBUZZ                         0
 #define USE_FRIBIDI                          0
 #define USE_LIBUNIBREAK                      0
@@ -220,7 +218,7 @@
 
 
 
-#if !defined(USE_WIN32_FONTS) && (USE_FREETYPE!=1)
+#if !defined(USE_WIN32_FONTS) && !defined(USE_FREETYPE)
 
 #if !defined(__SYMBIAN32__) && defined(_WIN32)
 /** \def USE_WIN32_FONTS
@@ -236,15 +234,11 @@
 #define ALLOW_KERNING 0
 #endif
 
-#endif  // !defined(USE_WIN32_FONTS) && (USE_FREETYPE!=1)
+#endif  // !defined(USE_WIN32_FONTS) && !defined(USE_FREETYPE)
 
 
 #ifndef CHM_SUPPORT_ENABLED
 #define CHM_SUPPORT_ENABLED 1
-#endif
-
-#ifndef USE_FREETYPE
-#define USE_FREETYPE 0
 #endif
 
 #ifndef USE_WIN32_FONTS
@@ -267,7 +261,7 @@
 
 #ifndef USE_BITMAP_FONTS
 
-#if (USE_WIN32_FONTS==1) || (USE_FREETYPE==1)
+#if (USE_WIN32_FONTS==1) || defined(USE_FREETYPE)
 #define USE_BITMAP_FONTS 0
 #else
 #define USE_BITMAP_FONTS 1

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -113,7 +113,7 @@ bool InitFontManager(lString8 path) {
     }
 #if (USE_WIN32_FONTS == 1)
     fontMan = new LVWin32FontManager;
-#elif USE_FREETYPE
+#elif defined(USE_FREETYPE)
     fontMan = new LVFreeTypeFontManager;
 #else
     fontMan = new LVBitmapFontManager;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -113,7 +113,7 @@ bool InitFontManager(lString8 path) {
     }
 #if (USE_WIN32_FONTS == 1)
     fontMan = new LVWin32FontManager;
-#elif (USE_FREETYPE == 1)
+#elif USE_FREETYPE
     fontMan = new LVFreeTypeFontManager;
 #else
     fontMan = new LVBitmapFontManager;

--- a/crengine/src/private/lvbitmapfont.h
+++ b/crengine/src/private/lvbitmapfont.h
@@ -21,7 +21,7 @@
 #include "lvbasefont.h"
 #include "lvfontcache.h"
 
-#if (USE_FREETYPE != 1) && (USE_BITMAP_FONTS == 1)
+#if !defined(USE_FREETYPE) && (USE_BITMAP_FONTS == 1)
 
 /* C++ wrapper class */
 class LBitmapFont : public LVBaseFont {
@@ -91,6 +91,6 @@ public:
     }
 };
 
-#endif  // (USE_FREETYPE!=1) && (USE_BITMAP_FONTS==1)
+#endif  // !defined(USE_FREETYPE) && (USE_BITMAP_FONTS==1)
 
 #endif // __LV_BITMAPFONT_H_INCLUDED__

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -35,7 +35,7 @@
 
 //DEFINE_NULL_REF( LVFont )
 
-#if (USE_FREETYPE == 1)
+#ifdef USE_FREETYPE
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -2402,4 +2402,4 @@ void LVFreeTypeFace::Clear() {
     }
 }
 
-#endif  // (USE_FREETYPE==1)
+#endif  // USE_FREETYPE=1

--- a/crengine/src/private/lvfreetypeface.h
+++ b/crengine/src/private/lvfreetypeface.h
@@ -34,7 +34,7 @@
 //#define DEBUG_FONT_MAN_LOG_FILE "/tmp/font_man.log"
 #endif
 
-#if (USE_FREETYPE == 1)
+#ifdef USE_FREETYPE
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -396,6 +396,6 @@ protected:
 #endif
 };
 
-#endif  // (USE_FREETYPE==1)
+#endif  // USE_FREETYPE=1
 
 #endif  // __LV_FREETYPEFACE_H_INCLUDED__

--- a/crengine/src/private/lvfreetypefontman.cpp
+++ b/crengine/src/private/lvfreetypefontman.cpp
@@ -21,7 +21,7 @@
 #include <fontconfig/fontconfig.h>
 #endif
 
-#if (USE_FREETYPE == 1)
+#ifdef USE_FREETYPE
 
 lString8 familyName(FT_Face face) {
     lString8 faceName(face->family_name);
@@ -1220,4 +1220,4 @@ bool LVFreeTypeFontManager::SetAsPreferredFontWithBias(lString8 face, int bias, 
     return _cache.setAsPreferredFontWithBias(face, bias, clearOthersBias);
 }
 
-#endif  // (USE_FREETYPE==1)
+#endif  // USE_FREETYPE=1

--- a/crengine/src/private/lvfreetypefontman.h
+++ b/crengine/src/private/lvfreetypefontman.h
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #endif
 
-#if (USE_FREETYPE == 1)
+#ifdef USE_FREETYPE
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -142,6 +142,6 @@ public:
     virtual bool SetAsPreferredFontWithBias( lString8 face, int bias, bool clearOthersBias );
 };
 
-#endif  // (USE_FREETYPE==1)
+#endif  // USE_FREETYPE=1
 
 #endif  // __LV_FREETYPEFONTMAN_H_INCLUDED__

--- a/crengine/src/private/lvwin32font.cpp
+++ b/crengine/src/private/lvwin32font.cpp
@@ -16,7 +16,7 @@
 #include "../../include/lvfnt.h"
 
 
-#if !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE != 1
+#if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(USE_FREETYPE)
 void LVBaseWin32Font::Clear()
 {
     if (_hfont)
@@ -672,4 +672,4 @@ bool LVWin32Font::Create(int size, int weight, bool italic, css_font_family_t fa
     return true;
 }
 
-#endif  // !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE != 1
+#endif  // !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(USE_FREETYPE)

--- a/crengine/src/private/lvwin32font.h
+++ b/crengine/src/private/lvwin32font.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 
-#if !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE != 1
+#if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(USE_FREETYPE)
 class LVBaseWin32Font : public LVBaseFont
 {
 protected:
@@ -354,6 +354,6 @@ public:
     virtual ~LVWin32Font() { }
 };
 
-#endif      // !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE!=1
+#endif      // !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(USE_FREETYPE)
 
 #endif  // __LV_WIN32FONT_H_INCLUDED__

--- a/crengine/src/private/lvwin32fontman.cpp
+++ b/crengine/src/private/lvwin32fontman.cpp
@@ -15,7 +15,7 @@
 #include "lvwin32fontman.h"
 #include "lvwin32font.h"
 
-#if !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE != 1
+#if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(USE_FREETYPE)
 
 // prototype
 int CALLBACK LVWin32FontEnumFontFamExProc(
@@ -187,4 +187,4 @@ int CALLBACK LVWin32FontEnumFontFamExProc(
     return 1;
 }
 
-#endif  // !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE != 1
+#endif  // !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(USE_FREETYPE)

--- a/crengine/src/private/lvwin32fontman.h
+++ b/crengine/src/private/lvwin32fontman.h
@@ -21,7 +21,7 @@
 #include "lvfontcache.h"
 
 
-#if !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE != 1
+#if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(USE_FREETYPE)
 
 class LVWin32FontManager : public LVFontManager
 {
@@ -58,6 +58,6 @@ public:
     virtual void getFontFileNameList( lString32Collection & list );
 };
 
-#endif  // !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE!=1
+#endif  // !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(USE_FREETYPE)
 
 #endif  // __LV_WIN32FONTMAN_H_INCLUDED__


### PR DESCRIPTION
Currently, `USE_FREETYPE` uses integer values `0` and `1`. At first glance, it might seem like more integer values are possible, considering there is freetype (freetype1) and freetype2. This PR converts `USE_FREETYPE` to a regular boolean flag.

It has the benefit that it's more "lintable" by static code analyzers and leverages the various boolean C++ macros.

This PR also fixes a typo in the .travis.yml definition, since `USE_FREETYPE2` doesn't exist. Added as a separate commit, in case the style changes are not acceptable.

If the style changes are alright, I'd like to tackle some of the other macros which are also in their integer form :).