### PR TITLE
legacy list item: remove

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -31,7 +31,6 @@ enum css_display_t {
     css_d_inline,  // All elements starts being css_d_inline, unless otherwise specified in fb2def.h
     // Above are those that define a mostly inline container, below those that define a mostly block container
     css_d_block,
-    css_d_list_item_legacy, // display: -cr-list-item-final (was used before 20180524 for display: list-item)
     css_d_list_item_block,  // display: list-item
     css_d_inline_block,
     css_d_inline_table, // (needs to be before css_d_table, as we use tests like if: (style->display > css_d_table))

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1464,7 +1464,6 @@ static const char * css_d_names[] =
     "run-in",
     "inline",
     "block",
-    "-cr-list-item-final", // non-standard, legacy crengine rendering of list items as final: css_d_list_item_legacy
     "list-item",           // correct rendering of list items as block: css_d_list_item_block
     "inline-block",
     "inline-table",
@@ -1991,9 +1990,6 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 break;
             case cssd_display:
                 n = parse_name( decl, css_d_names, -1 );
-                if (domVersionRequested < 20180524 && n == css_d_list_item_block) {
-                    n = css_d_list_item_legacy; // legacy rendering of list-item
-                }
                 break;
             case cssd_white_space:
                 n = parse_name( decl, css_ws_names, -1 );

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2141,16 +2141,6 @@ public:
                     lastBidiLevel = newBidiLevel;
             #endif
         }
-        if ( tabIndex >= 0 && m_srcs[0]->indent < 0) {
-            // Used by obsolete rendering of css_d_list_item_legacy when css_lsp_outside,
-            // where the marker width is provided as negative/hanging indent.
-            int tabPosition = -m_srcs[0]->indent; // has been set to marker_width
-            if ( tabPosition>0 && tabPosition > m_widths[tabIndex] ) {
-                int dx = tabPosition - m_widths[tabIndex];
-                for ( i=tabIndex; i<m_length; i++ )
-                    m_widths[i] += dx;
-            }
-        }
 //        // debug dump
 //        lString32 buf;
 //        for ( int i=0; i<m_length; i++ ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6160,9 +6160,6 @@ void ldomNode::initNodeRendMethod()
         //CRLog::trace("switch all children elements of <%s> to inline", LCSTR(getNodeName()));
         recurseElements( resetRendMethodToInline );
         setRendMethod(erm_inline);
-    } else if ( d==css_d_list_item_legacy ) {
-        // list item (no more used, obsolete rendering method)
-        setRendMethod(erm_final);
     } else if ( d==css_d_table ) {
         // table: this will "Generate missing child wrappers" if needed
         initTableRendMethods( this, 0 );
@@ -8545,22 +8542,11 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
     for ( ; p; p = p->getParentNode() ) {
         int rm = p->getRendMethod();
         if ( rm == erm_final ) {
-            if ( doc->getDOMVersionRequested() < 20180524 && p->getStyle()->display == css_d_list_item_legacy ) {
-                // This legacy rendering of list item is now erm_final, but
-                // can contain other real erm_final nodes.
-                // So, if we found an erm_final, and if we find this erm_final
-                // when going up, we should use it (unlike in next case).
-                // (This is needed to correctly display highlights on books opened
-                // with some older DOM_VERSION.)
-                finalNode = p;
-            }
-            else {
-                // With floats, we may get multiple erm_final when walking up
-                // to root node: keep the first one met (but go on up to the
-                // root node in case we're in some upper erm_invisible).
-                if (!finalNode)
-                    finalNode = p; // found final block
-            }
+            // With floats, we may get multiple erm_final when walking up
+            // to root node: keep the first one met (but go on up to the
+            // root node in case we're in some upper erm_invisible).
+            if (!finalNode)
+                finalNode = p; // found final block
         }
         else if ( p->getRendMethod() == erm_invisible ) {
             return false; // invisible !!!
@@ -17602,7 +17588,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & 
                         sibling = sibling->getUnboxedNextSibling(true);
                         continue;
                     }
-                    if ( cs->display != css_d_list_item_block && cs->display != css_d_list_item_legacy) {
+                    if ( cs->display != css_d_list_item_block ) {
                         // Alien element among list item nodes, skip it to not mess numbering
                         if ( sibling == this ) // Should not happen, but let's be sure
                             break;
@@ -17625,7 +17611,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & 
                     sibling = sibling->getUnboxedNextSibling(true);
                     continue;
                 }
-                if ( cs->display != css_d_list_item_block && cs->display != css_d_list_item_legacy) {
+                if ( cs->display != css_d_list_item_block ) {
                     // Alien element among list item nodes, skip it to not mess numbering
                     if ( sibling == this ) // Should not happen, but let's be sure
                         break;


### PR DESCRIPTION
There does not appear to be any practical reason to keep the legacy list item code paths now.

The legacy list item code path appears to have used a tab and a negative margin offset to achieve the presentation, with a hack in the text formatting code path for this.

If there is a good reason to keep this legacy code path around then please let me know, but it does not appear to be necessary and frustrates code development.

Was it just due to a lack of confidence in new code paths, so that there was a fallback, and is there confidence now and can these legacy code paths be remove now?

Was it to maintain pixel perfect presentation following legacy expectations?

If there is another reason then perhaps that could be documented, and perhaps there is a different way to achieve that requirement in future development?