### PR TITLE
CSS: add units vw vh vmin vmax

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -241,6 +241,10 @@ enum css_value_type_t {
     css_val_pt,  // 1/72 in  72pt = 96 css px
     css_val_pc,  // 12 pt     6pc = 96 css px
     css_val_percent,
+    css_val_vw,   // 1 percent of the screen width
+    css_val_vh,   // 1 percent of the screen height
+    css_val_vmin, // maximum of 1 percent of the screen height or width
+    css_val_vmax, // minimum of 1 percent of the screen height or width
     css_val_color,
     css_val_screen_px  // screen px, for already scaled values
 };

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -117,7 +117,7 @@ bool isSameFontStyle( css_style_rec_t * style1, css_style_rec_t * style2 );
 /// removes format data from node
 void freeFormatData( ldomNode * node );
 /// returns best suitable font for style
-LVFontRef getFont(css_style_rec_t * style, int documentId);
+LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId);
 /// initializes format data for node
 void initFormatData( ldomNode * node );
 /// initializes rendering method for node
@@ -166,7 +166,7 @@ void LVRendSetFontEmbolden( int addWidth=STYLE_FONT_EMBOLD_MODE_EMBOLD );
 int LVRendGetFontEmbolden();
 
 int measureBorder(ldomNode *enode,int border);
-int lengthToPx( css_length_t val, int base_px, int base_em, bool unspecified_as_em=false );
+int lengthToPx( ldomNode *enode, css_length_t val, int base_px, int base_em = -1, bool unspecified_as_em=false );
 int scaleForRenderDPI( int value );
 
 #define BASE_CSS_DPI 96 // at 96 dpi, 1 css px = 1 screen px

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -592,6 +592,14 @@ static bool parse_number_value( const char * & str, css_length_t & value,
             return false;
         }
     }
+    else if ( substr_icompare( "vw", str ) )
+        value.type = css_val_vw;
+    else if ( substr_icompare( "vh", str ) )
+        value.type = css_val_vh;
+    else if ( substr_icompare( "vmin", str ) )
+        value.type = css_val_vmin;
+    else if ( substr_icompare( "vmax", str ) )
+        value.type = css_val_vmax;
     else if (n == 0 && frac == 0)
         value.type = css_val_px;
     // allow unspecified unit (for line-height)

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -367,9 +367,8 @@ void LFormattedText::AddSourceObject(
 
     css_style_ref_t style = node->getStyle();
     lInt16 w = 0, h = 0;
-    int em = node->getFont()->getSize();
-    w = lengthToPx(style->width, 100, em);
-    h = lengthToPx(style->height, 100, em);
+    w = lengthToPx(node, style->width, 100);
+    h = lengthToPx(node, style->height, 100);
     // width in % will be computed in measureText() as a % of m_pbuffer->width
     // For height in %, it's more complicated... see:
     //   https://www.w3.org/TR/CSS2/visudet.html#the-width-property

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8283,10 +8283,9 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
         // In legacy mode, we just got the erm_final coordinates, and we must
         // compute and remove left/top border and padding (using rc.width() as
         // the base for % is wrong here, and so is rc.height() for padding top)
-        int em = finalNode->getFont()->getSize();
-        int padding_left = measureBorder(finalNode,3)+lengthToPx(finalNode->getStyle()->padding[0],rc.width(),em);
-        int padding_right = measureBorder(finalNode,1)+lengthToPx(finalNode->getStyle()->padding[1],rc.width(),em);
-        int padding_top = measureBorder(finalNode,0)+lengthToPx(finalNode->getStyle()->padding[2],rc.height(),em);
+        int padding_left = measureBorder(finalNode,3)+lengthToPx(finalNode, finalNode->getStyle()->padding[0],rc.width());
+        int padding_right = measureBorder(finalNode,1)+lengthToPx(finalNode, finalNode->getStyle()->padding[1],rc.width());
+        int padding_top = measureBorder(finalNode,0)+lengthToPx(finalNode, finalNode->getStyle()->padding[2],rc.height());
         pt.x -= padding_left;
         pt.y -= padding_top;
         // As well as the inner width
@@ -8598,12 +8597,11 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
             // In legacy mode, we just got the erm_final coordinates, and we must
             // compute and remove left/top border and padding (using rc.width() as
             // the base for % is wrong here)
-            int em = finalNode->getFont()->getSize();
-            int padding_left = measureBorder(finalNode,3) + lengthToPx(finalNode->getStyle()->padding[0], rc.width(), em);
-            int padding_right = measureBorder(finalNode,1) + lengthToPx(finalNode->getStyle()->padding[1], rc.width(), em);
+            int padding_left = measureBorder(finalNode,3) + lengthToPx(finalNode, finalNode->getStyle()->padding[0], rc.width());
+            int padding_right = measureBorder(finalNode,1) + lengthToPx(finalNode, finalNode->getStyle()->padding[1], rc.width());
             inner_width  = fmt.getWidth() - padding_left - padding_right;
             if (extended) {
-                int padding_top = measureBorder(finalNode,0) + lengthToPx(finalNode->getStyle()->padding[2], rc.width(), em);
+                int padding_top = measureBorder(finalNode,0) + lengthToPx(finalNode, finalNode->getStyle()->padding[2], rc.width());
                 rc.top += padding_top;
                 rc.left += padding_left;
                 // rc.right += padding_left; // wrong, but not used
@@ -10582,18 +10580,16 @@ bool ldomXRange::getRectEx( lvRect & rect, bool & isSingleLine )
     // compute and add left/top border and padding (using rc.width() as
     // the base for % is wrong here, and so is rc.height() for padding top)
     if ( ! RENDER_RECT_HAS_FLAG(fmt1, INNER_FIELDS_SET) ) {
-        int em = finalNode1->getFont()->getSize();
-        int padding_left = measureBorder(finalNode1,3) + lengthToPx(finalNode1->getStyle()->padding[0], fmt1.getWidth(), em);
-        int padding_top = measureBorder(finalNode1,0) + lengthToPx(finalNode1->getStyle()->padding[2], fmt1.getWidth(), em);
+        int padding_left = measureBorder(finalNode1,3) + lengthToPx(finalNode1, finalNode1->getStyle()->padding[0], fmt1.getWidth());
+        int padding_top = measureBorder(finalNode1,0) + lengthToPx(finalNode1, finalNode1->getStyle()->padding[2], fmt1.getWidth());
         rc1.top += padding_top;
         rc1.left += padding_left;
         rc1.right += padding_left;
         rc1.bottom += padding_top;
     }
     if ( ! RENDER_RECT_HAS_FLAG(fmt2, INNER_FIELDS_SET) ) {
-        int em = finalNode2->getFont()->getSize();
-        int padding_left = measureBorder(finalNode2,3) + lengthToPx(finalNode2->getStyle()->padding[0], fmt2.getWidth(), em);
-        int padding_top = measureBorder(finalNode2,0) + lengthToPx(finalNode2->getStyle()->padding[2], fmt2.getWidth(), em);
+        int padding_left = measureBorder(finalNode2,3) + lengthToPx(finalNode2, finalNode2->getStyle()->padding[0], fmt2.getWidth());
+        int padding_top = measureBorder(finalNode2,0) + lengthToPx(finalNode2, finalNode2->getStyle()->padding[2], fmt2.getWidth());
         rc2.top += padding_top;
         rc2.left += padding_left;
         rc2.right += padding_left;
@@ -15034,7 +15030,7 @@ bool tinyNodeCollection::updateLoadedStyles( bool enabled )
                     if ( !s.isNull() ) {
                         lUInt16 fntIndex = _fontMap.get( style );
                         if ( fntIndex==0 ) {
-                            LVFontRef fnt = getFont(s.get(), getFontContextDocIndex());
+                            LVFontRef fnt = getFont(&buf[j], s.get(), getFontContextDocIndex());
                             fntIndex = (lUInt16)_fonts.cache( fnt );
                             if ( fnt.isNull() ) {
                                 CRLog::error("font not found for style!");
@@ -17094,13 +17090,13 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction, bool strict_bo
         // (erm_table_row_group, erm_table_header_group, erm_table_footer_group, erm_table_row)
         bool ignore_margins = rm >= erm_table_row_group && rm <= erm_table_row;
 
-        int top_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[2], fmt.getWidth(), enode->getFont()->getSize());
+        int top_margin = ignore_margins ? 0 : lengthToPx(enode, enode->getStyle()->margin[2], fmt.getWidth());
         if ( pt.y < fmt.getY() - top_margin) {
             if ( direction >= PT_DIR_SCAN_FORWARD && rm == erm_final )
                 return this;
             return NULL;
         }
-        int bottom_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[3], fmt.getWidth(), enode->getFont()->getSize());
+        int bottom_margin = ignore_margins ? 0 : lengthToPx(enode, enode->getStyle()->margin[3], fmt.getWidth());
         if ( pt.y >= fmt.getY() + fmt.getHeight() + bottom_margin ) {
             if ( direction <= PT_DIR_SCAN_BACKWARD && rm == erm_final )
                 return this;
@@ -17270,7 +17266,7 @@ bool ldomNode::initNodeFont()
             CRLog::error("style not found for index %d", style);
             s = getDocument()->_styles.get( style );
         }
-        LVFontRef fnt = ::getFont(s.get(), getDocument()->getFontContextDocIndex());
+        LVFontRef fnt = ::getFont(this, s.get(), getDocument()->getFontContextDocIndex());
         fntIndex = (lUInt16)getDocument()->_fonts.cache( fnt );
         if ( fnt.isNull() ) {
             CRLog::error("font not found for style!");
@@ -18292,12 +18288,11 @@ int ldomNode::getSurroundingAddedHeight()
                 RenderRectAccessor fmt( parent );
                 base_width = fmt.getWidth();
             }
-            int em = n->getFont()->getSize();
             css_style_ref_t style = n->getStyle();
-            h += lengthToPx( style->margin[2], base_width, em );  // top margin
-            h += lengthToPx( style->margin[3], base_width, em );  // bottom margin
-            h += lengthToPx( style->padding[2], base_width, em ); // top padding
-            h += lengthToPx( style->padding[3], base_width, em ); // bottom padding
+            h += lengthToPx( n, style->margin[2], base_width );  // top margin
+            h += lengthToPx( n, style->margin[3], base_width );  // bottom margin
+            h += lengthToPx( n, style->padding[2], base_width ); // top padding
+            h += lengthToPx( n, style->padding[3], base_width ); // bottom padding
             h += measureBorder(n, 0); // top border
             h += measureBorder(n, 2); // bottom border
         }
@@ -18416,8 +18411,8 @@ bool ldomNode::refreshFinalBlock()
     LFormattedTextRef txtform;
     int width = fmt.getWidth();
     renderFinalBlock( txtform, &fmt, width-measureBorder(this,1)-measureBorder(this,3)
-         -lengthToPx(this->getStyle()->padding[0],fmt.getWidth(),this->getFont()->getSize())
-         -lengthToPx(this->getStyle()->padding[1],fmt.getWidth(),this->getFont()->getSize()));
+         -lengthToPx(this, this->getStyle()->padding[0],fmt.getWidth())
+         -lengthToPx(this, this->getStyle()->padding[1],fmt.getWidth()) );
     fmt.getRect( newRect );
     if ( oldRect == newRect )
         return false;


### PR DESCRIPTION
These units should be useful for epub documents. They might also complement the min/max-width/height work being done on the koreader crengine where a percentage unit for these might not be usable, and a trivial variant of this PR was also tested on koreader.

Had to get at the page width and height in ```lengthToPx()``` and chose to pass around a node as there is always a node handy, but a document might be passed in but there is not always a document at hand. Passing in the page width and height would appear to be a burden for the callers, but if that is what people would prefer then that is also possible.
