### PR TITLE
Fallback fonts management

### DIFF
--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -49,8 +49,8 @@ CRENGINE_SRC_FILES := \
     ../../crengine/src/cp_stats.cpp \
     ../../crengine/src/lvstring.cpp \
     ../../crengine/src/lvstring8collection.cpp \
-    ../../crengine/src/lvstring16collection.cpp \
-    ../../crengine/src/lvstring16hashedcollection.cpp \
+    ../../crengine/src/lvstring32collection.cpp \
+    ../../crengine/src/lvstring32hashedcollection.cpp \
     ../../crengine/src/crlog.cpp \
     ../../crengine/src/serialbuf.cpp \
     ../../crengine/src/props.cpp \

--- a/android/res/values-bg/strings.xml
+++ b/android/res/values-bg/strings.xml
@@ -381,6 +381,8 @@
     <string name="options_font_hinting_disabled">Изключено</string>
     <string name="options_font_hinting_auto">Автохинтинг на шрифта</string>
     <string name="options_font_fallback_face">Резервен шрифт</string>
+    <string name="options_font_fallback_face_num">Резервен шрифт #%s</string>
+    <string name="options_font_fallback_faces">Резервни шрифтове</string>
     <string name="win_title_confirm_catalog_delete">Действително ли искате да изтриете каталога?</string>
     <string name="win_title_confirm_history_record_delete">Действително ли искате да изтриете тази книга от списъка с последни книги?</string>
     <string name="win_title_confirm_book_delete">Действително ли искате да изтриете тази книга?</string>

--- a/android/res/values-by/strings.xml
+++ b/android/res/values-by/strings.xml
@@ -382,6 +382,8 @@
 <string name="options_font_hinting_disabled">Адключаны</string>
 <string name="options_font_hinting_auto">Аўтахінтынг</string>
 <string name="options_font_fallback_face">Дадатковы шрыфт</string>
+<string name="options_font_fallback_face_num">Дадатковы шрыфт №%s</string>
+<string name="options_font_fallback_faces">Дадатковыя шрыфты</string>
 <string name="win_title_confirm_catalog_delete">Вы сапраўды хочаце выдаліць гэтую тэчку</string>
 <string name="win_title_confirm_history_record_delete">Вы сапраўды хочаце выдаліць кнігу з спісу апошніх</string>
 <string name="win_title_confirm_book_delete">Вы сапраўды хочаце выдаліць кнігу</string>
@@ -482,4 +484,4 @@
 <string name="btn_toolbar_more"> Яшчэ ... </string>
 <string name="black_list_enforced"> Нельга дадаваць гэты адрас , так як па запыце LitRes.ru ён дададзены ў чорны спіс каталогаў , якія парушаюць аўтарскія правы. </string>
 <string name="black_list_warning"> Увага ! Гэты адрас па запыце LitRes.ru быў дададзены ў чорны спіс каталогаў , якія парушаюць аўтарскія правы. Вы сапраўды жадаеце выкарыстоўваць гэты каталог ? </string>
-</resources> 
+</resources>

--- a/android/res/values-cs/strings.xml
+++ b/android/res/values-cs/strings.xml
@@ -381,6 +381,8 @@
 <string name="options_font_hinting_disabled">"Vypnuto"</string>
 <string name="options_font_hinting_auto">"Automatické instruování písma"</string>
 <string name="options_font_fallback_face">"Náhradní písmo"</string>
+<string name="options_font_fallback_face_num">Náhradní písmo #%s</string>
+<string name="options_font_fallback_faces">Náhradní písma</string>
 <string name="win_title_confirm_catalog_delete">"Opravdu chcete smazat tento katalog?"</string>
 <string name="win_title_confirm_history_record_delete">"Opravdu chcete odstranit tuto knihu ze seznamu naposledy čtených?"</string>
 <string name="win_title_confirm_book_delete">"Opravdu chcete smazat tuto knihu?"</string>

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -386,6 +386,8 @@
     <string name="options_font_hinting_disabled">Deaktiviert</string>
     <string name="options_font_hinting_auto">Automatisch</string>
     <string name="options_font_fallback_face">Fallback-Schriftart</string>
+    <string name="options_font_fallback_face_num">Fallback-Schriftart Nr. %s</string>
+    <string name="options_font_fallback_faces">Fallback-Schriftarten</string>
     <string name="win_title_confirm_catalog_delete">Wollen Sie diesen Katalog wirklich löschen?</string>
     <string name="win_title_confirm_history_record_delete">Wollen Sie dieses Buch wirklich aus der Liste der letzten Bücher löschen?</string>
     <string name="win_title_confirm_book_delete">Wollen Sie dieses Buch wirklich löschen?</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -386,6 +386,8 @@
     <string name="options_font_hinting_disabled">Désactivé</string>
     <string name="options_font_hinting_auto">Automatique</string>
     <string name="options_font_fallback_face">Police par défaut</string>
+    <string name="options_font_fallback_face_num">Police supplémentaire n°%s</string>
+    <string name="options_font_fallback_faces">Polices supplémentaires</string>
     <string name="win_title_confirm_catalog_delete">Voulez-vous vraiment supprimer ce catalogue?</string>
     <string name="win_title_confirm_history_record_delete">Voulez-vous vraiment enlever ce livre de la liste des livres récents?</string>
     <string name="win_title_confirm_book_delete">Voulez-vous vraiment supprimer ce livre?</string>

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -381,6 +381,8 @@
     <string name="options_font_hinting_auto">Autohinting</string>
     <string name="options_font_hinting">Font hinting</string>
     <string name="options_font_fallback_face">Fallback font</string>
+    <string name="options_font_fallback_face_num">Fallback font #%s</string>
+    <string name="options_font_fallback_faces">Fallback fonts</string>
     <string name="win_title_confirm_catalog_delete">Do you really want to delete this catalog?</string>
     <string name="win_title_confirm_history_record_delete">Do you really want to remove this book from recent list?</string>
     <string name="win_title_confirm_book_delete">Do you really want to delete this book?</string>

--- a/android/res/values-lt/strings.xml
+++ b/android/res/values-lt/strings.xml
@@ -381,6 +381,8 @@
     <string name="options_font_hinting_disabled">Disabled</string>
     <string name="options_font_hinting_auto">Autohinting</string>
     <string name="options_font_fallback_face">Fallback font</string>
+    <string name="options_font_fallback_face_num">Fallback font #%s</string>
+    <string name="options_font_fallback_faces">Fallback fonts</string>
     <string name="win_title_confirm_catalog_delete">Do you really want to delete this catalog?</string>
     <string name="win_title_confirm_history_record_delete">Do you really want to remove this book from recent list?</string>
     <string name="win_title_confirm_book_delete">Do you really want to delete this book?</string>

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -381,6 +381,8 @@
     <string name="options_font_hinting_disabled">Off</string>
     <string name="options_font_hinting_auto">Automatische hinting van lettertype</string>
     <string name="options_font_fallback_face">Aanvullende lettertype</string>
+    <string name="options_font_fallback_face_num">Aanvullende lettertype #%s</string>
+    <string name="options_font_fallback_faces">Aanvullende lettertypen</string>
     <string name="win_title_confirm_catalog_delete">Ben je zeker deze map te verwijderen?</string>
     <string name="win_title_confirm_history_record_delete">Ben je zeker dit boek te verwijderen uit de recente boeken lijst?</string>
     <string name="win_title_confirm_book_delete">Ben je zeker dit boek te verwijderen?</string>

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -392,6 +392,8 @@
     <string name="options_font_hinting_disabled">Wyłączone</string>
     <string name="options_font_hinting_auto">Auto</string>
     <string name="options_font_fallback_face">Czcionka "zapasowa"</string>
+    <string name="options_font_fallback_face_num">Czcionka zastępcza nr %s</string>
+    <string name="options_font_fallback_faces">Czcionki zastępcze</string>
     <string name="win_title_confirm_catalog_delete">Potwierdź usunięcie katalogu?</string>
     <string name="win_title_confirm_history_record_delete">Potwierdź usunięcie książki z listy ostatnich?</string>
     <string name="win_title_confirm_book_delete">Potwierdź usunięcie książki?</string>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -418,6 +418,8 @@
     <string name="options_font_hinting_disabled">Отключен</string>
     <string name="options_font_hinting_auto">Автохинтинг</string>
     <string name="options_font_fallback_face">Резервный шрифт</string>
+    <string name="options_font_fallback_face_num">Резервный шрифт №%s</string>
+    <string name="options_font_fallback_faces">Резервные шрифты</string>
     <string name="win_title_confirm_catalog_delete">Вы действительно хотите удалить этот каталог?</string>
     <string name="win_title_confirm_history_record_delete">Вы действительно хотите удалить эту книгу из списка последних книг?</string>
     <string name="win_title_confirm_book_delete">Вы действительно хотите удалить эту книгу / архив ?</string>

--- a/android/res/values-sk/strings.xml
+++ b/android/res/values-sk/strings.xml
@@ -393,6 +393,8 @@
     <string name="options_font_hinting_disabled">Vypnutý</string>
     <string name="options_font_hinting_auto">Auto-hinting</string>
     <string name="options_font_fallback_face">Núdzové písmo</string>
+    <string name="options_font_fallback_face_num">Núdzové písmo #%s</string>
+    <string name="options_font_fallback_faces">Núdzové písma</string>
     <string name="win_title_confirm_catalog_delete">Určite chcete odstrániť tento katalóg?</string>
     <string name="win_title_confirm_history_record_delete">Určite chcete odstrániť túto knihu zo zoznamu nedávnych kníh?</string>
     <string name="win_title_confirm_book_delete">Určite chcete odstrániť túto knihu?</string>

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -400,6 +400,8 @@
     <string name="options_font_hinting_disabled">Відключено</string>
     <string name="options_font_hinting_auto">Автохінтинг</string>
     <string name="options_font_fallback_face">Додатковий шрифт</string>
+    <string name="options_font_fallback_face_num">Додатковий шрифт №%s</string>
+    <string name="options_font_fallback_faces">Додаткові шрифти</string>
     <string name="win_title_confirm_catalog_delete">Ви дійсно бажаєте вилучити цю теку?</string>
     <string name="win_title_confirm_history_record_delete">Ви дійсно бажаєте вилучити книжку із переліку останніх?</string>
     <string name="win_title_confirm_book_delete">Ви дійсно бажаєте вилучити книжку?</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -429,6 +429,8 @@
     <string name="options_font_hinting_disabled">Disabled</string>
     <string name="options_font_hinting_auto">Autohinting</string>
     <string name="options_font_fallback_face">Fallback font</string>
+    <string name="options_font_fallback_face_num">Fallback font #%s</string>
+    <string name="options_font_fallback_faces">Fallback fonts</string>
     <string name="win_title_confirm_catalog_delete">Do you really want to delete this catalog?</string>
     <string name="win_title_confirm_history_record_delete">Do you really want to remove this book from recent list?</string>
     <string name="win_title_confirm_book_delete">Do you really want to delete this book / archive ?</string>

--- a/android/src/org/coolreader/crengine/BaseActivity.java
+++ b/android/src/org/coolreader/crengine/BaseActivity.java
@@ -1689,7 +1689,6 @@ public class BaseActivity extends Activity implements Settings {
 			boolean res = false;
 			res = applyDefaultFont(props, ReaderView.PROP_FONT_FACE, DeviceInfo.DEF_FONT_FACE) || res;
 			res = applyDefaultFont(props, ReaderView.PROP_STATUS_FONT_FACE, DeviceInfo.DEF_FONT_FACE) || res;
-			res = applyDefaultFont(props, ReaderView.PROP_FALLBACK_FONT_FACE, "Droid Sans Fallback") || res;
 			res = applyDefaultFallbackFontList(props, ReaderView.PROP_FALLBACK_FONT_FACES, "Droid Sans Fallback; Noto Sans CJK SC; Noto Sans Arabic UI; Noto Sans Devanagari UI; Roboto; FreeSans; FreeSerif; Noto Serif; Noto Sans; Arial Unicode MS") || res;
 			return res;
 		}

--- a/android/src/org/coolreader/crengine/BaseDialog.java
+++ b/android/src/org/coolreader/crengine/BaseDialog.java
@@ -96,7 +96,8 @@ public class BaseDialog extends Dialog {
 			setContentView(layoutView);
 		}
 		contentsLayout.removeAllViews();
-		contentsLayout.addView(view);
+		if (null != view)
+			contentsLayout.addView(view);
 	}
 	
 	protected void onPositiveButtonClick()
@@ -210,7 +211,8 @@ public class BaseDialog extends Dialog {
             }
         }
         contentsLayout =  layout.findViewById(R.id.base_dialog_content_view);
-        contentsLayout.addView(view);
+        if (null != view)
+            contentsLayout.addView(view);
         setTitle(title);
 		return layout;
 	}

--- a/android/src/org/coolreader/crengine/OptionsDialog.java
+++ b/android/src/org/coolreader/crengine/OptionsDialog.java
@@ -345,6 +345,9 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 	public final static int OPTION_VIEW_TYPE_SUBMENU = 3;
 	//public final static int OPTION_VIEW_TYPE_COUNT = 3;
 
+	// This is an engine limitation, see lvfreetypefontman.cpp, lvfreetypeface.cpp
+	private static final int MAX_FALLBACK_FONTS_COUNT = 32;
+
 	public BaseActivity getActivity() { return mActivity; }
 	public Properties getProperties() { return mProperties; }
 	public LayoutInflater getInflater() { return mInflater; }
@@ -1238,7 +1241,132 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 				optionsListView.refresh();
 		}
 	}
-	
+
+	class FallbackFontItemOptions extends ListOption {
+
+		private final FallbackFontsOptions mParentOptions;	// parent option item
+		private final int mPosition;						// position in parent list
+
+		public FallbackFontItemOptions(OptionOwner owner, String label, String property, FallbackFontsOptions parentOptions, int pos) {
+			super(owner, label, property);
+			mParentOptions = parentOptions;
+			mPosition = pos;
+		}
+
+		public void onClick( Pair item ) {
+			super.onClick(item);
+			if (item.value.length() > 0) {
+				if (mPosition == mParentOptions.size() - 1) {
+					if (mPosition < MAX_FALLBACK_FONTS_COUNT - 1) {
+						// last item in parent list not empty => add new empty item in parent list
+						mParentOptions.addFallbackFontItem(mParentOptions.size(), "");
+					}
+				}
+			} else {
+				if (mPosition == mParentOptions.size() - 2) {
+					// penultimate item in parent list set to empty => remove last empty item
+					mParentOptions.removeFallbackFontItem(mParentOptions.size() - 1);
+				}
+			}
+		}
+	}
+
+	class FallbackFontsOptions extends SubmenuOption {
+
+		OptionsListView mListView;
+		private final Properties mFallbackProps = new Properties();
+		private final OptionOwner mFallbackOptionItemOwner = new OptionOwner() {
+			@Override
+			public BaseActivity getActivity() {
+				return  mOwner.getActivity();
+			}
+			@Override
+			public Properties getProperties() {
+				return mFallbackProps;
+			}
+			@Override
+			public LayoutInflater getInflater() {
+				return mOwner.getInflater();
+			}
+		};
+
+		public FallbackFontsOptions( OptionOwner owner, String label ) {
+			super( owner, label, PROP_FALLBACK_FONT_FACES );
+			mListView = new OptionsListView(getContext());
+		}
+
+		protected void addFallbackFontItem( int pos, String fontFace) {
+			String propName = Integer.toString(pos);
+			String label = getString(R.string.options_font_fallback_face_num, pos + 1);
+			mFallbackProps.setProperty(propName, fontFace);
+			FallbackFontItemOptions option = new FallbackFontItemOptions(mFallbackOptionItemOwner, label, propName, this, pos);
+			option.add("", "(empty)");
+			option.add(mFontFaces);
+			option.setDefaultValue("");
+			option.noIcon();
+			mListView.add(option);
+		}
+
+		protected boolean removeFallbackFontItem( int pos ) {
+			boolean res = mListView.remove(pos);
+			if (res)
+				mListView.refresh();
+			return res;
+		}
+
+		public void onSelect() {
+			if (!enabled)
+				return;
+			BaseDialog dlg = new BaseDialog(mActivity, label, false, false) {
+				protected void onClose()
+				{
+					updateMainPropertyValue();
+					this.setView(null);
+					super.onClose();
+				}
+			};
+			mListView.clear();
+			String fallbackFaces = getProperties().getProperty(property);
+			if (null == fallbackFaces)
+				fallbackFaces = "";
+			String[] list = fallbackFaces.split(";");
+			int pos = 0;
+			for (String face : list) {
+				face = face.trim();
+				if (face.length() > 0) {
+					addFallbackFontItem(pos, face);
+					pos++;
+				}
+			}
+			addFallbackFontItem(pos, "");
+			dlg.setView(mListView);
+			dlg.show();
+		}
+
+		public int size() {
+			return mListView.size();
+		}
+
+		public String getValueLabel() { return ">"; }
+
+		private void updateMainPropertyValue() {
+			StringBuilder fallbackFacesBuilder = new StringBuilder();
+			for (int i = 0; i < MAX_FALLBACK_FONTS_COUNT; i++) {
+				String propName = Integer.toString(i);
+				String fallback = mFallbackProps.getProperty(propName);
+				if (null != fallback && fallback.length() > 0) {
+					fallbackFacesBuilder.append(fallback);
+					fallbackFacesBuilder.append("; ");
+				}
+			}
+			String fallbackFaces = fallbackFacesBuilder.toString();
+			// Remove trailing "; " part
+			if (fallbackFaces.length() >= 2)
+				fallbackFaces = fallbackFaces.substring(0, fallbackFaces.length() - 2);
+			getProperties().setProperty(property, fallbackFaces);
+		}
+	}
+
 	class DictOptions extends ListOption
 	{
 		public DictOptions( OptionOwner owner, String label )
@@ -1505,6 +1633,20 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 			option.optionsListView = this;
 			return this;
 		}
+		public boolean remove(int index) {
+			try {
+				mOptions.remove(index);
+				return true;
+			} catch (Exception ignored) {
+			}
+			return false;
+		}
+		public boolean remove( OptionBase option ) {
+			return mOptions.remove(option);
+		}
+		public void clear() {
+			mOptions.clear();
+		}
 		public OptionsListView( Context context )
 		{
 			super(context, false);
@@ -1573,7 +1715,9 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 			mOptions.get(position).onSelect();
 			return true;
 		}
-		
+		public int size() {
+			return mOptions.size();
+		}
 	}
 	
 	public View createTabContent(String tag) {
@@ -1598,6 +1742,10 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 	private String getString( int resourceId )
 	{
 		return getContext().getResources().getString(resourceId); 
+	}
+
+	public String getString( int resourceId, Object... formatArgs ) {
+		return getContext().getResources().getString(resourceId, formatArgs);
 	}
 
 	class StyleEditorOption extends SubmenuOption {
@@ -2057,7 +2205,7 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 		mOptionsStyles.add(new ListOption(this, getString(R.string.options_render_font_gamma), PROP_FONT_GAMMA).add(mGammas).setDefaultValue("1.0").setIconIdByAttr(R.attr.cr3_option_font_gamma_drawable, R.drawable.cr3_option_font_gamma));
 		mOptionsStyles.add(new ListOption(this, getString(R.string.options_format_min_space_width_percent), PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT).addPercents(mMinSpaceWidths).setDefaultValue("50").setIconIdByAttr(R.attr.cr3_option_text_width_drawable, R.drawable.cr3_option_text_width));
 		mOptionsStyles.add(new ListOption(this, getString(R.string.options_font_hinting), PROP_FONT_HINTING).add(mHinting, mHintingTitles).setDefaultValue("2").noIcon());
-		mOptionsStyles.add(new ListOption(this, getString(R.string.options_font_fallback_face), PROP_FALLBACK_FONT_FACE).add(mFontFaces).setDefaultValue(mFontFaces[0]).setIconIdByAttr(R.attr.cr3_option_font_face_drawable, R.drawable.cr3_option_font_face));
+		mOptionsStyles.add(new FallbackFontsOptions(this, getString(R.string.options_font_fallback_faces)).setIconIdByAttr(R.attr.cr3_option_font_face_drawable, R.drawable.cr3_option_font_face));
 		
 		//
 		mOptionsPage = new OptionsListView(getContext());

--- a/android/src/org/coolreader/crengine/Settings.java
+++ b/android/src/org/coolreader/crengine/Settings.java
@@ -29,7 +29,6 @@ public interface Settings {
     public static final String PROP_LOG_LEVEL               ="crengine.log.level";
     public static final String PROP_LOG_AUTOFLUSH           ="crengine.log.autoflush";
     public static final String PROP_FONT_SIZE               ="crengine.font.size";
-    public static final String PROP_FALLBACK_FONT_FACE      ="crengine.font.fallback.face";
 	public static final String PROP_FALLBACK_FONT_FACES     ="crengine.font.fallback.faces";
     public static final String PROP_STATUS_FONT_COLOR       ="crengine.page.header.font.color";
     public static final String PROP_STATUS_FONT_COLOR_DAY   ="crengine.page.header.font.color.day";
@@ -304,7 +303,7 @@ public interface Settings {
 	    "font.*",
 	    "crengine.page.*",
 	    PROP_FONT_SIZE,
-	    PROP_FALLBACK_FONT_FACE,
+	    PROP_FALLBACK_FONT_FACES,
 	    PROP_INTERLINE_SPACE,
 	    PROP_STATUS_LINE,
 	    PROP_FOOTNOTES,

--- a/android/src/org/coolreader/sync2/Synchronizer.java
+++ b/android/src/org/coolreader/sync2/Synchronizer.java
@@ -29,7 +29,6 @@ import org.coolreader.R;
 import org.coolreader.crengine.BackgroundThread;
 import org.coolreader.crengine.BookInfo;
 import org.coolreader.crengine.Bookmark;
-import org.coolreader.crengine.FileBrowser;
 import org.coolreader.crengine.FileInfo;
 import org.coolreader.crengine.L;
 import org.coolreader.crengine.Logger;
@@ -122,7 +121,6 @@ public class Synchronizer {
 	private int m_lockTryCount = 0;
 
 	private static final String[] ALLOWED_OPTIONS_PROP_NAMES = {
-			Settings.PROP_FALLBACK_FONT_FACE,
 			Settings.PROP_FALLBACK_FONT_FACES,
 			Settings.PROP_FOOTNOTES,
 			Settings.PROP_APP_HIGHLIGHT_BOOKMARKS,

--- a/cr3qt/CMakeLists.txt
+++ b/cr3qt/CMakeLists.txt
@@ -2,7 +2,7 @@
 SET(CR3_UIS
   src/aboutdlg.ui        src/bookmarklistdlg.ui  src/mainwindow.ui  src/settings.ui
   src/addbookmarkdlg.ui  src/filepropsdlg.ui     src/recentdlg.ui   src/tocdlg.ui
-  src/wolexportdlg.ui    src/exportprogressdlg.ui src/searchdlg.ui
+  src/wolexportdlg.ui    src/exportprogressdlg.ui src/searchdlg.ui  src/fallbackfontsdialog.ui
 )
 
 SET(CR3_MOC_HDRS
@@ -18,6 +18,7 @@ SET(CR3_MOC_HDRS
   src/exportprogressdlg.h
   src/tocdlg.h
   src/searchdlg.h
+  src/fallbackfontsdialog.h
 )
 
 SET (CR3_SOURCES 
@@ -35,6 +36,7 @@ SET (CR3_SOURCES
   src/wolexportdlg.cpp
   src/exportprogressdlg.cpp
   src/searchdlg.cpp
+  src/fallbackfontsdialog.cpp
 )
 
 if(MAC)

--- a/cr3qt/src/fallbackfontsdialog.cpp
+++ b/cr3qt/src/fallbackfontsdialog.cpp
@@ -1,0 +1,239 @@
+#include "fallbackfontsdialog.h"
+#include "ui_fallbackfontsdialog.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QComboBox>
+#include <QPushButton>
+#include <QToolButton>
+#include <QSpacerItem>
+
+FallbackFontsDialog::FallbackFontsDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::FallbackFontsDialog)
+{
+    ui->setupUi(this);
+    m_layout = new QVBoxLayout;
+    m_spacer = new QSpacerItem(1, 1, QSizePolicy::Minimum, QSizePolicy::Expanding);
+    m_layout->addItem(m_spacer);
+    ui->frame->setLayout(m_layout);
+}
+
+FallbackFontsDialog::FallbackFontsDialog(QWidget* parent, const QStringList& availFaces) :
+    QDialog(parent),
+    ui(new Ui::FallbackFontsDialog)
+{
+    ui->setupUi(this);
+    m_layout = new QVBoxLayout;
+    m_spacer = new QSpacerItem(1, 1, QSizePolicy::Minimum, QSizePolicy::Expanding);
+    m_layout->addItem(m_spacer);
+    ui->frame->setLayout(m_layout);
+    setAvailableFaces(availFaces);
+}
+
+FallbackFontsDialog::~FallbackFontsDialog()
+{
+    cleanupFontItems();
+    delete ui;
+}
+
+void FallbackFontsDialog::setAvailableFaces(const QStringList& availFaces)
+{
+    m_availableFaces = availFaces;
+}
+
+void FallbackFontsDialog::setFallbackFaces(const QString& faces)
+{
+    m_fallbackFaces = faces;
+    QStringList list;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    list = faces.split(";", Qt::SkipEmptyParts);
+#else
+    // TODO: for Qt older than 5.14
+#endif
+    cleanupFontItems();
+    m_layout->removeItem(m_spacer);
+    QStringList::const_iterator it;
+    int item_idx = 0;
+    FontControlItem* item;
+    for (it = list.begin(); it != list.end(); ++it) {
+        QString face = (*it).trimmed();
+        int face_idx = m_availableFaces.indexOf(face);
+        if (face_idx >= 0) {
+            item = addFontItem(item_idx, face_idx);
+            m_layout->addLayout(item->layout);
+            item_idx++;
+        }
+    }
+    // add empty item
+    item = addFontItem(item_idx, -1);
+    m_layout->addLayout(item->layout);
+    m_layout->addItem(m_spacer);
+}
+
+void FallbackFontsDialog::slot_delete_clicked()
+{
+    int item_idx = -1;
+    QVariant itemIdxProp;
+    QObject* signalSender = sender();
+    if (signalSender)
+        itemIdxProp = signalSender->property("ITEMIDX");
+    if (itemIdxProp.isValid()) {
+        bool ok = false;
+        int tmp = itemIdxProp.toInt(&ok);
+        if (ok)
+            item_idx = tmp;
+    }
+    if (item_idx >= 0 && item_idx < m_items.size()) {
+        bool res = removeFontItem(item_idx);
+        if (res) {
+            if (m_items.size() > 0) {
+                FontControlItem* lastItem = m_items[m_items.size() - 1];
+                if (lastItem && lastItem->btnDel)
+                    lastItem->btnDel->setEnabled(false);
+            }
+            updateFallbackFaces();
+        }
+    }
+}
+
+void FallbackFontsDialog::slot_currectIndexChanged(int index)
+{
+    int item_idx = -1;
+    QVariant itemIdxProp;
+    QObject* signalSender = sender();
+    if (signalSender)
+        itemIdxProp = signalSender->property("ITEMIDX");
+    if (itemIdxProp.isValid()) {
+        bool ok = false;
+        int tmp = itemIdxProp.toInt(&ok);
+        if (ok)
+            item_idx = tmp;
+    }
+    if (item_idx >= 0 && item_idx < m_items.size()) {
+        FontControlItem* item = m_items[item_idx];
+        if (item_idx == m_items.size() - 1) {
+            if (item && item->combobox && !item->combobox->currentText().isEmpty()) {
+                item->btnDel->setEnabled(true);
+                // last empty item changed
+                FontControlItem* newItem = addFontItem(m_items.size(), -1);
+                m_layout->removeItem(m_spacer);
+                m_layout->addLayout(newItem->layout);
+                m_layout->addItem(m_spacer);
+            }
+        } else if (item_idx == m_items.size() - 2) {
+            if (item && item->combobox && item->combobox->currentText().isEmpty()) {
+                FontControlItem* lastItem = m_items[m_items.size() - 1];
+                if (lastItem && lastItem->combobox && lastItem->combobox->currentText().isEmpty()) {
+                    // remove empty last item
+                    removeFontItem(m_items.size() - 1);
+                    item->btnDel->setEnabled(false);
+                }
+            }
+        }
+        updateFallbackFaces();
+    }
+}
+
+FallbackFontsDialog::FontControlItem *FallbackFontsDialog::addFontItem(int pos, int face_idx)
+{
+    FontControlItem* item = new FontControlItem;
+    item->pos = pos;
+    item->layout = new QHBoxLayout;
+    item->combobox = new QComboBox(ui->frame);
+    item->combobox->setProperty("ITEMIDX", pos);
+    item->combobox->addItem("");
+    item->combobox->addItems(m_availableFaces);
+    if (face_idx >= 0)
+        item->combobox->setCurrentIndex(face_idx + 1);
+    item->btnDel = new QToolButton(ui->frame);
+    item->btnDel->setProperty("ITEMIDX", pos);
+    item->btnDel->setEnabled(face_idx >= 0);
+    item->btnDel->setIcon(QIcon(":/icons/action/icons/fileclose.png"));
+    item->btnDel->setToolTip(tr("Remove this fallback font"));
+    item->layout->addWidget(item->combobox, 10);
+    item->layout->addWidget(item->btnDel, 0);
+    connect(item->btnDel, SIGNAL(clicked()), this, SLOT(slot_delete_clicked()));
+    connect(item->combobox, SIGNAL(currentIndexChanged(int)), this, SLOT(slot_currectIndexChanged(int)));
+    m_items.append(item);
+    return item;
+}
+
+bool FallbackFontsDialog::removeFontItem(int pos)
+{
+    if (pos >= 0 && pos < m_items.size()) {
+        FontControlItem* item = m_items[pos];
+        if (item) {
+            if (item->layout) {
+                m_layout->removeItem(item->layout);
+                if (item->btnDel) {
+                    item->btnDel->disconnect();
+                    item->layout->removeWidget(item->btnDel);
+                    delete item->btnDel;
+                }
+                if (item->combobox) {
+                    item->combobox->disconnect();
+                    item->layout->removeWidget(item->combobox);
+                    delete item->combobox;
+                }
+                delete item->layout;
+            }
+            delete item;
+            m_items.remove(pos);
+            // update item's position
+            for (int i = pos; i < m_items.size(); i++) {
+                FontControlItem* item = m_items[i];
+                item->btnDel->setProperty("ITEMIDX", i);
+                item->combobox->setProperty("ITEMIDX", i);
+                item->pos = i;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+void FallbackFontsDialog::cleanupFontItems()
+{
+    QVector<FontControlItem*>::const_iterator it;
+    for (it = m_items.begin(); it != m_items.end(); ++it) {
+        const FontControlItem* item = *it;
+        if (item) {
+            if (item->layout) {
+                if (item->btnDel) {
+                    item->btnDel->disconnect();
+                    item->layout->removeWidget(item->btnDel);
+                    delete item->btnDel;
+                }
+                if (item->combobox) {
+                    item->combobox->disconnect();
+                    item->layout->removeWidget(item->combobox);
+                    delete item->combobox;
+                }
+                m_layout->removeItem(item->layout);
+                delete item->layout;
+            }
+            delete item;
+        }
+    }
+    m_items.clear();
+}
+
+void FallbackFontsDialog::updateFallbackFaces()
+{
+    m_fallbackFaces = QString();
+    for (int i = 0; i < m_items.size() - 1; i++) {
+        FontControlItem* item = m_items[i];
+        if (item) {
+            if (item->combobox) {
+                QString text = item->combobox->currentText();
+                if (!text.isEmpty()) {
+                    m_fallbackFaces.append(text);
+                    if (i < m_items.size() - 2) {
+                        m_fallbackFaces.append("; ");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cr3qt/src/fallbackfontsdialog.h
+++ b/cr3qt/src/fallbackfontsdialog.h
@@ -1,0 +1,55 @@
+#ifndef FALLBACKFONTSDIALOG_H
+#define FALLBACKFONTSDIALOG_H
+
+#include <QDialog>
+#include <QVector>
+#include <QStringList>
+
+namespace Ui {
+	class FallbackFontsDialog;
+}
+
+class QHBoxLayout;
+class QVBoxLayout;
+class QComboBox;
+class QToolButton;
+class QSpacerItem;
+
+class FallbackFontsDialog : public QDialog
+{
+	Q_OBJECT
+private:
+	struct FontControlItem {
+		int pos;
+		QHBoxLayout* layout;
+		QComboBox* combobox;
+		QToolButton* btnDel;
+	};
+public:
+	explicit FallbackFontsDialog(QWidget *parent);
+	explicit FallbackFontsDialog(QWidget *parent, const QStringList& availFaces);
+	~FallbackFontsDialog();
+	void setAvailableFaces(const QStringList& availFaces);
+	QString fallbackFaces() {
+		return m_fallbackFaces;
+	}
+	void setFallbackFaces(const QString& faces);
+protected slots:
+	void slot_delete_clicked();
+	void slot_currectIndexChanged(int);
+protected:
+    FontControlItem* addFontItem(int pos, int face_idx);
+    bool removeFontItem(int pos);
+	void cleanupFontItems();
+	void updateFallbackFaces();
+private:
+	QStringList m_availableFaces;
+	QString m_fallbackFaces;
+	Ui::FallbackFontsDialog *ui;
+	QVBoxLayout* m_layout;
+	QSpacerItem *m_spacer;
+	// data
+	QVector<FontControlItem*> m_items;
+};
+
+#endif // FALLBACKFONTSDIALOG_H

--- a/cr3qt/src/fallbackfontsdialog.ui
+++ b/cr3qt/src/fallbackfontsdialog.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FallbackFontsDialog</class>
+ <widget class="QDialog" name="FallbackFontsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Fallback fonts</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>List of fallback fonts:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>FallbackFontsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>FallbackFontsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/cr3qt/src/i18n/cr3_bg.ts
+++ b/cr3qt/src/i18n/cr3_bg.ts
@@ -1397,7 +1397,7 @@ See README.TXT at root directory of project for build instructions.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fallback font</source>
+        <source>Fallback fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/cr3qt/src/i18n/cr3_cs.ts
+++ b/cr3qt/src/i18n/cr3_cs.ts
@@ -1471,8 +1471,8 @@ p, li { white-space: pre-wrap; }
         <translation>Automatické instruování písma</translation>
     </message>
     <message>
-        <source>Fallback font</source>
-        <translation>Záložní písmo</translation>
+        <source>Fallback fonts</source>
+        <translation>Záložní písma</translation>
     </message>
     <message>
         <source>Enable document internal styles</source>

--- a/cr3qt/src/i18n/cr3_ru.ts
+++ b/cr3qt/src/i18n/cr3_ru.ts
@@ -1630,8 +1630,8 @@ p, li { white-space: pre-wrap; }
         <translation>Автохинтинг</translation>
     </message>
     <message>
-        <source>Fallback font</source>
-        <translation>Дополнительный шрифт</translation>
+        <source>Fallback fonts</source>
+        <translation>Дополнительные шрифты</translation>
     </message>
     <message>
         <source>Enable document internal styles</source>

--- a/cr3qt/src/i18n/cr3_ru.ts
+++ b/cr3qt/src/i18n/cr3_ru.ts
@@ -48,9 +48,9 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libpng - PNG image format support&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libjpeg - JPEG image format support&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Hyphenation dictionaries - from AlReader&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt;Languages character set database by Fontconfig&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Languages character set database by Fontconfig&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -66,7 +66,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libpng - библиотека поддержки изображений формата PNG&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libjpeg - библиотека поддержки изображений формата JPEG&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Словари переносов - из AlReader&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt;Набор символов различных письменностей от Fontconfig&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Набор символов различных письменностей от Fontconfig&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
@@ -78,7 +78,7 @@ Latest source code is available from GIT repository:
 
 See README.TXT at root directory of project for build instructions.
 </source>
-        <translation type="unfinished">Исходный код доступен на странице проекта crengine:
+        <translation>Исходный код доступен на странице проекта crengine:
 http://sourceforge.net/projects/crengine/
 
 Исходный код доступен из GIT репозитория:
@@ -122,6 +122,46 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libjpeg - библиотека поддержки изображений формата JPEG&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Словари переносов - из AlReader&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;CoolReader is free open source e-book viewer based on CoolReader engine.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Source code is available at SourceForge &lt;/span&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; text-decoration: underline;&quot;&gt;http://sourceforge.net/projects/crengine &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;under the terms of GNU GPL2 license.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; text-decoration: underline;&quot;&gt;Third party components used:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Qt %QT_VER% - as GUI library&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;FreeType - font engine&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;HarfBuzz - font kerning, ligatures&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;ZLib - compressing library&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libpng - PNG image format support&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libjpeg - JPEG image format support&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:9pt;&quot;&gt;NanoSVG - SVG image format support&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Hyphenation dictionaries - from AlReader&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Languages character set database by Fontconfig&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;CoolReader это свободная программа с открытым исходным кодом для просмотра електронных книг основана на движке CoolReader.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Исходный код доступен на SourceForge &lt;/span&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; text-decoration: underline;&quot;&gt;http://sourceforge.net/projects/crengine &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;под лицензией GNU GPL2.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; text-decoration: underline;&quot;&gt;Использованы следующие компоненты:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Qt %QT_VER% - библиотека ГПИ&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;FreeType - шрифтовой движок&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;HarfBuzz - кернинг шрифта, лигатуры&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;ZLib - библиотека сжатия&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libpng - библиотека поддержки изображений формата PNG&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;libjpeg - библиотека поддержки изображений формата JPEG&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:9pt;&quot;&gt;NanoSVG - SVG image format support&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Словари переносов - из AlReader&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;Набор символов различных писменностей от Fontconfig&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;DejaVu Sans&apos;; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -256,6 +296,14 @@ p, li { white-space: pre-wrap; }
         <source>Loading: please wait...</source>
         <translation>Загрузка: подождите...</translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation>Предупреждение</translation>
+    </message>
+    <message>
+        <source>Font &quot;%1&quot; isn&apos;t compatible with language &quot;%2&quot;. Instead will be used fallback font.</source>
+        <translation>Шрифт &quot;%1&quot; не совместим с языком &quot;%2&quot;. Вместо него будет задействован дополнительный шрифт.</translation>
+    </message>
 </context>
 <context>
     <name>ExportProgressDlg</name>
@@ -266,6 +314,21 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Export is in progress...</source>
         <translation>Идет экспорт...</translation>
+    </message>
+</context>
+<context>
+    <name>FallbackFontsDialog</name>
+    <message>
+        <source>Fallback fonts</source>
+        <translation>Дополнительные шрифты</translation>
+    </message>
+    <message>
+        <source>List of fallback fonts:</source>
+        <translation>Список дополнительных шрифтов:</translation>
+    </message>
+    <message>
+        <source>Remove this fallback font</source>
+        <translation>Удалить этот дополнительный шрифт</translation>
     </message>
 </context>
 <context>
@@ -488,6 +551,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>ZIP archives</source>
         <translation>Архивы ZIP</translation>
+    </message>
+    <message>
+        <source>FB3 books</source>
+        <translation>Книги FB3</translation>
+    </message>
+    <message>
+        <source>Open Document files</source>
+        <translation type="unfinished">Файлы Open Document</translation>
     </message>
 </context>
 <context>
@@ -1823,11 +1894,75 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Use ligatures</source>
-        <translation>Использовать лигатуры</translation>
+        <translation type="vanished">Использовать лигатуры</translation>
     </message>
     <message>
         <source>Enable ligatutes (very slowly!)</source>
-        <translation>Разрешить лигатуры (очень медленно!)</translation>
+        <translation type="vanished">Разрешить лигатуры (очень медленно!)</translation>
+    </message>
+    <message>
+        <source>Rendering flags</source>
+        <translation type="unfinished">Флаги рендеринга</translation>
+    </message>
+    <message>
+        <source>Legacy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Web (Full)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DOM level:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Newest</source>
+        <translation type="unfinished">Самый новый</translation>
+    </message>
+    <message>
+        <source>Multi languages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Support for multilingual documents</source>
+        <translation type="unfinished">Поддержка мультиязычных документов</translation>
+    </message>
+    <message>
+        <source>Manage...</source>
+        <translation>Настроить...</translation>
+    </message>
+    <message>
+        <source>Text Shaping</source>
+        <translation type="unfinished">Формировщик текста</translation>
+    </message>
+    <message>
+        <source>Simple (FreeType only, fastest)</source>
+        <translation type="unfinished">Простой (FreeType only, быстрый)</translation>
+    </message>
+    <message>
+        <source>Light (HarfBuzz without ligatures)</source>
+        <translation type="unfinished">Легкий (HarfBuzz, без лигатур)</translation>
+    </message>
+    <message>
+        <source>Full (HarfBuzz with ligatures)</source>
+        <translation type="unfinished">Полный (HarfBuzz, с лигатурами)</translation>
+    </message>
+    <message>
+        <source>Hyphenation:</source>
+        <translation>Переносы:</translation>
+    </message>
+    <message>
+        <source>Enable hyphenation</source>
+        <translation>Разрешить переносы</translation>
     </message>
 </context>
 <context>

--- a/cr3qt/src/i18n/cr3_uk.ts
+++ b/cr3qt/src/i18n/cr3_uk.ts
@@ -1908,8 +1908,8 @@ p, li { white-space: pre-wrap; }
         <translation>Автохінтинг</translation>
     </message>
     <message>
-        <source>Fallback font</source>
-        <translation>Допоміжний шрифт</translation>
+        <source>Fallback fonts</source>
+        <translation>Додаткові шрифти</translation>
     </message>
     <message>
         <source>Stylesheet</source>

--- a/cr3qt/src/settings.h
+++ b/cr3qt/src/settings.h
@@ -147,6 +147,7 @@ private:
     QString m_oldHyph;
     QStringList m_backgroundFiles;
     QStringList m_faceList;
+    QString m_defFontFace;
     QString m_styleName;
     StyleItem m_styleItemAlignment;
     StyleItem m_styleItemIndent;
@@ -209,7 +210,6 @@ private slots:
     void on_cbDefFontStyle_currentIndexChanged(int index);
     void on_cbDefFontColor_currentIndexChanged(int index);
     void on_cbFontHinting_currentIndexChanged(int index);
-    void on_cbFallbackFontFace_currentIndexChanged(const QString &arg1);
     void on_cbEnableEmbeddedFonts_toggled(bool checked);
     void on_cbEnableDocumentStyles_toggled(bool checked);
     void on_btnSelectionColor_clicked();
@@ -229,6 +229,7 @@ private slots:
     void on_cbDOMLevel_currentIndexChanged(int index);
     void on_cbMultiLang_stateChanged(int state);
     void on_cbEnableHyph_stateChanged(int state);
+    void on_btnFallbackMan_clicked();
 };
 
 #endif // SETTINGSDLG_H

--- a/cr3qt/src/settings.ui
+++ b/cr3qt/src/settings.ui
@@ -1493,17 +1493,20 @@
          <item row="10" column="0">
           <widget class="QLabel" name="label_36">
            <property name="text">
-            <string>Fallback font</string>
+            <string>Fallback fonts</string>
            </property>
           </widget>
          </item>
          <item row="10" column="1">
-          <widget class="QComboBox" name="cbFallbackFontFace">
+          <widget class="QPushButton" name="btnFallbackMan">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Manage...</string>
            </property>
           </widget>
          </item>
@@ -1733,8 +1736,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>393</width>
-              <height>620</height>
+              <width>389</width>
+              <height>621</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -1974,7 +1977,7 @@
   <tabstop>cbMultiLang</tabstop>
   <tabstop>cbHyphenation</tabstop>
   <tabstop>cbFontGamma</tabstop>
-  <tabstop>cbFallbackFontFace</tabstop>
+  <tabstop>btnFallbackMan</tabstop>
   <tabstop>cbFontHinting</tabstop>
   <tabstop>cbFontShaping</tabstop>
   <tabstop>cbInterlineSpace</tabstop>
@@ -2011,8 +2014,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>257</x>
-     <y>472</y>
+     <x>266</x>
+     <y>739</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -2027,8 +2030,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>325</x>
-     <y>472</y>
+     <x>334</x>
+     <y>739</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -18,7 +18,6 @@
 #define PROP_LOG_LEVEL               "crengine.log.level"
 #define PROP_LOG_AUTOFLUSH           "crengine.log.autoflush"
 #define PROP_FONT_SIZE               "crengine.font.size"
-#define PROP_FALLBACK_FONT_FACE      "crengine.font.fallback.face"
 #define PROP_FALLBACK_FONT_FACES     "crengine.font.fallback.faces"
 #define PROP_STATUS_FONT_COLOR       "crengine.page.header.font.color"
 #define PROP_STATUS_FONT_FACE        "crengine.page.header.font.face"

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -35,11 +35,7 @@ public:
     /// returns most similar font
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
                                 int features=0, int documentId = -1, bool useBias=false) = 0;
-    /// set fallback font face (returns true if specified font is found)
-    virtual bool SetFallbackFontFace( lString8 face ) {
-        CR_UNUSED(face);
-        return false;
-    }
+
     /// set fallback font face list semicolon separated (returns true if any font is found)
     virtual bool SetFallbackFontFaces( lString8 faces ) {
         CR_UNUSED(faces);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6315,8 +6315,6 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 	if (list.length() > 0 && !list.contains(props->getStringDef(PROP_FONT_FACE,
 			defFontFace.c_str())))
 		props->setString(PROP_FONT_FACE, list[0]);
-	//props->setStringDef(PROP_FALLBACK_FONT_FACE, props->getStringDef(PROP_FONT_FACE,
-    //                    defFontFace.c_str()));
 	props->setStringDef(PROP_FALLBACK_FONT_FACES, fallbackFonts);
 
 	props->setIntDef(PROP_FONT_SIZE,
@@ -6603,21 +6601,13 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         } else if (name == PROP_FONT_FACE) {
             setDefaultFontFace(UnicodeToUtf8(value));
             needUpdateMargins = true;
-        } else if (name == PROP_FALLBACK_FONT_FACE) {
-            lString8 oldFace = fontMan->GetFallbackFontFace();
-            if ( UnicodeToUtf8(value)!=oldFace )
-                fontMan->SetFallbackFontFace(UnicodeToUtf8(value));
-            value = Utf8ToUnicode(fontMan->GetFallbackFontFace());
-            if ( UnicodeToUtf8(value) != oldFace ) {
-                REQUEST_RENDER("propsApply  fallback font face")
-            }
         } else if (name == PROP_FALLBACK_FONT_FACES) {
             lString8 oldFaces = fontMan->GetFallbackFontFaces();
             if ( UnicodeToUtf8(value)!=oldFaces )
                 fontMan->SetFallbackFontFaces(UnicodeToUtf8(value));
             value = Utf8ToUnicode(fontMan->GetFallbackFontFaces());
             if ( UnicodeToUtf8(value) != oldFaces ) {
-                REQUEST_RENDER("propsApply  fallback font face")
+                REQUEST_RENDER("propsApply  fallback font faces")
             }
         } else if (name == PROP_STATUS_FONT_FACE) {
             setStatusFontFace(UnicodeToUtf8(value));

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -356,8 +356,13 @@ LVFont *LVFreeTypeFace::getFallbackFont(lUInt32 fallbackPassMask) {
     // Get first unprocessed font
     if (!res.isNull() ) {
         if ( res->getFallbackMask() & fallbackPassMask ) {       // already processed
-            // (full_mask & fallbackPassMask) != full_mask, then recursion is not endless
-            res = res->getFallbackFont(fallbackPassMask | _fallback_mask);
+            if ((fallbackPassMask | _fallback_mask) != fallbackPassMask) {
+                // (full_mask & fallbackPassMask) != full_mask, then recursion is not endless
+                res = res->getFallbackFont(fallbackPassMask | _fallback_mask);
+            } else {
+                CRLog::error("getFallbackFont(): invalid fallback pass mask: fallbackPassMask=0x%04X, _fallback_mask=0x%04X", fallbackPassMask, _fallback_mask);
+                return NULL;
+            }
         }
     }
     return res.get();

--- a/crengine/src/private/lvfreetypefontman.cpp
+++ b/crengine/src/private/lvfreetypefontman.cpp
@@ -38,31 +38,6 @@ lUInt32 LVFreeTypeFontManager::GetFontListHash(int documentId) {
     return _cache.GetFontListHash(documentId) * 75 + _fallbackFontFaces.getHash();
 }
 
-bool LVFreeTypeFontManager::SetFallbackFontFace(lString8 face) {
-    FONT_MAN_GUARD
-    lString8 oldFace = _fallbackFontFaces.length() > 0 ? _fallbackFontFaces[0] : lString8();
-    if (face != oldFace) {
-        CRLog::trace("Looking for fallback font %s", face.c_str());
-        LVFontCacheItem *item = _cache.findFallback(face, -1);
-        if (!item) {
-            face.clear();
-            // Don't reset previous fallback if this one is not found/valid
-            return false;
-        }
-        _cache.clearFallbackFonts();
-        if (_fallbackFontFaces.empty())
-            _fallbackFontFaces.add(face);
-        else
-            _fallbackFontFaces[0] = face;
-        // Somehow, with Fedra Serif (only!), changing the fallback font does
-        // not prevent glyphs from previous fallback font to be re-used...
-        // So let's clear glyphs caches too.
-        gc();
-        clearGlyphCache();
-    }
-    return _fallbackFontFaces.length() > 0;
-}
-
 bool LVFreeTypeFontManager::SetFallbackFontFaces(lString8 facesStr)
 {
     FONT_MAN_GUARD
@@ -457,24 +432,8 @@ bool LVFreeTypeFontManager::initSystemFonts() {
         FcFontSetDestroy(fontset);
         CRLog::info("FONTCONFIG: %d fonts registered", facesFound);
         
-        const char * fallback_faces [] = {
-            "Arial Unicode MS",
-            "AR PL ShanHeiSun Uni",
-            "Liberation Sans",
-            "Roboto",
-            "DejaVu Sans",
-            "Noto Sans",
-            "Droid Sans",
-            NULL
-        };
-        
-        for ( int i=0; fallback_faces[i]; i++ )
-            if ( SetFallbackFontFace(lString8(fallback_faces[i])) ) {
-                CRLog::info("Fallback font %s is found", fallback_faces[i]);
-                break;
-            } else {
-                CRLog::trace("Fallback font %s is not found", fallback_faces[i]);
-            }
+        const char * fallback_faces = "Arial Unicode MS; AR PL ShanHeiSun Uni; Liberation Sans; Roboto; DejaVu Sans; Noto Sans; Droid Sans";
+        SetFallbackFontFaces(lString8(fallback_faces));
         
         return facesFound > 0;
     }

--- a/crengine/src/private/lvfreetypefontman.h
+++ b/crengine/src/private/lvfreetypefontman.h
@@ -47,9 +47,6 @@ public:
     /// get hash of installed fonts and fallback font
     virtual lUInt32 GetFontListHash(int documentId);
 
-    /// set fallback font
-    virtual bool SetFallbackFontFace(lString8 face);
-
     /// set fallback font face list semicolon separated (returns true if any font is found)
     virtual bool SetFallbackFontFaces(lString8 facesStr );
 

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -158,6 +158,8 @@ HyphMethod * TextLangMan::getHyphMethodForLang( lString32 lang_tag ) {
     HyphDictionary* dict;
     lString32 dict_lang_tag;
     lang_tag.lowercase();
+    int left_hyphen_min = 2;
+    int right_hyphen_min = 3;
     for (int i = 0; i < dictList->length(); i++) {
         dict = dictList->get(i);
         if (dict) {
@@ -166,9 +168,16 @@ HyphMethod * TextLangMan::getHyphMethodForLang( lString32 lang_tag ) {
             else
                 dict_lang_tag = TextLangMan::getLangTag(dict->getId());         // for default dictionaries
             dict_lang_tag.lowercase();
-            if (lang_tag == dict_lang_tag)
-                return HyphMan::getHyphMethodForDictionary( dict->getId(),
-                            _hyph_dict_table[i].left_hyphen_min, _hyph_dict_table[i].right_hyphen_min);
+            if (lang_tag == dict_lang_tag) {
+                for (int j=0; _hyph_dict_table[j].lang_tag!=NULL; j++) {
+                    if ( lang_tag == lString32(_hyph_dict_table[j].lang_tag).lowercase() ) {
+                        left_hyphen_min = _hyph_dict_table[j].left_hyphen_min;
+                        right_hyphen_min = _hyph_dict_table[j].right_hyphen_min;
+                        break;
+                    }
+                }
+                return HyphMan::getHyphMethodForDictionary( dict->getId(), left_hyphen_min, right_hyphen_min );
+            }
         }
     }
     // Look for lang_tag initial subpart
@@ -185,8 +194,14 @@ HyphMethod * TextLangMan::getHyphMethodForLang( lString32 lang_tag ) {
                     dict_lang_tag = TextLangMan::getLangTag(dict->getId());     // for default dictionaries
                 dict_lang_tag.lowercase();
                 if (lang_tag2 == dict_lang_tag)
-                    return HyphMan::getHyphMethodForDictionary( dict->getId(),
-                                _hyph_dict_table[i].left_hyphen_min, _hyph_dict_table[i].right_hyphen_min);
+                    for (int j=0; _hyph_dict_table[j].lang_tag!=NULL; j++) {
+                        if ( lang_tag == lString32(_hyph_dict_table[j].lang_tag).lowercase() ) {
+                            left_hyphen_min = _hyph_dict_table[j].left_hyphen_min;
+                            right_hyphen_min = _hyph_dict_table[j].right_hyphen_min;
+                            break;
+                        }
+                    }
+                    return HyphMan::getHyphMethodForDictionary( dict->getId(), left_hyphen_min, right_hyphen_min );
             }
         }
     }


### PR DESCRIPTION
* Implemented management over the list of fallback fonts in Qt & Android build. Related to #218.
* Added security check in fallback font processing: potential infinite recursion.
* Fixed incorrect value of "left_hyphen_min" and "right_hyphen_min" values, as well as the "index out of range" bug.

![settings-new-qt-m](https://user-images.githubusercontent.com/36960933/105574348-70d16b80-5d7d-11eb-94a3-1b519fe0f7d7.png)
![settings-new-android-s](https://user-images.githubusercontent.com/36960933/105574353-762eb600-5d7d-11eb-8aa7-19688ca3c28c.png)
