### PR TITLE
initSystemFonts: avoid the 'Material Icons *' fonts for monospace.

### DIFF
--- a/crengine/src/private/lvfreetypefontman.cpp
+++ b/crengine/src/private/lvfreetypefontman.cpp
@@ -401,7 +401,8 @@ bool LVFreeTypeFontManager::initSystemFonts() {
             css_font_family_t fontFamily = css_ff_sans_serif;
             lString32 face32((const char *)family);
             face32.lowercase();
-            if ( spacing==FC_MONO )
+            // Avoid using the 'Material Icons *' fonts for monospace.
+            if ( spacing==FC_MONO && face32.pos("icons") == 0 )
                 fontFamily = css_ff_monospace;
             else if (face32.pos("sans") >= 0)
                 fontFamily = css_ff_sans_serif;


### PR DESCRIPTION
The 'Material Icons *' have a limited character set and are not
generally a suitable choice to match a 'monospace' font familty.

Use of the font-family monospace was failing badly on Linux when the  'Material Icons *' were available as these happened to be a best match for monospace and could be chosen and yet they have a very limited character set. This is a quick hack to work around this. This does not prevent the 'Material Icons *' being used if named, just not a choice for the 'monospace' font family.

Perhaps this could be a place to discuss a more general solution.

Might the search for a matching font be best to match the language that the font declared?

Should the mapping from the CSS named font family to a system font depend on the language?

Might it consider the character set, but wouldn't that that depend on the language? Are there fonts in other languages that could possible map to the CSS named fonts and not support ASCII, could that be a minimum?

There appear to be two somewhat separate font selection paths in operation in CR. One path mapping the CSS font description to a font, and another path searching the fallback fonts. Currently there in only one primary font preference choice and fallback font preferences for that, but is this rather more complex, could there be a primary font preference for each of the CSS named fonts families, each with its own fallback list?

There is the function ```setAsPreferredFontWithBias()``` from koreader, and might it be more appropriate to use that? Would this bias against fonts by name, bias against the symbol and icon fonts? Would this bias in favor of the user preferred font and then the preferred fallback fonts so that a user preferred monospace font would get priority?

Anyway this hack keeps CR presenting something reasonable on Linux for monospace, rather than garbage output, and identifies the issue.
