### PR TITLE
Android: default the hyphenation dictionary to 'algorithm'

### DIFF
--- a/android/src/org/coolreader/crengine/BaseActivity.java
+++ b/android/src/org/coolreader/crengine/BaseActivity.java
@@ -1900,7 +1900,7 @@ public class BaseActivity extends Activity implements Settings {
 
 			props.setProperty(ReaderView.PROP_MIN_FILE_SIZE_TO_CACHE, "100000");
 			props.setProperty(ReaderView.PROP_FORCED_MIN_FILE_SIZE_TO_CACHE, "32768");
-			props.applyDefault(ReaderView.PROP_HYPHENATION_DICT, Engine.HyphDict.RUSSIAN.toString());
+			props.applyDefault(ReaderView.PROP_HYPHENATION_DICT, Engine.HyphDict.ALGORITHM.toString());
 			props.applyDefault(ReaderView.PROP_APP_FILE_BROWSER_SIMPLE_MODE, "0");
 
 			props.applyDefault(ReaderView.PROP_TEXTLANG_EMBEDDED_LANGS_ENABLED, "0");

--- a/android/src/org/coolreader/crengine/OptionsDialog.java
+++ b/android/src/org/coolreader/crengine/OptionsDialog.java
@@ -1278,7 +1278,7 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 		public HyphenationOptions( OptionOwner owner, String label )
 		{
 			super( owner, label, PROP_HYPHENATION_DICT );
-			setDefaultValue(Engine.HyphDict.RUSSIAN.code);
+			setDefaultValue(Engine.HyphDict.ALGORITHM.code);
 			Engine.HyphDict[] dicts = Engine.HyphDict.values();
 			for ( Engine.HyphDict dict : dicts )
 				if (!dict.hide)


### PR DESCRIPTION
The language is currently derived from the hyphenation dictionary so having that defaulted to Russian defaulted the language to Russian, and that in turn affected the symbols chosen for quotes etc. It would have seemed better to default from the locale, but that would want to work for the 'algorithm' setting too, so this seems a start. There is an interesting option to use the books language, but I can't see that actually working, but perhaps something to look into. People might fairly consider this PR EN centric, but perhaps this is at least somewhere to discuss making better use of the locale and how that should default settings.