### PR TITLE
Switch deprecated QtWheelEvent.delta to QtWheelEvent.angleDelta

### DIFF
--- a/cr3qt/src/cr3widget.cpp
+++ b/cr3qt/src/cr3widget.cpp
@@ -483,7 +483,11 @@ bool CR3View::loadDocument( QString fileName )
 void CR3View::wheelEvent( QWheelEvent * event )
 {
     // Get degrees delta from vertical scrolling
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     int numDegrees = event->angleDelta().y() / 8;
+#else
+    int numDegrees = event->delta() / 8;
+#endif
     int numSteps = numDegrees / 15;
     if ( numSteps==0 && numDegrees!=0 )
         numSteps = numDegrees>0 ? 1 : -1;

--- a/cr3qt/src/cr3widget.cpp
+++ b/cr3qt/src/cr3widget.cpp
@@ -482,7 +482,8 @@ bool CR3View::loadDocument( QString fileName )
 
 void CR3View::wheelEvent( QWheelEvent * event )
 {
-    int numDegrees = event->delta() / 8;
+    // Get degrees delta from vertical scrolling
+    int numDegrees = event->angleDelta().y() / 8;
     int numSteps = numDegrees / 15;
     if ( numSteps==0 && numDegrees!=0 )
         numSteps = numDegrees>0 ? 1 : -1;


### PR DESCRIPTION
The compiler warns that the `QtWheelEvent::delta()` method is deprecated and `QtWheelEvent::angleDelta()` should be used instead:
```cpp
/home/amender/pkgbuilds/coolreader/trunk/src/coolreader-cr3.2.51/cr3qt/src/cr3widget.cpp: In member function ‘virtual void CR3View::wheelEvent(QWheelEvent*)’:
/home/amender/pkgbuilds/coolreader/trunk/src/coolreader-cr3.2.51/cr3qt/src/cr3widget.cpp:485:35: warning: ‘int QWheelEvent::delta() const’ is deprecated: Use angleDelta() [-Wdeprecated-declarations]
  485 |     int numDegrees = event->delta() / 8;
      |                                   ^
In file included from /usr/include/qt/QtGui/QResizeEvent:1,
                 from /home/amender/pkgbuilds/coolreader/trunk/src/coolreader-cr3.2.51/cr3qt/src/cr3widget.cpp:11:
/usr/include/qt/QtGui/qevent.h:219:16: note: declared here
  219 |     inline int delta() const  { return qt4D; }
      |                ^~~~~
```

The Qt docs mention that there is both `angleDelta` and `pixelDelta`:  https://doc.qt.io/qt-5/qwheelevent.html#angleDelta  
Because horizontal scrolling is now supported, both deltas return a `QPoint` object, from which the horizontal or vertical delta can be extracted. I think it makes sense to extract the vertical (y) deltas in this case.

