### PR TITLE
Fixes 2021.02-1

### DIFF
--- a/android/res/layout/option_item_number.xml
+++ b/android/res/layout/option_item_number.xml
@@ -68,8 +68,9 @@
     </LinearLayout>
 
     <View
-            android:id="@+id/view"
+            android:id="@+id/margin_view"
             android:layout_width="4dp"
             android:layout_height="1dp"
-            android:layout_weight="0" />
+            android:layout_weight="0"
+            android:focusableInTouchMode="true" />
 </LinearLayout>

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -936,12 +936,6 @@ public class CoolReader extends BaseActivity {
 		log.i("CoolReader.onStop() exiting");
 	}
 
-	public void einkRefresh() {
-		try {
-			getEinkScreen().refreshScreen(mReaderView.getSurface());
-		} catch (Exception ignored) {}
-	}
-
 	private void requestStoragePermissions() {
 		// check or request permission for storage
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/android/src/org/coolreader/crengine/BaseActivity.java
+++ b/android/src/org/coolreader/crengine/BaseActivity.java
@@ -255,16 +255,9 @@ public class BaseActivity extends Activity implements Settings {
 		log.i("CoolReader.onPause() : saving reader state");
 		mIsStarted = false;
 		mPaused = true;
-//		setScreenUpdateMode(-1, mReaderView);
-		einkRefresh();
 		releaseBacklightControl();
 		super.onPause();
 	}
-
-	public void einkRefresh() {
-		// override it
-	}
-
 
 	protected static String PREF_FILE = "CR3LastBook";
 	protected static String PREF_LAST_BOOK = "LastBook";

--- a/android/src/org/coolreader/crengine/OptionsDialog.java
+++ b/android/src/org/coolreader/crengine/OptionsDialog.java
@@ -1705,6 +1705,9 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 				EditText valueView = view.findViewById(R.id.option_value);
 				ImageButton decButton = view.findViewById(R.id.option_btn_dec);
 				ImageButton incButton = view.findViewById(R.id.option_btn_inc);
+				View marginView = view.findViewById(R.id.margin_view);
+				marginView.setFocusableInTouchMode(true);
+				marginView.requestFocusFromTouch();
 				labelView.setText(label);
 				labelView.setEnabled(enabled);
 				valueView.setText(String.valueOf(getValueInt()));

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -119,7 +119,8 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		@Override
 		public void onWindowVisibilityChanged(int visibility) {
 			if (visibility == VISIBLE) {
-				mActivity.einkRefresh();
+				if (DeviceInfo.EINK_SCREEN)
+					mActivity.getEinkScreen().refreshScreen(surface);
 				startStats();
 				checkSize();
 			} else
@@ -130,7 +131,8 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		@Override
 		public void onWindowFocusChanged(boolean hasWindowFocus) {
 			if (hasWindowFocus) {
-				BackgroundThread.instance().postGUI(mActivity::einkRefresh, 400);
+				if (DeviceInfo.EINK_SCREEN)
+					BackgroundThread.instance().postGUI(() -> mActivity.getEinkScreen().refreshScreen(surface), 400);
 				startStats();
 				checkSize();
 			} else
@@ -5560,7 +5562,6 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 	}
 
 	public void save() {
-		mActivity.einkRefresh();
 		BackgroundThread.ensureGUI();
 		if (isBookLoaded() && mBookInfo != null) {
 			if (!Services.isStopped()) {

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -365,6 +365,10 @@ public:
     }
     void SplitLineIfOverflowPage( LVRendLineInfo * line )
     {
+        // If page_h <= 0 this function will fall into an infinite loop
+        // in which it will allocate memory until it runs out.
+        if (page_h <= 0)
+            return;
         // A 'line' is usually a line of text from a paragraph, but
         // can be an image, or a fully rendered table row (<tr>), and
         // can have a huge height, possibly overflowing page height.


### PR DESCRIPTION
* Fixed infinity loop in `PageSplitState::SplitLineIfOverflowPage()`.
* Hides the onscreen software keyboard when opening the preferences dialog. TextEdit for editing the font size automatically opens this keyboard on some Android versions immediately upon opening a dialog.
* Removed useless screen refresh on e-ink devices.