### PR TITLE
preformatted text: don't remove trailing space from the last word on a line

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3310,7 +3310,10 @@ public:
                         word->min_width = word->width;
                         word->flags |= LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER;
                     }
-                    if ( m_flags[i-1] & LCHAR_IS_SPACE) { // Current word ends with a space
+
+                    bool preformatted = srcline->flags & LTEXT_FLAG_PREFORMATTED;
+                    if ( m_flags[i-1] & LCHAR_IS_SPACE ) {
+                        // Current word ends with a space.
                         // Each word ending with a space (except in some conditions) can
                         // have its width reduced by a fraction of this space width or
                         // increased if needed (for text justification), so actually
@@ -3326,8 +3329,11 @@ public:
                                 word->min_width = word->width - dw;
                             }
                         }
-                        if ( lastWord ) {
-                            // If last word of line, remove any trailing space from word's width
+                        if ( lastWord && !preformatted ) {
+                            // If last word of line, remove any trailing space
+                            // from word's width (but not with preformatted, in
+                            // case of text-align:right where we don't want to
+                            // lose any trailing space)
                             word->width = m_widths[i>1 ? i-2 : 0] - (wstart>0 ? m_widths[wstart-1] : 0);
                             word->min_width = word->width;
                         }


### PR DESCRIPTION
Noticed this issue exploring the ::marker support, where trailing spaces in content might be expected to remain. This can be reproduced in the following example so seems to be a more general issue - notice that the trailing space on the second line is short, and this seems unexpected and is not consistent with Chrome, so perhaps this issue and PR might be considered in isolation.

Also noticed that CR will format per-formatted text on multiple lines, where Chome will not - but that seems like a feature. With this change these lines retain their trailing space too, not just that last line. This works well when used for a marker content as it offsets the marker nicely even if it wraps on multiple lines.

```
<pre style="background: grey; text-align: right;">123456789</pre>
<pre style="background: grey; text-align: right;">123456   </pre>
```
