### PR TITLE
CacheFileHeader: zero the alignment padding for reproducibility

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -491,6 +491,9 @@ struct SimpleCacheFileHeader
 struct CacheFileHeader : public SimpleCacheFileHeader
 {
     lUInt32 _fsize;
+    // Padding to explicitly align the index block structure, and that can be
+    // be initialized to zero for reproducible file contents.
+    lUInt32 _padding;
     CacheFileItem _indexBlock; // index array block parameters,
     // duplicate of one of index records which contains
     bool validate(lUInt32 domVersionRequested)
@@ -513,6 +516,7 @@ struct CacheFileHeader : public SimpleCacheFileHeader
     }
     CacheFileHeader( CacheFileItem * indexRec, int fsize, lUInt32 dirtyFlag, lUInt32 domVersion )
     : SimpleCacheFileHeader(dirtyFlag, domVersion), _indexBlock(0,0)
+    , _padding(0)
     {
         if ( indexRec ) {
             memcpy( &_indexBlock, indexRec, sizeof(CacheFileItem));


### PR DESCRIPTION
The CacheFileItem struct within the CacheFileHeader was being aligned by the
compiler to an 8 byte boundary creating a 4 byte whole in the header that was
not being zeroed and this was leading to unreproducible content in the cache
file. Add the padding explicitly and zero it.
