### PR TITLE
Distinct list circle and disc characters (replay)

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -17534,13 +17534,13 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & 
     default:
         // treat default as disc
     case css_lst_disc:
-        marker = U"\x2022"; //U"\x25CF"; // 25e6
+        marker = U"\x2022"; // U"\x25CF" U"\x26AB" (medium circle) U"\x2981" (spot) U"\x2022" (bullet, small)
         break;
     case css_lst_circle:
-        marker = U"\x2022"; //U"\x25CB";
+        marker = U"\x25E6"; // U"\x25CB" U"\x26AA (medium) U"\25E6" (bullet) U"\x26AC (medium small)
         break;
     case css_lst_square:
-        marker = U"\x25A0";
+        marker = U"\x25AA"; // U"\x25A0" U"\x25FE" (medium small) U"\x25AA" (small)
         break;
     case css_lst_none:
         // When css_lsp_inside, no space is used by the invisible marker

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -116,14 +116,18 @@ static lChar32 getReplacementChar(lUInt32 code, bool * can_be_ignored = NULL) {
         case 0x2044:
             return '/';
         case 0x2022: // css_lst_disc:
-            return '*';
-        case 0x26AA: // css_lst_disc:
-        case 0x25E6: // css_lst_disc:
+        case 0x26AB: // css_lst_disc:
+        case 0x2981: // css_lst_disc:
         case 0x25CF: // css_lst_disc:
-            return 'o';
-        case 0x25CB: // css_lst_circle:
             return '*';
+        case 0x26AA: // css_lst_circle:
+        case 0x25E6: // css_lst_circle:
+        case 0x26AC: // css_lst_circle:
+        case 0x25CB: // css_lst_circle:
+            return 'o';
         case 0x25A0: // css_lst_square:
+        case 0x25AA: // css_lst_square:
+        case 0x25FE: // css_lst_square:
             return '-';
         default:
             break;

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -863,12 +863,12 @@ FT_UInt LVFreeTypeFace::getCharIndex(lUInt32 code, lChar32 def_char) {
             FT_Select_Charmap(_face, FT_ENCODING_UNICODE);
         }
     }
-    if ( ch_glyph_index==0 ) {
+    if ( ch_glyph_index==0 && def_char != 0 ) {
         bool can_be_ignored = false;
         lUInt32 replacement = getReplacementChar( code, &can_be_ignored );
         if ( replacement )
             ch_glyph_index = FT_Get_Char_Index( _face, replacement );
-        if ( ch_glyph_index==0 && def_char && !can_be_ignored ) {
+        if ( ch_glyph_index==0 && !can_be_ignored ) {
             // if neither the index of this character nor the index of the replacement character is found,
             // and if this character can be safely ignored,
             // we simply skip it so as not to draw the unnecessary replacement character.


### PR DESCRIPTION
Copied from #217.
> The source included commented out distinct list circle and disc characters which this PR enables. It had been using the same characters for both, and a different character. Could this be revisited now so that there are distinct circle and disc list labels available? Was there are lack of support in the fonts, or was it a presentation decision?

Since it was not possible to implement the rendering of replacement characters with the main font, but not with the fallback one without complicating the code, it was decided to abandon this idea for now.