### PR TITLE
Distinct list circle and disc characters

### DIFF
--- a/crengine/include/lvfont.h
+++ b/crengine/include/lvfont.h
@@ -168,9 +168,30 @@ public:
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \param def_char replacement char if glyph for code not found for this font
         \param fallbackPassMask bitmask of processed fallback fonts
-        \return true if glyph was found 
+        \param replace_missing internal use for recursive search
+        \return true if glyph was found
     */
-    virtual bool getGlyphInfo(lUInt32 code, glyph_info_t *glyph, lChar32 def_char = 0, lUInt32 fallbackPassMask = 0) = 0;
+    virtual bool getGlyphInfo(
+            lUInt32 code,
+            glyph_info_t *glyph,
+            lChar32 def_char = 0,
+            lUInt32 fallbackPassMask = 0,
+            bool replace_missing = false
+    ) = 0;
+
+    /** \brief get glyph info, search without and with character replacement
+        \param code is unicode character code
+        \param glyph is pointer to glyph_info_t struct to place retrieved info
+        \param def_char replacement char if glyph for code not found for this font
+        \param fallbackPassMask bitmask of processed fallback fonts
+        \return true if glyph was found
+    */
+    virtual bool getGlyphInfoSearch(
+            lUInt32 code,
+            glyph_info_t *glyph,
+            lChar32 def_char = 0,
+            lUInt32 fallbackPassMask = 0
+    );
 
     /** \brief measure text
         \param text is text string pointer
@@ -210,13 +231,33 @@ public:
 //        \return true if glyph was found
 //    */
 //    virtual bool getGlyphImage(lUInt32 code, lUInt8 * buf, lChar32 def_char=0) = 0;
+
     /** \brief get glyph item
         \param ch is unicode character code
         \param def_char replacement char if glyph for ch not found for this font
         \param fallbackPassMask bitmask of processed fallback fonts
+        \param replace_missing internal use for recursive search
         \return glyph pointer if glyph was found, NULL otherwise
     */
-    virtual LVFontGlyphCacheItem *getGlyph(lUInt32 ch, lChar32 def_char = 0, lUInt32 fallbackPassMask = 0) = 0;
+    virtual LVFontGlyphCacheItem *getGlyph(
+            lUInt32 ch,
+            lChar32 def_char = 0,
+            lUInt32 fallbackPassMask = 0,
+            bool replace_missing = false
+    ) = 0;
+
+    /** \brief get glyph item, searching without and with character replacement
+        \param ch is unicode character code
+        \param def_char replacement char if glyph for ch not found for this font
+        \param fallbackPassMask bitmask of processed fallback fonts
+        \param replace_missing internal use for recursive search
+        \return glyph pointer if glyph was found, NULL otherwise
+    */
+    virtual LVFontGlyphCacheItem *getGlyphSearch(
+            lUInt32 ch,
+            lChar32 def_char = 0,
+            lUInt32 fallbackPassMask = 0
+    );
 
     /// returns font baseline offset
     virtual int getBaseline() = 0;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -17534,13 +17534,13 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & 
     default:
         // treat default as disc
     case css_lst_disc:
-        marker = U"\x2022"; //U"\x25CF"; // 25e6
+        marker = U"\x2022"; // U"\x25CF" U"\x26AB" (medium circle) U"\x2981" (spot) U"\x2022" (bullet, small)
         break;
     case css_lst_circle:
-        marker = U"\x2022"; //U"\x25CB";
+        marker = U"\x25E6"; // U"\x25CB" U"\x26AA (medium) U"\25E6" (bullet) U"\x26AC (medium small)
         break;
     case css_lst_square:
-        marker = U"\x25A0";
+        marker = U"\x25AA"; // U"\x25A0" U"\x25FE" (medium small) U"\x25AA" (small)
         break;
     case css_lst_none:
         // When css_lsp_inside, no space is used by the invisible marker

--- a/crengine/src/private/lvbasefont.cpp
+++ b/crengine/src/private/lvbasefont.cpp
@@ -28,7 +28,7 @@ int LVBaseFont::DrawTextString(LVDrawBuf * buf, int x, int y,
         if (len <= 1 || *text != UNICODE_SOFT_HYPHEN_CODE) {
             lChar32 ch = ((len == 0) ? UNICODE_SOFT_HYPHEN_CODE : *text);
 
-            LVFontGlyphCacheItem *item = getGlyph(ch, def_char);
+            LVFontGlyphCacheItem *item = getGlyphSearch(ch, def_char);
             int w = 0;
             if (item) {
                 // avoid soft hyphens inside text string

--- a/crengine/src/private/lvfontboldtransform.cpp
+++ b/crengine/src/private/lvfontboldtransform.cpp
@@ -39,8 +39,9 @@ int LVFontBoldTransform::getHyphenWidth() {
 }
 
 bool
-LVFontBoldTransform::getGlyphInfo(lUInt32 code, LVFont::glyph_info_t *glyph, lChar32 def_char, lUInt32 fallbackPassMask) {
-    bool res = _baseFont->getGlyphInfo(code, glyph, def_char, fallbackPassMask);
+LVFontBoldTransform::getGlyphInfo(lUInt32 code, LVFont::glyph_info_t *glyph, lChar32 def_char,
+                                  lUInt32 fallbackPassMask, bool replace_missing) {
+    bool res = _baseFont->getGlyphInfo(code, glyph, def_char, fallbackPassMask, replace_missing);
     if (!res)
         return res;
     glyph->blackBoxX += glyph->blackBoxX > 0 ? _hShift : 0;
@@ -95,13 +96,14 @@ lUInt32 LVFontBoldTransform::getTextWidth(const lChar32 *text, int len, TextLang
     return 0;
 }
 
-LVFontGlyphCacheItem *LVFontBoldTransform::getGlyph(lUInt32 ch, lChar32 def_char, lUInt32 fallbackPassMask) {
+LVFontGlyphCacheItem *LVFontBoldTransform::getGlyph(lUInt32 ch, lChar32 def_char, lUInt32 fallbackPassMask,
+                                                    bool replace_missing) {
 
     LVFontGlyphCacheItem *item = _glyph_cache.get(ch);
     if (item)
         return item;
 
-    LVFontGlyphCacheItem *olditem = _baseFont->getGlyph(ch, def_char, fallbackPassMask);
+    LVFontGlyphCacheItem *olditem = _baseFont->getGlyph(ch, def_char, fallbackPassMask, replace_missing);
     if (!olditem)
         return NULL;
 
@@ -179,7 +181,7 @@ int LVFontBoldTransform::DrawTextString(LVDrawBuf *buf, int x, int y, const lCha
             isHyphen = 0;
         }
 
-        LVFontGlyphCacheItem * item = getGlyph(ch, def_char);
+        LVFontGlyphCacheItem * item = getGlyphSearch(ch, def_char);
         int w  = 0;
         if ( item ) {
             // avoid soft hyphens inside text string
@@ -226,11 +228,11 @@ int LVFontBoldTransform::DrawTextString(LVDrawBuf *buf, int x, int y, const lCha
 /*
 bool LVFontBoldTransform::getGlyphImage(lUInt16 code, lUInt8 *buf, lChar32 def_char)
 {
-    LVFontGlyphCacheItem * item = getGlyph( code, def_char );
+    LVFontGlyphCacheItem * item = getGlyphSearch( code, def_char );
     if ( !item )
         return false;
     glyph_info_t glyph;
-    if ( !_baseFont->getGlyphInfo( code, &glyph, def_char ) )
+    if ( !_baseFont->getGlyphInfoSearch( code, &glyph, def_char ) )
         return 0;
     int oldx = glyph.blackBoxX;
     int oldy = glyph.blackBoxY;
@@ -246,10 +248,10 @@ bool LVFontBoldTransform::getGlyphImage(lUInt16 code, lUInt8 *buf, lChar32 def_c
         //CRLog::error("Glyph buffer corrupted!");
         // clear cache
         for ( int i=32; i<4000; i++ ) {
-            _baseFont->getGlyphInfo( i, &glyph, def_char );
+            _baseFont->getGlyphInfoSearch( i, &glyph, def_char );
             _baseFont->getGlyphImage( i, tmp.get(), def_char );
         }
-        _baseFont->getGlyphInfo( code, &glyph, def_char );
+        _baseFont->getGlyphInfoSearch( code, &glyph, def_char );
         _baseFont->getGlyphImage( code, tmp.get(), def_char );
     }
     for ( int y=0; y<dy; y++ ) {

--- a/crengine/src/private/lvfontboldtransform.h
+++ b/crengine/src/private/lvfontboldtransform.h
@@ -67,9 +67,16 @@ public:
 
     /** \brief get glyph info
         \param glyph is pointer to glyph_info_t struct to place retrieved info
+        \param replace_missing internal use for recursive search
         \return true if glyh was found
     */
-    virtual bool getGlyphInfo(lUInt32 code, glyph_info_t *glyph, lChar32 def_char = 0, lUInt32 fallbackPassMask = 0);
+    virtual bool getGlyphInfo(
+            lUInt32 code,
+            glyph_info_t *glyph,
+            lChar32 def_char = 0,
+            lUInt32 fallbackPassMask = 0,
+            bool replace_missing = false
+    );
 
     /** \brief measure text
         \param text is text string pointer
@@ -103,9 +110,15 @@ public:
 
     /** \brief get glyph item
         \param code is unicode character
+        \param replace_missing internal use for recursive search
         \return glyph pointer if glyph was found, NULL otherwise
     */
-    virtual LVFontGlyphCacheItem *getGlyph(lUInt32 ch, lChar32 def_char = 0, lUInt32 fallbackPassMask = 0);
+    virtual LVFontGlyphCacheItem *getGlyph(
+            lUInt32 ch,
+            lChar32 def_char = 0,
+            lUInt32 fallbackPassMask = 0,
+            bool replace_missing = false
+    );
 
     /** \brief get glyph image in 1 byte per pixel format
         \param code is unicode character

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -836,10 +836,10 @@ bool LVFreeTypeFace::hbCalcCharWidth(LVCharPosInfo *posInfo, const LVCharTriplet
         }
 
     }
-    // Otherwise, use plain Freetype getGlyphInfo() which will check
+    // Otherwise, use plain Freetype getGlyphInfoSearch() which will check
     // again with this font, or the fallback one
     glyph_info_t glyph;
-    if ( getGlyphInfo(triplet.Char, &glyph, def_char, fallbackPassMask) ) {
+    if ( getGlyphInfoSearch(triplet.Char, &glyph, def_char, fallbackPassMask) ) {
         posInfo->offset = 0;
         posInfo->width = glyph.width;
         return true;
@@ -849,7 +849,7 @@ bool LVFreeTypeFace::hbCalcCharWidth(LVCharPosInfo *posInfo, const LVCharTriplet
 
 #endif  // USE_HARFBUZZ==1
 
-FT_UInt LVFreeTypeFace::getCharIndex(lUInt32 code, lChar32 def_char) {
+FT_UInt LVFreeTypeFace::getCharIndex(lUInt32 code, bool replace_missing, lChar32 def_char) {
     if (code == '\t')
         code = ' ';
     FT_UInt ch_glyph_index = FT_Get_Char_Index(_face, code);
@@ -863,7 +863,7 @@ FT_UInt LVFreeTypeFace::getCharIndex(lUInt32 code, lChar32 def_char) {
             FT_Select_Charmap(_face, FT_ENCODING_UNICODE);
         }
     }
-    if ( ch_glyph_index==0 ) {
+    if ( ch_glyph_index==0 && replace_missing ) {
         bool can_be_ignored = false;
         lUInt32 replacement = getReplacementChar( code, &can_be_ignored );
         if ( replacement )
@@ -1020,22 +1020,20 @@ void LVFreeTypeFace::setupHBFeatures()
 }
 #endif
 
-bool LVFreeTypeFace::getGlyphInfo(lUInt32 code, LVFont::glyph_info_t *glyph, lChar32 def_char, lUInt32 fallbackPassMask) {
+bool LVFreeTypeFace::getGlyphInfo(lUInt32 code, LVFont::glyph_info_t *glyph, lChar32 def_char,
+                                  lUInt32 fallbackPassMask, bool replace_missing) {
     //FONT_GUARD
-    int glyph_index = getCharIndex(code, 0);
+    int glyph_index = getCharIndex(code, replace_missing, def_char);
     if (glyph_index == 0) {
         LVFont *fallback = getFallbackFont(fallbackPassMask);
-        if (NULL == fallback) {
-            // No fallback
-            glyph_index = getCharIndex(code, def_char);
-            if (glyph_index == 0)
-                return false;
-        } else {
-            // Fallback
-            lUInt32 passMask = fallbackPassMask | _fallback_mask;
-            return fallback->getGlyphInfo(code, glyph, def_char, passMask);
-        }
+        if (!fallback)
+            return false;
+        return fallback->getGlyphInfo(code, glyph, def_char,
+                                      fallbackPassMask | _fallback_mask,
+                                      replace_missing);
     }
+
+    //FONT_GUARD
     int flags = FT_LOAD_DEFAULT;
     flags |= (!_drawMonochrome ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO);
     if (_hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR) {
@@ -1133,6 +1131,14 @@ bool LVFreeTypeFace::getGlyphInfo(lUInt32 code, LVFont::glyph_info_t *glyph, lCh
     // a ceil()'ed value when considering negative numbers as some overflow,
     // which is good when we're using it for adding some padding.
     return true;
+}
+
+bool LVFont::getGlyphInfoSearch(lUInt32 code, LVFont::glyph_info_t *glyph, lChar32 def_char,
+                                lUInt32 fallbackPassMask) {
+    // Firstly try the font and the fallbacks list without character replacement,
+    // and then if necessary retry with character replacement.
+    return getGlyphInfo(code, glyph, def_char, fallbackPassMask, false) ||
+           getGlyphInfo(code, glyph, def_char, fallbackPassMask, true);
 }
 
 bool LVFreeTypeFace::checkFontLangCompat(const lString8 &langCode) {
@@ -1652,7 +1658,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
 #if (ALLOW_KERNING==1)
         if ( use_kerning && previous>0  ) {
             if ( ch_glyph_index==(FT_UInt)-1 )
-                ch_glyph_index = getCharIndex( ch, def_char );
+                ch_glyph_index = getCharIndex( ch, true, def_char );
             if ( ch_glyph_index != 0 ) {
                 FT_Vector delta;
                 error = FT_Get_Kerning( _face,          /* handle to face object */
@@ -1671,7 +1677,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
         int w = _wcache.get(ch);
         if ( w == CACHED_UNSIGNED_METRIC_NOT_SET ) {
             glyph_info_t glyph;
-            if ( getGlyphInfo( ch, &glyph, def_char, fallbackPassMask ) ) {
+            if ( getGlyphInfoSearch( ch, &glyph, def_char, fallbackPassMask ) ) {
                 w = glyph.width;
                 _wcache.put(ch, w);
             } else {
@@ -1682,7 +1688,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
         }
         if ( use_kerning ) {
             if ( ch_glyph_index==(FT_UInt)-1 )
-                ch_glyph_index = getCharIndex( ch, 0 );
+                ch_glyph_index = getCharIndex( ch, false);
             previous = ch_glyph_index;
         }
         widths[i] = prev_width + w + FONT_METRIC_TO_PX(kerning);
@@ -1764,21 +1770,19 @@ void LVFreeTypeFace::updateTransform() {
     //        }
 }
 
-LVFontGlyphCacheItem *LVFreeTypeFace::getGlyph(lUInt32 ch, lChar32 def_char, lUInt32 fallbackPassMask) {
+LVFontGlyphCacheItem *LVFreeTypeFace::getGlyph(lUInt32 ch, lChar32 def_char,
+                                               lUInt32 fallbackPassMask,
+                                               bool replace_missing) {
     //FONT_GUARD
-    FT_UInt ch_glyph_index = getCharIndex(ch, 0);
+    FT_UInt ch_glyph_index = getCharIndex(ch, replace_missing, def_char);
     if (ch_glyph_index == 0) {
         LVFont *fallback = getFallbackFont(fallbackPassMask);
-        if (NULL == fallback) {
-            // No fallback
-            ch_glyph_index = getCharIndex(ch, def_char);
-            if (ch_glyph_index == 0)
-                return NULL;
-        } else {
-            // Fallback
-            return fallback->getGlyph(ch, def_char, fallbackPassMask | _fallback_mask );
-        }
+        if (!fallback)
+            return NULL;
+        return fallback->getGlyph(ch, def_char, fallbackPassMask | _fallback_mask,
+                                  replace_missing);
     }
+
     LVFontGlyphCacheItem *item = _glyph_cache.get(ch);
     if (!item) {
         int rend_flags = FT_LOAD_RENDER | (!_drawMonochrome ? FT_LOAD_TARGET_LIGHT
@@ -1825,6 +1829,17 @@ LVFontGlyphCacheItem *LVFreeTypeFace::getGlyph(lUInt32 ch, lChar32 def_char, lUI
             _glyph_cache.put(item);
     }
     return item;
+}
+
+LVFontGlyphCacheItem *LVFont::getGlyphSearch(lUInt32 ch, lChar32 def_char,
+                                                     lUInt32 fallbackPassMask) {
+
+    // Firstly try the font and the fallbacks list without character replacement,
+    // and then if necessary retry with character replacement.
+    LVFontGlyphCacheItem *item = getGlyph(ch, def_char, fallbackPassMask, false);
+    if (item)
+        return item;
+    return getGlyph(ch, def_char, fallbackPassMask, true);
 }
 
 #if USE_HARFBUZZ == 1
@@ -1894,7 +1909,7 @@ int LVFreeTypeFace::getCharWidth(lChar32 ch, lChar32 def_char) {
     lUInt16 w = _wcache.get(ch);
     if (w == CACHED_UNSIGNED_METRIC_NOT_SET) {
         glyph_info_t glyph;
-        if (getGlyphInfo(ch, &glyph, def_char)) {
+        if (getGlyphInfoSearch(ch, &glyph, def_char)) {
             w = glyph.width;
         } else {
             w = 0;
@@ -1911,7 +1926,7 @@ int LVFreeTypeFace::getLeftSideBearing( lChar32 ch, bool negative_only, bool ita
     lInt16 b = _lsbcache.get(ch);
     if ( b == CACHED_SIGNED_METRIC_NOT_SET ) {
         glyph_info_t glyph;
-        if ( getGlyphInfo( ch, &glyph, '?' ) ) {
+        if ( getGlyphInfoSearch( ch, &glyph, '?' ) ) {
             b = glyph.originX;
         }
         else {
@@ -1931,7 +1946,7 @@ int LVFreeTypeFace::getRightSideBearing( lChar32 ch, bool negative_only, bool it
     lInt16 b = _rsbcache.get(ch);
     if ( b == CACHED_SIGNED_METRIC_NOT_SET ) {
         glyph_info_t glyph;
-        if ( getGlyphInfo( ch, &glyph, '?' ) ) {
+        if ( getGlyphInfoSearch( ch, &glyph, '?' ) ) {
             b = glyph.rsb;
         }
         else {
@@ -2239,7 +2254,7 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
 
         if (addHyphen) {
             ch = UNICODE_SOFT_HYPHEN_CODE;
-            LVFontGlyphCacheItem *item = getGlyph(ch, def_char);
+            LVFontGlyphCacheItem *item = getGlyphSearch(ch, def_char);
             if (item) {
                 w = item->advance;
                 buf->Draw( x + item->origin_x,
@@ -2272,7 +2287,7 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
                 ch = UNICODE_SOFT_HYPHEN_CODE;
                 isHyphen = false; // an hyphen, but not one to not draw
             }
-            LVFontGlyphCacheItem * item = getGlyph(ch, def_char, fallbackPassMask);
+            LVFontGlyphCacheItem * item = getGlyphSearch(ch, def_char, fallbackPassMask);
             if ( !item )
                 continue;
             if ( (item && !isHyphen) || i==len ) { // only draw soft hyphens at end of string
@@ -2319,7 +2334,7 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
             ch = UNICODE_SOFT_HYPHEN_CODE;
             isHyphen = 0;
         }
-        FT_UInt ch_glyph_index = getCharIndex( ch, def_char );
+        FT_UInt ch_glyph_index = getCharIndex( ch, true, def_char );
         int kerning = 0;
 #if (ALLOW_KERNING==1)
         if ( use_kerning && previous>0 && ch_glyph_index>0 ) {
@@ -2333,7 +2348,7 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
                 kerning = delta.x;
         }
 #endif
-        LVFontGlyphCacheItem * item = getGlyph(ch, def_char, fallbackPassMask);
+        LVFontGlyphCacheItem * item = getGlyphSearch(ch, def_char, fallbackPassMask);
         if ( !item )
             continue;
         if ( (item && !isHyphen) || i>=len-1 ) { // avoid soft hyphens inside text string

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -116,14 +116,18 @@ static lChar32 getReplacementChar(lUInt32 code, bool * can_be_ignored = NULL) {
         case 0x2044:
             return '/';
         case 0x2022: // css_lst_disc:
-            return '*';
-        case 0x26AA: // css_lst_disc:
-        case 0x25E6: // css_lst_disc:
+        case 0x26AB: // css_lst_disc:
+        case 0x2981: // css_lst_disc:
         case 0x25CF: // css_lst_disc:
-            return 'o';
-        case 0x25CB: // css_lst_circle:
             return '*';
+        case 0x26AA: // css_lst_circle:
+        case 0x25E6: // css_lst_circle:
+        case 0x26AC: // css_lst_circle:
+        case 0x25CB: // css_lst_circle:
+            return 'o';
         case 0x25A0: // css_lst_square:
+        case 0x25AA: // css_lst_square:
+        case 0x25FE: // css_lst_square:
             return '-';
         default:
             break;

--- a/crengine/src/private/lvfreetypeface.h
+++ b/crengine/src/private/lvfreetypeface.h
@@ -234,9 +234,17 @@ public:
 
     /** \brief get glyph info
         \param glyph is pointer to glyph_info_t struct to place retrieved info
+        \param replace_missing internal use for recursive search
         \return true if glyh was found
     */
-    virtual bool getGlyphInfo(lUInt32 code, glyph_info_t *glyph, lChar32 def_char = 0, lUInt32 fallbackPassMask = 0);
+    virtual bool getGlyphInfo(
+            lUInt32 code,
+            glyph_info_t *glyph,
+            lChar32 def_char = 0,
+            lUInt32 fallbackPassMask = 0,
+            bool replace_missing = false
+    );
+
 /*
   // USE GET_CHAR_FLAGS instead
     inline int calcCharFlags( lChar32 ch )
@@ -293,9 +301,15 @@ public:
 
     /** \brief get glyph item
         \param code is unicode character
+        \param replace_missing internal use for recursive search
         \return glyph pointer if glyph was found, NULL otherwise
     */
-    virtual LVFontGlyphCacheItem *getGlyph(lUInt32 ch, lChar32 def_char = 0, lUInt32 fallbackPassMask = 0);
+    virtual LVFontGlyphCacheItem *getGlyph(
+            lUInt32 ch,
+            lChar32 def_char = 0,
+            lUInt32 fallbackPassMask = 0,
+            bool replace_missing = false
+    );
 
 //    /** \brief get glyph image in 1 byte per pixel format
 //        \param code is unicode character
@@ -382,7 +396,7 @@ public:
     virtual void Clear();
 protected:
     void updateTransform();
-    FT_UInt getCharIndex(lUInt32 code, lChar32 def_char);
+    FT_UInt getCharIndex(lUInt32 code, bool replace_missing, lChar32 def_char = 0);
 #if USE_HARFBUZZ==1
     LVFontGlyphCacheItem *getGlyphByIndex(lUInt32 index);
     lChar32 filterChar(lChar32 code, lChar32 def_char=0);

--- a/crengine/src/private/lvwin32font.cpp
+++ b/crengine/src/private/lvwin32font.cpp
@@ -118,7 +118,8 @@ bool LVBaseWin32Font::Create(int size, int weight, bool italic, css_font_family_
     \param glyph is pointer to glyph_info_t struct to place retrieved info
     \return true if glyh was found 
 */
-bool LVWin32DrawFont::getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char, lUInt32 fallbackPassMask )
+bool LVWin32DrawFont::getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char,
+                                    lUInt32 fallbackPassMask, bool replace_missing )
 {
     return false;
 }
@@ -517,7 +518,8 @@ glyph_t * LVWin32Font::GetGlyphRec( lChar32 ch )
     \param glyph is pointer to glyph_info_t struct to place retrieved info
     \return true if glyh was found 
 */
-bool LVWin32Font::getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char, lUInt32 fallbackPassMask )
+bool LVWin32Font::getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char,
+                                lUInt32 fallbackPassMask, bool replace_missing )
 {
     if (_hfont==NULL)
         return false;

--- a/crengine/src/private/lvwin32font.h
+++ b/crengine/src/private/lvwin32font.h
@@ -67,7 +67,7 @@ public:
     virtual int getCharWidth( lChar32 ch, lChar32 def_char=0 )
     {
         glyph_info_t glyph;
-        if ( getGlyphInfo(ch, &glyph, def_char) )
+        if ( getGlyphInfoSearch(ch, &glyph, def_char) )
             return glyph.width;
         return 0;
     }
@@ -104,7 +104,8 @@ public:
         return css_ff_inherit;
     }
 
-    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar32 def_char=0, lUInt32 fallbackPassMask = 0) {
+    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar32 def_char=0, lUInt32 fallbackPassMask = 0
+                                            bool replace_missing = false) {
         return NULL;
     }
 
@@ -127,7 +128,12 @@ public:
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyh was found
     */
-    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char=0, lUInt32 fallbackPassMask = 0 );
+    virtual bool getGlyphInfo(
+                        lUInt32 code,
+                        glyph_info_t * glyph,
+                        lChar32 def_char=0,
+                        lUInt32 fallbackPassMask = 0,
+                        bool replace_missing = false);
 
     /** \brief measure text
         \param glyph is pointer to glyph_info_t struct to place retrieved info
@@ -309,7 +315,12 @@ public:
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyh was found
     */
-    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char=0, lUInt32 fallbackPassMask = 0 );
+    virtual bool getGlyphInfo(
+                        lUInt32 code,
+                        glyph_info_t * glyph,
+                        lChar32 def_char=0,
+                        lUInt32 fallbackPassMask = 0,
+                        bool replace_missing = false);
 
     /** \brief measure text
         \param glyph is pointer to glyph_info_t struct to place retrieved info


### PR DESCRIPTION
The source included commented out distinct list circle and disc characters which this PR enables. It had been using the same characters for both, and a different character. Could this be revisited now so that there are distinct circle and disc list labels available? Was there are lack of support in the fonts, or was it a presentation decision?