### PR TITLE
Fallback fonts: rework the list management

### DIFF
--- a/android/src/org/coolreader/crengine/BaseActivity.java
+++ b/android/src/org/coolreader/crengine/BaseActivity.java
@@ -1689,8 +1689,8 @@ public class BaseActivity extends Activity implements Settings {
 			boolean res = false;
 			res = applyDefaultFont(props, ReaderView.PROP_FONT_FACE, DeviceInfo.DEF_FONT_FACE) || res;
 			res = applyDefaultFont(props, ReaderView.PROP_STATUS_FONT_FACE, DeviceInfo.DEF_FONT_FACE) || res;
+			res = applyDefaultFallbackFontList(props, ReaderView.PROP_DEFAULT_FALLBACK_FONT_FACES, "Droid Sans Fallback; Noto Sans CJK SC; Noto Sans Arabic UI; Noto Sans Devanagari UI; Roboto; FreeSans; FreeSerif; Noto Serif; Noto Sans; Arial Unicode MS") || res;
 			res = applyDefaultFont(props, ReaderView.PROP_FALLBACK_FONT_FACE, "Droid Sans Fallback") || res;
-			res = applyDefaultFallbackFontList(props, ReaderView.PROP_FALLBACK_FONT_FACES, "Droid Sans Fallback; Noto Sans CJK SC; Noto Sans Arabic UI; Noto Sans Devanagari UI; Roboto; FreeSans; FreeSerif; Noto Serif; Noto Sans; Arial Unicode MS") || res;
 			return res;
 		}
 

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -2629,6 +2629,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		props.remove(PROP_EMBEDDED_FONTS);
 		props.remove(PROP_REQUESTED_DOM_VERSION);
 		props.remove(PROP_RENDER_BLOCK_RENDERING_FLAGS);
+
 		BackgroundThread.ensureBackground();
 		log.v("applySettings()");
 		boolean isFullScreen = props.getBool(PROP_APP_FULLSCREEN, false);

--- a/android/src/org/coolreader/crengine/Settings.java
+++ b/android/src/org/coolreader/crengine/Settings.java
@@ -29,8 +29,8 @@ public interface Settings {
     public static final String PROP_LOG_LEVEL               ="crengine.log.level";
     public static final String PROP_LOG_AUTOFLUSH           ="crengine.log.autoflush";
     public static final String PROP_FONT_SIZE               ="crengine.font.size";
+    public static final String PROP_DEFAULT_FALLBACK_FONT_FACES ="crengine.font.default.fallback.faces";
     public static final String PROP_FALLBACK_FONT_FACE      ="crengine.font.fallback.face";
-	public static final String PROP_FALLBACK_FONT_FACES     ="crengine.font.fallback.faces";
     public static final String PROP_STATUS_FONT_COLOR       ="crengine.page.header.font.color";
     public static final String PROP_STATUS_FONT_COLOR_DAY   ="crengine.page.header.font.color.day";
     public static final String PROP_STATUS_FONT_COLOR_NIGHT ="crengine.page.header.font.color.night";

--- a/android/src/org/coolreader/sync2/Synchronizer.java
+++ b/android/src/org/coolreader/sync2/Synchronizer.java
@@ -123,7 +123,6 @@ public class Synchronizer {
 
 	private static final String[] ALLOWED_OPTIONS_PROP_NAMES = {
 			Settings.PROP_FALLBACK_FONT_FACE,
-			Settings.PROP_FALLBACK_FONT_FACES,
 			Settings.PROP_FOOTNOTES,
 			Settings.PROP_APP_HIGHLIGHT_BOOKMARKS,
 			Settings.PROP_HYPHENATION_DICT,

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -18,6 +18,7 @@
 #define PROP_LOG_LEVEL               "crengine.log.level"
 #define PROP_LOG_AUTOFLUSH           "crengine.log.autoflush"
 #define PROP_FONT_SIZE               "crengine.font.size"
+#define PROP_DEFAULT_FALLBACK_FONT_FACES "crengine.font.default.fallback.faces"
 #define PROP_FALLBACK_FONT_FACE      "crengine.font.fallback.face"
 #define PROP_FALLBACK_FONT_FACES     "crengine.font.fallback.faces"
 #define PROP_STATUS_FONT_COLOR       "crengine.page.header.font.color"

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -35,6 +35,10 @@ public:
     /// returns most similar font
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
                                 int features=0, int documentId = -1, bool useBias=false) = 0;
+    /// set a default fallback font faces list semicolon separated
+    virtual void SetDefaultFallbackFontFaces( lString8 faces ) {
+        CR_UNUSED(faces);
+    }
     /// set fallback font face (returns true if specified font is found)
     virtual bool SetFallbackFontFace( lString8 face ) {
         CR_UNUSED(face);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6315,9 +6315,9 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 	if (list.length() > 0 && !list.contains(props->getStringDef(PROP_FONT_FACE,
 			defFontFace.c_str())))
 		props->setString(PROP_FONT_FACE, list[0]);
-	//props->setStringDef(PROP_FALLBACK_FONT_FACE, props->getStringDef(PROP_FONT_FACE,
-    //                    defFontFace.c_str()));
-	props->setStringDef(PROP_FALLBACK_FONT_FACES, fallbackFonts);
+	props->setStringDef(PROP_DEFAULT_FALLBACK_FONT_FACES, fallbackFonts);
+	props->setStringDef(PROP_FALLBACK_FONT_FACE, props->getStringDef(PROP_FONT_FACE,
+                                                                         defFontFace.c_str()));
 
 	props->setIntDef(PROP_FONT_SIZE,
 			m_font_sizes[m_font_sizes.length() * 2 / 3]);
@@ -6603,20 +6603,14 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         } else if (name == PROP_FONT_FACE) {
             setDefaultFontFace(UnicodeToUtf8(value));
             needUpdateMargins = true;
+        } else if (name == PROP_DEFAULT_FALLBACK_FONT_FACES) {
+            fontMan->SetDefaultFallbackFontFaces(UnicodeToUtf8(value));
         } else if (name == PROP_FALLBACK_FONT_FACE) {
             lString8 oldFace = fontMan->GetFallbackFontFace();
             if ( UnicodeToUtf8(value)!=oldFace )
                 fontMan->SetFallbackFontFace(UnicodeToUtf8(value));
             value = Utf8ToUnicode(fontMan->GetFallbackFontFace());
             if ( UnicodeToUtf8(value) != oldFace ) {
-                REQUEST_RENDER("propsApply  fallback font face")
-            }
-        } else if (name == PROP_FALLBACK_FONT_FACES) {
-            lString8 oldFaces = fontMan->GetFallbackFontFaces();
-            if ( UnicodeToUtf8(value)!=oldFaces )
-                fontMan->SetFallbackFontFaces(UnicodeToUtf8(value));
-            value = Utf8ToUnicode(fontMan->GetFallbackFontFaces());
-            if ( UnicodeToUtf8(value) != oldFaces ) {
                 REQUEST_RENDER("propsApply  fallback font face")
             }
         } else if (name == PROP_STATUS_FONT_FACE) {

--- a/crengine/src/private/lvfreetypefontman.h
+++ b/crengine/src/private/lvfreetypefontman.h
@@ -35,6 +35,7 @@ class LVFreeTypeFontManager : public LVFontManager {
 private:
     lString8 _path;
     lString8Collection _fallbackFontFaces;
+    lString8 _defaultFallbackFontFaces;
     LVFontCache _cache;
     FT_Library _library;
     LVFontGlobalGlyphCache _globalCache;
@@ -47,7 +48,12 @@ public:
     /// get hash of installed fonts and fallback font
     virtual lUInt32 GetFontListHash(int documentId);
 
+    /// set default fallback font face list semicolon separated (returns true if any font is found)
+    /// this list is appended to the fonts on calls to SetFallbackFontFace()
+    virtual void SetDefaultFallbackFontFaces(lString8 faces);
+
     /// set fallback font
+    /// Updated the fallback font faces list, appending the given 'face and the default list.
     virtual bool SetFallbackFontFace(lString8 face);
 
     /// set fallback font face list semicolon separated (returns true if any font is found)


### PR DESCRIPTION
Add support for storing a default fallback font face list which is
appended when setting a single font face.

The front ends are only setting a single fallback font, but also rely
on a larger fallback font sets which is either the default crengine
list or a platform specific list. This was failing because the code
paths had been setting a single user specified fallback font and then
overriding this with the fallback list.

The code could also get stuck with a filtered list of fallback fonts
and did not retry the filter in the case of new fonts being added. The
new default list is not filtered and when the fallback font changes
they are all retried which now picks up new fonts that might be
available.

This was my re-attempt at getting this working, but I see a much my extensive attempt at https://github.com/buggins/coolreader/pull/241 which I will look at, but here are some ideas too.