### PR TITLE
initSystemFonts: recognise the 'ttc' font file type

### DIFF
--- a/android/src/org/coolreader/crengine/Engine.java
+++ b/android/src/org/coolreader/crengine/Engine.java
@@ -1616,7 +1616,8 @@ public class Engine {
 				String[] fileList = fontDir.list((dir, filename) -> {
 					String lc = filename.toLowerCase();
 					return (lc.endsWith(".ttf") || lc.endsWith(".otf")
-							|| lc.endsWith(".pfb") || lc.endsWith(".pfa"))
+							|| lc.endsWith(".pfb") || lc.endsWith(".pfa")
+							|| lc.endsWith(".ttc"))
 //								&& !filename.endsWith("Fallback.ttf")
 							;
 				});

--- a/crengine/src/private/lvfreetypefontman.cpp
+++ b/crengine/src/private/lvfreetypefontman.cpp
@@ -294,6 +294,7 @@ bool LVFreeTypeFontManager::initSystemFonts() {
             FcChar8 *style=(FcChar8*)"";
             //FcBool b;
             FcResult res;
+
             //FC_SCALABLE
             //res = FcPatternGetBool( fontset->fonts[i], FC_OUTLINE, 0, (FcBool*)&b);
             //if(res != FcResultMatch)
@@ -307,7 +308,7 @@ bool LVFreeTypeFontManager::initSystemFonts() {
             lString8 fn( (const char *)s );
             lString32 fn32( fn.c_str() );
             fn32.lowercase();
-            if (!fn32.endsWith(".ttf") && !fn32.endsWith(".odf") && !fn32.endsWith(".otf") && !fn32.endsWith(".pfb") && !fn32.endsWith(".pfa")  ) {
+            if (!fn32.endsWith(".ttf") && !fn32.endsWith(".odf") && !fn32.endsWith(".otf") && !fn32.endsWith(".pfb") && !fn32.endsWith(".pfa") && !fn32.endsWith(".ttc") ) {
                 continue;
             }
             int weight = FC_WEIGHT_MEDIUM;


### PR DESCRIPTION
TrueType Collection (TTC) files are commonly distributed
e.g. Noto Sans CJK

Simply accepting the 'ttc' type files in initSystemFonts appears adequate to get these working in cr3qt on linux. The code appears to already be using the index.

https://github.com/buggins/coolreader/issues/250
