### PR TITLE
HTML: emit img alt text in text selections and read-aloud

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5236,6 +5236,18 @@ void ldomElementWriter::onBodyEnter()
                 }
             }
         }
+
+        // Add img alt text as a child. This will only be used by the
+        // graphical renderer if there is no image, but is needed for the text
+        // selection which is in turn used by Read-Aloud. This approach works
+        // simply with ::before and ::after pseudo elements which should be
+        // applied when the alternate text is emitted.
+        if ( _element->getNodeId() == el_img ) {
+            lString32 alt = _element->getAttributeValue( attr_alt );
+            if (!alt.empty())
+                _element->insertChildText(alt);
+        }
+
         _isBlock = isBlockNode(_element);
         // If initNodeStyle() has set "white-space: pre" or alike, update _flags
         if ( _element->getStyle()->white_space >= css_ws_pre_line) {


### PR DESCRIPTION
This is adequate to get the text selection returning the img alt text, and that works with the Read-Aloud feature where it can be very useful.

Seems a bit of a hack, adding a child text element to an img element, but when you consider that the ::before and ::after pseudo elements can be used on the img element and are already added as child elements, and that these are to be emitted around the alt text, this approach is much simpler than having all the users include special cases to emit the alt text out of order with the pseudo elements (I tried that first and it was a big change that I never completed!)

This PR plays well with a WIP patch to get the pseudo elements emitted in text selection and thus for Read-Aloud.

If people have other suggestions then help would be appreciated?
