### PR TITLE
parse_number_value: accept '+' prefix and exponent

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -414,4 +414,27 @@ typedef struct css_length_tag {
     lUInt32 pack() { return (lUInt32)type + (((lUInt32)value)<<4); }
 } css_length_t;
 
+// Support
+
+// Integer division with rounding to nearest.
+//
+// This does not bother to 'round to nearest integer' in the case of a tie.
+static inline lInt32 roundi(lInt32 n, lInt32 divisor)
+{
+    if (divisor < 0) {
+        if (divisor == 0) {
+            if (n >= 0)
+                return 0x7fffffff;
+            return 0x80000000;
+        }
+        n = -n;
+        divisor = -divisor;
+    }
+
+    if (n >= 0)
+        return (n + (divisor / 2)) / divisor;
+    else
+        return (n - (divisor / 2)) / divisor;
+}
+
 #endif // __CSS_DEF_H_INCLUDED__


### PR DESCRIPTION
CSS appears to allow a '+' prefix to numbers and also an exponent. The '+' is easy to handle. There is limited range for the exponent but this PR takes a positive exponent back from the power of 10 fraction dividend when possible so in these case it should work the same, e.g. 0.123456e6 is the same as 123456.