### PR TITLE
list marker: separate the content, max width, and rendering functions

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1106,7 +1106,7 @@ public:
     ldomNode * modify();
 
     /// for display:list-item node, get marker
-    bool getNodeListMarker( int & counterValue, lString32 & marker, int & markerWidth );
+    bool getNodeListMarker( int & counterValue, lString32 & marker );
     /// is node a floating floatBox
     bool isFloatingBox() const;
     /// is node an inlineBox that has not been re-inlined by having

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -17521,12 +17521,11 @@ ldomNode * ldomNode::getUnboxedPrevSibling( bool skip_text_nodes ) const
 }
 
 /// for display:list-item node, get marker
-bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & markerWidth )
+bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker)
 {
 #if BUILD_LITE!=1
     css_style_ref_t s = getStyle();
     marker.clear();
-    markerWidth = 0;
     if ( s.isNull() )
         return false;
     css_list_style_type_t st = s->list_style_type;
@@ -17695,22 +17694,10 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & 
         }
         break;
     }
-    bool res = false;
-    if ( !marker.empty() ) {
-        LVFontRef font = getFont();
-        if ( !font.isNull() ) {
-            TextLangCfg * lang_cfg = TextLangMan::getTextLangCfg( this );
-            markerWidth = font->getTextWidth((marker + "  ").c_str(), marker.length()+2, lang_cfg) + font->getSize()/8;
-            res = true;
-        } else {
-            marker.clear();
-        }
-    }
-    return res;
 #else
     marker = cs32("*");
-    return true;
 #endif
+    return true;
 }
 
 


### PR DESCRIPTION
renderListItemMarker() had been also computing the maximum width,
walking all the list elements to do so if the value was not cached,
and this part has been split out into a separate function
listItemMarkerMaxWidth() which can simply obtain the cached value if
that is all the caller needs.

getNodeListMarker() had been also computing a width for the marker
content, and that computation has been split out into the few callers,
this leaves this function returning the content of the marker and
brings the code closer to supporting list ::marker content.

Basically a suggested clean up of this code, if you think that it is cleaner separating these function. This might support slightly better performance in cases where the caller did not need all the computation performed.

Could not spot any functional reasons that these function were combining the width computation. Only thought is that if the computation of the maximum width could fail somehow then it could fallback to the width of the one element, but that does not appear to be an issue.

Perhaps there was considered to be a possible need to adjust the width in some cases, where this would not just be based just on the content, but such hacks would not work with ::marker user defined content.