### PR TITLE
HTML docs: support the 'q' element, via the css files

### DIFF
--- a/android/res/raw/htm.css
+++ b/android/res/raw/htm.css
@@ -80,6 +80,9 @@ blockquote { display: block;
    margin-top: 0.5em; 
    margin-bottom: 0.5em; 
    } 
+/* No support for the "quotes:" property, these will use default quote chars */
+q::before               { content: open-quote; }
+q::after                { content: close-quote; }
 
 img { 
    margin: 0.5em; 

--- a/cr3gui/data/htm.css
+++ b/cr3gui/data/htm.css
@@ -244,3 +244,7 @@ table { font-size: 100% }
 td, th { text-indent: 0px; padding: 3px } 
 th { font-weight: bold; text-align: center } 
 table caption { text-indent: 0px; padding: 4px }
+
+/* No support for the "quotes:" property, these will use default quote chars */
+q::before               { content: open-quote; }
+q::after                { content: close-quote; }

--- a/cr3qt/data/htm.css
+++ b/cr3qt/data/htm.css
@@ -80,6 +80,9 @@ blockquote { display: block;
    margin-top: 0.5em; 
    margin-bottom: 0.5em; 
    } 
+/* No support for the "quotes:" property, these will use default quote chars */
+q::before               { content: open-quote; }
+q::after                { content: close-quote; }
 
 img { 
    margin: 0.5em; 


### PR DESCRIPTION
This can work now, so it could be supported when reading html docs.