### PR TITLE
HTML ordered lists: correct 'reversed' attribute handling

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -17568,7 +17568,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & 
             ldomNode * parent = getUnboxedParent();
 
             // See if parent has a 'reversed' attribute.
-            int increment = parent->getAttributeValue(attr_reversed).empty() ? +1 : -1;
+            int increment = parent->hasAttribute(attr_reversed) ? -1 : +1;
 
             // If the caller passes in a non-zero counter then it is assumed
             // have been already calculated and have the value of the prior


### PR DESCRIPTION
The list should be reversed if the 'reversed' attribute is present,
irrespective of the value of the attritube.