### PR TITLE
ONYX fixes (tier 4)

### DIFF
--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -28,6 +28,7 @@ import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.text.ClipboardManager;
 import android.util.Log;
 import android.util.SparseArray;
@@ -4074,7 +4075,10 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 			Canvas canvas = null;
 			long startTs = android.os.SystemClock.uptimeMillis();
 			try {
-				canvas = holder.lockCanvas(rc);
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+					canvas = holder.lockHardwareCanvas();
+				else
+					canvas = holder.lockCanvas(rc);
 				//log.v("before draw(canvas)");
 				if (canvas != null) {
 					if (DeviceInfo.EINK_SCREEN) {

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -122,7 +122,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		public void onWindowVisibilityChanged(int visibility) {
 			if (visibility == VISIBLE) {
 				if (DeviceInfo.EINK_SCREEN)
-					mActivity.getEinkScreen().refreshScreen(surface);
+					mEinkScreen.refreshScreen(surface);
 				startStats();
 				checkSize();
 			} else
@@ -134,7 +134,7 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 		public void onWindowFocusChanged(boolean hasWindowFocus) {
 			if (hasWindowFocus) {
 				if (DeviceInfo.EINK_SCREEN)
-					BackgroundThread.instance().postGUI(() -> mActivity.getEinkScreen().refreshScreen(surface), 400);
+					BackgroundThread.instance().postGUI(() -> mEinkScreen.refreshScreen(surface), 400);
 				startStats();
 				checkSize();
 			} else
@@ -4087,10 +4087,6 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 						mEinkScreen.prepareController(surface, isPartially);
 					}
 					callback.drawTo(canvas);
-					if (DeviceInfo.EINK_SCREEN) {
-						// post draw update
-						mEinkScreen.updateController(surface, isPartially);
-					}
 				}
 			} finally {
 				//log.v("exiting finally");
@@ -4102,6 +4098,10 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 						long endTs = android.os.SystemClock.uptimeMillis();
 						updateAnimationDurationStats(endTs - startTs);
 						//}
+						if (DeviceInfo.EINK_SCREEN) {
+							// post draw update
+							mEinkScreen.updateController(surface, isPartially);
+						}
 					}
 					//log.v("after unlockCanvasAndPost");
 				}


### PR DESCRIPTION
**ONYX BOOX support:**
Make full screen refresh after new page is appears on screen.
This eliminates the two-step screen refresh on a full screen refresh - first the screen is refreshed (keeping the old page) and then the new page is displayed. In addition, because of this, theoretically, traces of the previous page may be visible after such a complete refresh of the screen.
Now, the full screen refresh (when needed) performed after the new page appears on the screen, but visually it looks like a one-step refresh.

**Other:**
**Use hardware accelerated canvas on Android 8.0 (API 26) and newer. This significantly speed up rendering operations, including paging animation.**