### PR TITLE
Add option to ignore document internal margins

### DIFF
--- a/android/res/raw/chm.css
+++ b/android/res/raw/chm.css
@@ -1,6 +1,9 @@
 head, style, form, script { display: none; } 
 
-body { $def.all } 
+body {
+    $def.all
+    $body.margin
+}
 
 DocFragment { page-break-before: always }
 

--- a/android/res/raw/epub.css
+++ b/android/res/raw/epub.css
@@ -1,7 +1,8 @@
 body {
     text-indent: 0;
-    margin: 0;
     text-align: justify;
+    margin: 0;
+    $body.margin
 }
 
 head, script {

--- a/android/res/raw/fb2.css
+++ b/android/res/raw/fb2.css
@@ -1,4 +1,9 @@
-body { text-align: left; margin: 0; text-indent: 0px }
+body {
+    text-align: left;
+    text-indent: 0px;
+    margin: 0;
+    $body.margin
+}
 
 p { $def.all } 
 
@@ -139,4 +144,4 @@ img {
    text-indent: 0em; 
    border-style: solid; 
    border-width: medium; 
-} 
+}

--- a/android/res/raw/fb3.css
+++ b/android/res/raw/fb3.css
@@ -1,4 +1,9 @@
-body { text-align: left; margin: 0; text-indent: 0px }
+body {
+    text-align: left;
+    text-indent: 0px;
+    margin: 0;
+    $body.margin
+}
 
 p { $def.all } 
 
@@ -137,4 +142,4 @@ img {
    text-indent: 0em; 
    border-style: solid; 
    border-width: medium; 
-} 
+}

--- a/android/res/raw/htm.css
+++ b/android/res/raw/htm.css
@@ -1,6 +1,9 @@
 head, style, form, script { display: none; } 
 
-body { $def.all } 
+body {
+    $def.all
+    $body.margin
+}
 
 p { $def.all } 
 *.justindent { text-align: justify; text-indent: 1.2em; margin-top:0em; margin-bottom: 0em }

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="options_page_landscape_pages">Landscape pages</string>
     <string name="options_page_landscape_pages_one">One page</string>
     <string name="options_page_landscape_pages_two">Two pages</string>
+    <string name="options_ignore_document_margins">Ignore document margins</string>
     <string name="options_page_margin_left">Left margin</string>
     <string name="options_page_margin_right">Right margin</string>
     <string name="options_page_margin_top">Top margin</string>

--- a/cr3qt/data/chm.css
+++ b/cr3qt/data/chm.css
@@ -1,6 +1,9 @@
 head, style, form, script { display: none; } 
 
-body { $def.all } 
+body {
+    $def.all
+    $body.margin
+}
 
 DocFragment { page-break-before: always }
 

--- a/cr3qt/data/epub.css
+++ b/cr3qt/data/epub.css
@@ -1,7 +1,8 @@
 body {
     text-indent: 0;
-    margin: 0;
     text-align: justify;
+    margin: 0;
+    $body.margin
 }
 
 head, script {

--- a/cr3qt/data/fb2.css
+++ b/cr3qt/data/fb2.css
@@ -1,4 +1,9 @@
-body { text-align: left; margin: 0; text-indent: 0px }
+body {
+    text-align: left;
+    text-indent: 0px;
+    margin: 0;
+    $body.margin
+}
 
 p { $def.all } 
 
@@ -139,4 +144,4 @@ img {
    text-indent: 0em; 
    border-style: solid; 
    border-width: medium; 
-} 
+}

--- a/cr3qt/data/fb3.css
+++ b/cr3qt/data/fb3.css
@@ -1,4 +1,9 @@
-body { text-align: left; margin: 0; text-indent: 0px }
+body {
+    text-align: left;
+    text-indent: 0px;
+    margin: 0;
+    $body.margin
+}
 
 p { $def.all } 
 
@@ -137,4 +142,4 @@ img {
    text-indent: 0em; 
    border-style: solid; 
    border-width: medium; 
-} 
+}

--- a/cr3qt/data/htm.css
+++ b/cr3qt/data/htm.css
@@ -1,6 +1,9 @@
 head, style, form, script { display: none; } 
 
-body { $def.all } 
+body {
+    $def.all
+    $body.margin
+}
 
 p { $def.all } 
 *.justindent { text-align: justify; text-indent: 1.2em; margin-top:0em; margin-bottom: 0em }

--- a/cr3qt/src/settings.cpp
+++ b/cr3qt/src/settings.cpp
@@ -161,6 +161,9 @@ SettingsDlg::SettingsDlg(QWidget *parent, CR3View * docView ) :
         m_props->setString(PROP_FONT_GAMMA, "1.0");
     optionToUiString(PROP_FONT_GAMMA, m_ui->cbFontGamma);
 
+    QString ignoreDocMargins = m_props->getStringDef("styles.body.margin", "");
+    m_ui->cbIgnoreDocumentMargins->setCheckState(ignoreDocMargins.length() > 0 ?  Qt::Checked : Qt::Unchecked);
+
     optionToUiInversed( PROP_STATUS_LINE, m_ui->cbShowPageHeader );
 
     bool b = m_props->getIntDef( PROP_STATUS_LINE, 0 )==0;
@@ -1071,10 +1074,17 @@ void SettingsDlg::on_cbEnableEmbeddedFonts_toggled(bool checked)
     setCheck(PROP_EMBEDDED_FONTS, checked ? Qt::Checked : Qt::Unchecked);
 }
 
+void SettingsDlg::on_cbIgnoreDocumentMargins_stateChanged(int s)
+{
+    QString value = (s == Qt::Checked) ? "margin: 0em !important" : "";
+    m_props->setString("styles.body.margin", value);
+}
+
 void SettingsDlg::on_cbEnableDocumentStyles_toggled(bool checked)
 {
     setCheck(PROP_EMBEDDED_STYLES, checked ? Qt::Checked : Qt::Unchecked);
     m_ui->cbEnableEmbeddedFonts->setEnabled(checked);
+    m_ui->cbIgnoreDocumentMargins->setEnabled(checked);
 }
 
 void SettingsDlg::on_btnSelectionColor_clicked()

--- a/cr3qt/src/settings.h
+++ b/cr3qt/src/settings.h
@@ -184,6 +184,7 @@ private slots:
     void on_cbShowBattery_stateChanged(int s);
     void on_cbShowClock_stateChanged(int s);
     void on_cbShowBookName_stateChanged(int s);
+    void on_cbIgnoreDocumentMargins_stateChanged(int s);
     void on_cbShowPageHeader_stateChanged(int s);
     void on_cbViewMode_currentIndexChanged(int index);
     void on_cbWindowShowScrollbar_stateChanged(int );

--- a/cr3qt/src/settings.ui
+++ b/cr3qt/src/settings.ui
@@ -1653,27 +1653,41 @@
           </widget>
          </item>
          <item row="18" column="0">
+          <widget class="QLabel" name="label_49">
+           <property name="text">
+            <string>Internal</string>
+           </property>
+          </widget>
+         </item>
+         <item row="18" column="1">
+          <widget class="QCheckBox" name="cbIgnoreDocumentMargins">
+           <property name="text">
+            <string>Ignore document margins</string>
+           </property>
+          </widget>
+         </item>
+         <item row="19" column="0">
           <widget class="QLabel" name="label_17">
            <property name="text">
             <string>.TXT files</string>
            </property>
           </widget>
          </item>
-         <item row="18" column="1">
+         <item row="19" column="1">
           <widget class="QCheckBox" name="cbTxtPreFormatted">
            <property name="text">
             <string>Disable automatic formatting</string>
            </property>
           </widget>
          </item>
-         <item row="19" column="0">
+         <item row="209" column="0">
           <widget class="QLabel" name="label_15">
            <property name="text">
             <string>Sample</string>
            </property>
           </widget>
          </item>
-         <item row="19" column="1">
+         <item row="20" column="1">
           <widget class="CR3View" name="crSample" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">


### PR DESCRIPTION
Some epub documents set margins that can become a problem viewing on
small screen devices, so add an option to ignore these.

btw KOreader appears to have an extensible feature for adding style mods and a similar one for this. The PR is a minimal change to be consistent with the existing CR code.

Tested on epub and html documents.
