### PR TITLE
Update thirdparty-deploy.sh

### DIFF
--- a/thirdparty-deploy.sh
+++ b/thirdparty-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 top_srcdir=`pwd`
 


### PR DESCRIPTION
As it contains Bash-isms (or posix-isms) that are not compatible with some shells, like fish.

Any dev machine that has `/bin/sh` should also has `/bin/bash`. Since I don't see a bat alternative I don't expect to manage these repos from windows.

Pinging @virxkane