### PR TITLE
Fixed IllegalStateException in PhoneStateReceiver.java.

### DIFF
--- a/android/src/org/coolreader/PhoneStateReceiver.java
+++ b/android/src/org/coolreader/PhoneStateReceiver.java
@@ -1,54 +1,76 @@
 package org.coolreader;
 
+import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
-import android.util.Log;
+
+import org.coolreader.crengine.L;
+import org.coolreader.crengine.Logger;
 
 public class PhoneStateReceiver extends BroadcastReceiver {
+	public static final Logger log = L.create("phsr");
+
+	private static Runnable onPhoneActivityStartedHandler;
+	public static boolean listenerIsRegistered;
 
 	public static class CustomPhoneStateListener extends PhoneStateListener {
 
 		int lastState = -1;
+
 		@Override
-		public void onCallStateChanged(int state, String incomingNumber){
-		        Log.v("cr3", "onCallStateChange state=" + state);
-		        if (state == lastState)
-		        	return;
-		        lastState = state;
-		        switch(state){
-	                case TelephonyManager.CALL_STATE_IDLE:
-//	                    Log.d("cr3", "call state: IDLE");
-//	                    if (onPhoneActivityStartedHandler != null)
-//	                    	onPhoneActivityStartedHandler.run();
-	                    break;
-	                case TelephonyManager.CALL_STATE_RINGING:
-                        Log.d("cr3", "call state: RINGING");
-                        if (onPhoneActivityStartedHandler != null)
-                        	onPhoneActivityStartedHandler.run();
-                        break;
-	                case TelephonyManager.CALL_STATE_OFFHOOK:
-                        Log.d("cr3", "call state: OFFHOOK");
-                        if (onPhoneActivityStartedHandler != null)
-                        	onPhoneActivityStartedHandler.run();
-                        break;
-		        }       
+		public void onCallStateChanged(int state, String incomingNumber) {
+			log.v("onCallStateChange state=" + state);
+			if (state == lastState)
+				return;
+			lastState = state;
+			switch (state) {
+				case TelephonyManager.CALL_STATE_IDLE:
+//					log.d("call state: IDLE");
+//					if (onPhoneActivityStartedHandler != null)
+//					onPhoneActivityStartedHandler.run();
+					break;
+				case TelephonyManager.CALL_STATE_RINGING:
+					log.d("call state: RINGING");
+					if (onPhoneActivityStartedHandler != null)
+						onPhoneActivityStartedHandler.run();
+					break;
+				case TelephonyManager.CALL_STATE_OFFHOOK:
+					log.d("call state: OFFHOOK");
+					if (onPhoneActivityStartedHandler != null)
+						onPhoneActivityStartedHandler.run();
+					break;
+			}
 		}
 	}
-	
+
+	@SuppressLint("UnsafeProtectedBroadcastReceiver")
 	@Override
 	public void onReceive(Context context, Intent intent) {
-	    TelephonyManager telephony = (TelephonyManager)context.getSystemService(Context.TELEPHONY_SERVICE);
-        CustomPhoneStateListener customPhoneListener = new CustomPhoneStateListener();
-
-        telephony.listen(customPhoneListener, PhoneStateListener.LISTEN_CALL_STATE);
+		if (!listenerIsRegistered) {
+			try {
+				TelephonyManager telephony = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+				CustomPhoneStateListener customPhoneListener = new CustomPhoneStateListener();
+				telephony.listen(customPhoneListener, PhoneStateListener.LISTEN_CALL_STATE);
+				listenerIsRegistered = true;
+				log.v("phone state listener is registered.");
+			} catch (Exception e) {
+				log.e("Failed to register phone state listener: " + e.toString());
+			}
+		}
 	}
-	
+
 	public static void setPhoneActivityHandler(Runnable handler) {
 		onPhoneActivityStartedHandler = handler;
 	}
-	private static Runnable onPhoneActivityStartedHandler;
 
+	protected void finalize() throws Throwable {
+		super.finalize();
+		if (listenerIsRegistered) {
+			listenerIsRegistered = false;
+			log.v("phone state listener is DESTROYED.");
+		}
+	}
 }


### PR DESCRIPTION
Stack trace:
```
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4034)
  at android.app.ActivityThread.access$1400 (ActivityThread.java:238)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1925)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:223)
  at android.app.ActivityThread.main (ActivityThread.java:7698)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:592)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:952)
Caused by: java.lang.IllegalStateException: 
  at android.os.Parcel.createExceptionOrNull (Parcel.java:2381)
  at android.os.Parcel.createException (Parcel.java:2357)
  at android.os.Parcel.readException (Parcel.java:2340)
  at android.os.Parcel.readException (Parcel.java:2282)
  at com.android.internal.telephony.ITelephonyRegistry$Stub$Proxy.listenForSubscriber (ITelephonyRegistry.java:1105)
  at android.telephony.TelephonyRegistryManager.listenForSubscriber (TelephonyRegistryManager.java:231)
  at android.telephony.TelephonyManager.listen (TelephonyManager.java:5723)
  at org.coolreader.PhoneStateReceiver.onReceive (PhoneStateReceiver.java:46)
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4025)
Caused by: android.os.RemoteException: 
  at com.android.server.TelephonyRegistry.add (TelephonyRegistry.java:1158)
  at com.android.server.TelephonyRegistry.listen (TelephonyRegistry.java:833)
  at com.android.server.TelephonyRegistry.listenForSubscriber (TelephonyRegistry.java:801)
  at com.android.internal.telephony.ITelephonyRegistry$Stub.onTransact (ITelephonyRegistry.java:453)
  at android.os.Binder.execTransactInternal (Binder.java:1154)
```
According to the documentation https://developer.android.com/reference/android/telephony/TelephonyManager#listen(android.telephony.PhoneStateListener,%20int), calling android.telephony.TelephonyManager.listen() can throw an exception IllegalStateException if the process registers too many listeners without unregistering them.
Therefore, we should not create and register a new listener if the previous one has not already been destroyed.