### PR TITLE
Android: workaround fallback font face(s) conflict

### DIFF
--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -2629,6 +2629,14 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		props.remove(PROP_EMBEDDED_FONTS);
 		props.remove(PROP_REQUESTED_DOM_VERSION);
 		props.remove(PROP_RENDER_BLOCK_RENDERING_FLAGS);
+
+		// If a fallback font face is defined then set it in the font
+		// faces, otherwise the font faces may override the font face
+		// depending on which is applied first.
+		String fallbackFontFace = props.getProperty(PROP_FALLBACK_FONT_FACE);
+		if (fallbackFontFace.length() > 0)
+			props.setProperty(PROP_FALLBACK_FONT_FACES, fallbackFontFace);
+
 		BackgroundThread.ensureBackground();
 		log.v("applySettings()");
 		boolean isFullScreen = props.getBool(PROP_APP_FULLSCREEN, false);


### PR DESCRIPTION
The Android reader uses both PROP_FALLBACK_FONT_FACE and
PROP_FALLBACK_FONT_FACES and sets PROP_FALLBACK_FONT_FACES empty if
PROP_FALLBACK_FONT_FACE is defined. This could result in a single face
being set and then the faces being set to an empty set clearing the
initial face set and the fallback font setting not working.

Removing PROP_FALLBACK_FONT_FACES in this case does not solve this
problem as it will be defaulted to a hard coded list and override the
UI fallback font face setting.

The workaround here is to copy the PROP_FALLBACK_FONT_FACE into the
PROP_FALLBACK_FONT_FACES when set.

A cleaner fix would appear to be to remove PROP_FALLBACK_FONT_FACE and just have a single font placed in PROP_FALLBACK_FONT_FACES where that was the intention? The front end would then be responsible to managing a list of fallback fonts vs a single fallback font.