### PR TITLE
Font weight fixes

### DIFF
--- a/android/src/org/coolreader/crengine/OptionsDialog.java
+++ b/android/src/org/coolreader/crengine/OptionsDialog.java
@@ -2543,8 +2543,8 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 			option.add(weight, label);
 		}
 		// enable/disable font hinting option
-		int base_weight = mProperties.getInt(PROP_FONT_BASE_WEIGHT, 400);
-		mFontHintingOption.setEnabled(nativeWeightsArray.contains(base_weight));
+		//int base_weight = mProperties.getInt(PROP_FONT_BASE_WEIGHT, 400);
+		//mFontHintingOption.setEnabled(nativeWeightsArray.contains(base_weight));
 	}
 
 	private void setupReaderOptions()
@@ -2582,8 +2582,8 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 				ArrayList<Integer> nativeWeightsArray = new ArrayList<>();    // for search
 				for (int w : nativeWeights)
 					nativeWeightsArray.add(w);
-				int base_weight = mProperties.getInt(PROP_FONT_BASE_WEIGHT, 400);
-				mFontHintingOption.setEnabled(nativeWeightsArray.contains(base_weight));
+				//int base_weight = mProperties.getInt(PROP_FONT_BASE_WEIGHT, 400);
+				//mFontHintingOption.setEnabled(nativeWeightsArray.contains(base_weight));
 			}
 		});
 		mOptionsStyles.add(new ListOption(this, getString(R.string.options_font_antialias), PROP_FONT_ANTIALIASING).add(mAntialias, mAntialiasTitles).setDefaultValue("2").setIconIdByAttr(R.attr.cr3_option_text_antialias_drawable, R.drawable.cr3_option_text_antialias));

--- a/android/src/org/coolreader/crengine/OptionsDialog.java
+++ b/android/src/org/coolreader/crengine/OptionsDialog.java
@@ -103,7 +103,12 @@ public class OptionsDialog extends BaseDialog implements TabContentFactory, Opti
 	public static int[] mPagesPerFullSwipe;
 	public static String[] mPagesPerFullSwipeTitles;
 	int[] mInterlineSpaces = new int[] {
-			80, 85, 90, 95, 100, 105, 110, 115, 120, 130, 140, 150, 160, 180, 200
+			 80,  81,  82,  83,  84,  85, 86,   87,  88,  89,
+			 90,  91,  92,  93,  94,  95, 96,   97,  98,  99,
+			100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+			110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+			120, 125, 130, 135, 140, 145, 150, 155, 160, 165,
+			170, 175, 180, 185, 190, 195, 200
 		};
 	int[] mMinSpaceWidths = new int[] {
 			25, 30, 40, 50, 60, 70, 80, 90, 100

--- a/cr3qt/src/settings.cpp
+++ b/cr3qt/src/settings.cpp
@@ -1355,6 +1355,6 @@ void SettingsDlg::on_cbFontWeightChange_currentIndexChanged(int index)
     QString face = m_props->getStringDef( PROP_FONT_FACE, "" );
     LVArray<int> nativeWeights;
     fontMan->GetAvailableFontWeights(nativeWeights, UnicodeToUtf8(qt2cr(face)));
-    m_ui->cbFontHinting->setEnabled(nativeWeights.indexOf(weight) >= 0);
+    //m_ui->cbFontHinting->setEnabled(nativeWeights.indexOf(weight) >= 0);
     updateStyleSample();
 }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -70,7 +70,7 @@ public:
     /// registers font by name
     virtual bool RegisterFont( lString8 name ) = 0;
     /// registers font by name and face
-    virtual bool RegisterExternalFont(lString32 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
+    virtual bool RegisterExternalFont(int /*documentId*/, lString32 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
     /// registers document font
     virtual bool
     RegisterDocumentFont(int /*documentId*/, LVContainerRef /*container*/, lString32 /*name*/,

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -820,7 +820,8 @@ public:
                     state = 2;
             else if (state == 1) {                // ex. [<secure/_stdio.h> or 5/3]
                     tmp<<('/');
-                    state = 0;
+                    if (c != ('/'))               // stay in state 1 if [//]
+                        state = 0;
             }
             else if (state == 2 && c == ('*'))    // ex. [/*he*]
                     state = 3;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6276,7 +6276,14 @@ int LVDocView::onSelectionCommand( int cmd, int param )
 }
 
 //static int cr_font_sizes[] = { 24, 29, 33, 39, 44 };
-static int cr_interline_spaces[] = { 100, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 160, 180, 200 };
+static int cr_interline_spaces[] = {
+		 80,  81,  82,  83,  84,  85, 86,   87,  88,  89,
+		 90,  91,  92,  93,  94,  95, 96,   97,  98,  99,
+		100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+		110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+		120, 125, 130, 135, 140, 145, 150, 155, 160, 165,
+		170, 175, 180, 185, 190, 195, 200
+};
 
 static const char * def_style_macros[] = {
     "styles.def.align", "text-align: justify",
@@ -6399,7 +6406,7 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 	props->setIntDef(PROP_FONT_SIZE, m_min_font_size + (m_min_font_size + m_max_font_size)/7);
 #endif
 	props->limitValueList(PROP_INTERLINE_SPACE, cr_interline_spaces,
-			sizeof(cr_interline_spaces) / sizeof(int));
+			sizeof(cr_interline_spaces) / sizeof(int), 20);
 #if CR_INTERNAL_PAGE_ORIENTATION==1
 	static int def_rot_angle[] = {0, 1, 2, 3};
 	props->limitValueList( PROP_ROTATE_ANGLE, def_rot_angle, 4 );
@@ -6748,7 +6755,7 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             }
         } else if (name == PROP_INTERLINE_SPACE) {
             int interlineSpace = props->getIntDef(PROP_INTERLINE_SPACE,
-                                                  cr_interline_spaces[0]);
+                                                  cr_interline_spaces[20]);
             setDefaultInterlineSpace(interlineSpace);//cr_font_sizes
             value = lString32::itoa(m_def_interline_space);
 #if CR_INTERNAL_PAGE_ORIENTATION==1

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -18175,7 +18175,7 @@ void ldomDocument::registerEmbeddedFonts()
             continue;
         }
         if (url.startsWithNoCase(lString32("res://")) || url.startsWithNoCase(lString32("file://"))) {
-            if (!fontMan->RegisterExternalFont(item->getUrl(), item->getFace(), item->getBold(), item->getItalic())) {
+            if (!fontMan->RegisterExternalFont(getDocIndex(), item->getUrl(), item->getFace(), item->getBold(), item->getItalic())) {
                 //CRLog::error("Failed to register external font face: %s file: %s", item->getFace().c_str(), LCSTR(item->getUrl()));
             }
             continue;

--- a/crengine/src/private/lvbasefont.cpp
+++ b/crengine/src/private/lvbasefont.cpp
@@ -32,7 +32,7 @@ int LVBaseFont::DrawTextString(LVDrawBuf * buf, int x, int y,
             int w = 0;
             if (item) {
                 // avoid soft hyphens inside text string
-                w = item->advance_26_6 >> 6;
+                w = item->advance;
                 if (item->bmp_width && item->bmp_height) {
                     buf->Draw(x + item->origin_x,
                               y + baseline - item->origin_y,

--- a/crengine/src/private/lvfontboldtransform.cpp
+++ b/crengine/src/private/lvfontboldtransform.cpp
@@ -112,7 +112,7 @@ LVFontGlyphCacheItem *LVFontBoldTransform::getGlyph(lUInt32 ch, lChar32 def_char
 
     item = LVFontGlyphCacheItem::newItem(&_glyph_cache, (lChar32)ch, dx, dy); //, _drawMonochrome
     if (item) {
-        item->advance_26_6 = olditem->advance_26_6 + (_hShift << 6);
+        item->advance = olditem->advance + _hShift;
         item->origin_x = olditem->origin_x;
         item->origin_y = olditem->origin_y;
     
@@ -183,7 +183,7 @@ int LVFontBoldTransform::DrawTextString(LVDrawBuf *buf, int x, int y, const lCha
         int w  = 0;
         if ( item ) {
             // avoid soft hyphens inside text string
-            w = item->advance_26_6 >> 6;
+            w = item->advance;
             if ( item->bmp_width && item->bmp_height && (!isHyphen || i==len) ) {
                 buf->Draw( x + item->origin_x,
                     y + _baseline - item->origin_y,

--- a/crengine/src/private/lvfontdef.cpp
+++ b/crengine/src/private/lvfontdef.cpp
@@ -63,7 +63,7 @@ int LVFontDef::CalcMatch(const LVFontDef &def, bool useBias) const {
     // bias
     int bias = useBias ? _bias : 0;
 
-    // Special handling for synthetized fonts:
+    // Special handling for synthesized fonts:
     // The way this function is called:
     // 'this' (or '', properties not prefixed) is either an instance of a
     //     registered font, or a registered font definition,

--- a/crengine/src/private/lvfontdef.cpp
+++ b/crengine/src/private/lvfontdef.cpp
@@ -46,6 +46,15 @@ int LVFontDef::CalcMatch(const LVFontDef &def, bool useBias) const {
         weight_diff = 800;
     int weight_match = (_weight == -1 || def._weight == -1) ? 256
                                                             : (256 - weight_diff * 256 / 800);
+    // It might happen that 2 fonts with different weights can get the same
+    // score, e.g. with def._weight=550, a font with _weight=400 and an other
+    // with _weight=700. Any could then be picked depending on their random
+    // ordering in the cache, which may mess a book on re-openings.
+    // To avoid this inconsistency, we give arbitrarily a small increase to
+    // the score of the smaller weight font (mostly so that with the above
+    // case, we keep synthesizing the 550 from the 400)
+    if ( _weight < def._weight )
+        weight_match += 1;
     int italic_match = (_italic == def._italic || _italic == -1 || def._italic == -1) ? 256 : 0;
     if ((_italic == 2 || def._italic == 2) && _italic > 0 && def._italic > 0)
         italic_match = 128;

--- a/crengine/src/private/lvfontdef.h
+++ b/crengine/src/private/lvfontdef.h
@@ -21,6 +21,19 @@
 #include "../../include/cssdef.h"
 #include "../../include/lvarray.h"
 
+// LVFontDef carries a font definition, and can be used to identify:
+// - registered fonts, from available font files (size=-1 if scalable)
+// - instantiated fonts from one of the registered fonts, with some
+//   updated properties:
+//     - the specific size, > -1
+//     - _italic=2 (if font has no real italic, and it is synthesized
+//       thanks to Freetype from the regular font glyphs)
+//     - _weight=600 (updated weight if synthesized weight made from
+//       the regular font glyphs)
+// It can be used as a key by caches to retrieve a registered font
+// or an instantiated one, and as a query to find in the cache an
+// exact or an approximate font.
+
 /**
     @brief Font properties definition
 */

--- a/crengine/src/private/lvfontglyphcache.cpp
+++ b/crengine/src/private/lvfontglyphcache.cpp
@@ -90,7 +90,7 @@ LVFontGlyphCacheItem *LVFontGlyphCacheItem::newItem(LVFontLocalGlyphCache* local
         item->bmp_height = (lUInt16) h;
         item->origin_x = 0;
         item->origin_y = 0;
-        item->advance_26_6 = 0;
+        item->advance = 0;
         item->prev_global = NULL;
         item->next_global = NULL;
         item->prev_local = NULL;

--- a/crengine/src/private/lvfontglyphcache.h
+++ b/crengine/src/private/lvfontglyphcache.h
@@ -143,7 +143,7 @@ struct LVFontGlyphCacheItem {
     lUInt16 bmp_height;
     lInt16 origin_x;
     lInt16 origin_y;
-    lUInt32 advance_26_6;
+    lUInt16 advance;
     lUInt8 bmp[1];
 
     //=======================================================================

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -1070,8 +1070,9 @@ bool LVFreeTypeFace::getGlyphInfo(lUInt32 code, LVFont::glyph_info_t *glyph, lCh
     }
     if (_synth_weight > 0 || _italic == 2) { // Don't render yet
         rend_flags &= ~FT_LOAD_RENDER;
-        // Also disable any hinting, as it would be wrong after embolden
-        rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
+        // Also disable any hinting, as it would be wrong after embolden.
+        // But it feels this is now fine after switching to FT_LOAD_TARGET_LIGHT.
+        // rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
     }
     updateTransform(); // no-op
     int error = FT_Load_Glyph(
@@ -1823,8 +1824,9 @@ LVFontGlyphCacheItem *LVFreeTypeFace::getGlyph(lUInt32 ch, lChar32 def_char, lUI
         }
         if (_synth_weight > 0 || _italic == 2) { // Don't render yet
             rend_flags &= ~FT_LOAD_RENDER;
-            // Also disable any hinting, as it would be wrong after embolden
-            rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
+            // Also disable any hinting, as it would be wrong after embolden.
+            // But it feels this is now fine after switching to FT_LOAD_TARGET_LIGHT.
+            // rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
         }
         /* load glyph image into the slot (erase previous one) */
         updateTransform(); // no-op
@@ -1893,8 +1895,9 @@ LVFontGlyphCacheItem* LVFreeTypeFace::getGlyphByIndex(lUInt32 index) {
 
         if (_synth_weight > 0 || _italic == 2) { // Don't render yet
             rend_flags &= ~FT_LOAD_RENDER;
-            // Also disable any hinting, as it would be wrong after embolden
-            rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
+            // Also disable any hinting, as it would be wrong after embolden.
+            // But it feels this is now fine after switching to FT_LOAD_TARGET_LIGHT.
+            // rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
         }
 
         /* load glyph image into the slot (erase previous one) */

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -47,7 +47,7 @@
 // #define FONT_METRIC_FLOOR(x)    ((x) & -64)
 // #define FONT_METRIC_CEIL(x)     (((x)+63) & -64)
 // #define FONT_METRIC_ROUND(x)    (((x)+32) & -64)
-// #define FONT_METRIC_TRUNC(x)    ((x) >> 6)
+#define FONT_METRIC_TRUNC(x)    ((x) >> 6)
 #define FONT_METRIC_TO_PX(x)    (((x)+32) >> 6) // ROUND + TRUNC
 // Uncomment to use the former >>6 (trunc) with no rounding (instead of previous one)
 // #define FONT_METRIC_TO_PX(x)    ((x) >> 6)
@@ -210,7 +210,7 @@ static LVFontGlyphCacheItem *newItem(LVFontLocalGlyphCache *local_cache, lChar32
     }
     item->origin_x = (lInt16) slot->bitmap_left;
     item->origin_y = (lInt16) slot->bitmap_top;
-    item->advance_26_6 = (lUInt32)( myabs(slot->metrics.horiAdvance) );
+    item->advance = (lUInt16)(FONT_METRIC_TO_PX( myabs(slot->metrics.horiAdvance) ));
     return item;
 }
 
@@ -253,7 +253,7 @@ static LVFontGlyphCacheItem *newItem(LVFontLocalGlyphCache *local_cache, lUInt32
     }
     item->origin_x = (lInt16) slot->bitmap_left;
     item->origin_y = (lInt16) slot->bitmap_top;
-    item->advance_26_6 = (lUInt32)( myabs(slot->metrics.horiAdvance) );
+    item->advance = (lUInt16)(FONT_METRIC_TO_PX( myabs(slot->metrics.horiAdvance) ));
     return item;
 }
 
@@ -303,8 +303,8 @@ struct LVCharTriplet
 
 struct LVCharPosInfo
 {
-    lInt32 offset_26_6;
-    lInt32 advance_26_6;
+    lInt16 offset;
+    lInt16 advance;
 };
 
 inline lUInt32 getHash( const struct LVCharTriplet& triplet )
@@ -851,19 +851,18 @@ bool LVFreeTypeFace::hbCalcCharWidth(LVCharPosInfo *posInfo, const LVCharTriplet
             // which will be the one that will be rendered
             FT_UInt ch_glyph_index = FT_Get_Char_Index( _face, triplet.Char );
             if ( glyph_info[cluster].codepoint == ch_glyph_index ) {
-                posInfo->offset_26_6 = glyph_pos[cluster].x_offset;
-                posInfo->advance_26_6 = glyph_pos[cluster].x_advance;
+                posInfo->offset = FONT_METRIC_TO_PX(glyph_pos[cluster].x_offset);
+                posInfo->advance = FONT_METRIC_TO_PX(glyph_pos[cluster].x_advance);
                 return true;
             }
         }
     }
-    // Otherwise, use plain Freetype getGlyph() which will check
+    // Otherwise, use plain Freetype getGlyphInfo() which will check
     // again with this font, or the fallback one
-    LVFontGlyphCacheItem *glyph = getGlyph(triplet.Char, def_char, fallbackPassMask);
-    if (glyph) {
-        posInfo->offset_26_6 = 0;
-        posInfo->advance_26_6 = glyph->advance_26_6;
-        return true;
+    glyph_info_t glyph;
+    if ( getGlyphInfo(triplet.Char, &glyph, def_char, fallbackPassMask) ) {
+        posInfo->offset = 0;
+        posInfo->advance = glyph.width;
     }
     return false;
 }
@@ -1261,12 +1260,12 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
     else if ( letter_spacing > MAX_LETTER_SPACING ) {
         letter_spacing = MAX_LETTER_SPACING;
     }
-    FT_Pos letter_spacing_26_6 = PX_TO_FONT_METRIC(letter_spacing) + _synth_weight_strength;
+    int letter_spacing_w = letter_spacing + FONT_METRIC_TO_PX(_synth_weight_strength);
 
     int i;
 
-    FT_Pos prev_width_26_6 = 0;
-    FT_Pos cur_width_26_6 = 0;
+    lUInt16 prev_width = 0;
+    lUInt16 cur_width = 0;
     lUInt32 lastFitChar = 0;
     updateTransform();  // no-op
     // measure character widths
@@ -1357,11 +1356,11 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
 
         // Some additional care might need to be taken, see:
         //   https://www.w3.org/TR/css-text-3/#letter-spacing-property
-        if ( letter_spacing_26_6 != 0 ) {
+        if ( letter_spacing_w != 0 ) {
             // Don't apply letter-spacing if the script is cursive
             hb_script_t script = hb_buffer_get_script(_hb_buffer);
             if ( isHBScriptCursive(script) )
-                letter_spacing_26_6 = 0;
+                letter_spacing_w = 0;
         }
         // todo: if letter_spacing, ligatures should be disabled (-liga, -clig)
         // todo: letter-spacing must not be applied at the beginning or at the end of a line
@@ -1449,7 +1448,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
             while ( hg < glyph_count ) {
                 hcl = glyph_info[hg].cluster;
                 if (hcl <= t) {
-                    FT_Pos advance_26_6 = 0;
+                    int advance = 0;
                     if ( glyph_info[hg].codepoint != 0 ) { // Codepoint found in this font
                         #ifdef DEBUG_MEASURE_TEXT
                             printf("(found cp=%x) ", glyph_info[hg].codepoint);
@@ -1487,8 +1486,8 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                                     widths[tn] += last_good_width;
                                 }
                                 // And fix our current width
-                                cur_width_26_6 = PX_TO_FONT_METRIC(widths[t_notdef_end-1]);
-                                prev_width_26_6 = cur_width_26_6;
+                                cur_width = widths[t_notdef_end-1];
+                                prev_width = cur_width;
                                 #ifdef DEBUG_MEASURE_TEXT
                                     printf("MTHB ### measured past failures > W= %d\n[...]", cur_width);
                                 #endif
@@ -1502,13 +1501,13 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                             // And go on with the found glyph now that we fixed what was before
                         }
                         // Glyph found in this font
-                        advance_26_6 = glyph_pos[hg].x_advance;
+                        advance = FONT_METRIC_TO_PX(glyph_pos[hg].x_advance);
                     } else {
                         #ifdef DEBUG_MEASURE_TEXT
                             printf("(glyph not found) ");
                         #endif
                         // Keep the advance of .notdef/tofu in case there is no fallback font to correct them
-                        advance_26_6 = glyph_pos[hg].x_advance;
+                        advance = FONT_METRIC_TO_PX(glyph_pos[hg].x_advance);
                         if ( t_notdef_start < 0 ) {
                             t_notdef_start = t;
                         }
@@ -1516,7 +1515,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                     #ifdef DEBUG_MEASURE_TEXT
                         printf("c%d+%d ", hcl, advance);
                     #endif
-                    cur_width_26_6 += advance_26_6;
+                    cur_width += advance;
                     cur_cluster = hcl;
                     hg++;
                     continue; // keep grabbing glyphs
@@ -1530,28 +1529,25 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                 flags[t] = LCHAR_IS_CLUSTER_TAIL;
                 // todo: see at using HB_GLYPH_FLAG_UNSAFE_TO_BREAK to
                 // set this flag instead/additionally
-            }
-            else {
+            } else {
                 // We're either a single char cluster, or the start
                 // of a multi chars cluster.
                 flags[t] = GET_CHAR_FLAGS(text[t]);
                 // It seems each soft-hyphen is in its own cluster, of length 1 and width 0,
                 // so HarfBuzz must already deal correctly with soft-hyphens.
-                if (cur_width_26_6 == prev_width_26_6) {
+                if (cur_width == prev_width) {
                     // But if there is no advance (this happens with soft-hyphens),
                     // flag it and don't add any letter spacing.
                     flags[t] |= LCHAR_IS_CLUSTER_TAIL;
-                }
-                else {
-                    cur_width_26_6 += letter_spacing_26_6; // only between clusters/graphemes
+                } else {
+                    cur_width += letter_spacing_w; // only between clusters/graphemes
                 }
             }
-            int cur_width = FONT_METRIC_TO_PX(cur_width_26_6);
             widths[t] = cur_width;
             #ifdef DEBUG_MEASURE_TEXT
                 printf("=> %d (flags=%d) => W=%d\n", cur_width - prev_width, flags[t], cur_width);
             #endif
-            prev_width_26_6 = cur_width_26_6;
+            prev_width = cur_width;
 
             // (Not sure about how that max_width limit could play and if it could mess things)
             if (cur_width > max_width) {
@@ -1586,7 +1582,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                     widths[tn] += last_good_width;
                 }
                 // And add all that to our current width
-                cur_width_26_6 = PX_TO_FONT_METRIC(widths[t_notdef_end-1]);
+                cur_width = widths[t_notdef_end-1];
                 #ifdef DEBUG_MEASURE_TEXT
                     printf("MTHB ### measured past failures at EOT > W= %d\n[...]", cur_width);
                 #endif
@@ -1620,7 +1616,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                 // do just what would be done below if zero width (no change
                 // in prev_width), and don't get involved in kerning
                 flags[i] = 0; // no LCHAR_ALLOW_WRAP_AFTER, will be dealt with by hyphenate()
-                widths[i] = FONT_METRIC_TO_PX(prev_width_26_6);
+                widths[i] = prev_width;
                 lastFitChar = i + 1;
                 continue;
             }
@@ -1635,23 +1631,23 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                 if (hbCalcCharWidth(&posInfo, triplet, def_char, fallbackPassMask))
                     _width_cache2.set(triplet, posInfo);
                 else { // (seems this never happens, unlike with kerning disabled)
-                    widths[i] = FONT_METRIC_TO_PX(prev_width_26_6);
+                    widths[i] = prev_width;
                     lastFitChar = i + 1;
                     continue;  /* ignore errors */
                 }
             }
-            cur_width_26_6 = prev_width_26_6 + posInfo.advance_26_6;
-            if ( posInfo.advance_26_6 == 0 ) {
+            cur_width = prev_width + posInfo.advance;
+            if ( posInfo.advance == 0 ) {
                 // Assume zero advance means it's a diacritic, and we should not apply
                 // any letter spacing on this char (now, and when justifying)
                 flags[i] |= LCHAR_IS_CLUSTER_TAIL;
             } else {
-                cur_width_26_6 += letter_spacing_26_6;
+                cur_width += letter_spacing_w;
             }
-            widths[i] = FONT_METRIC_TO_PX(cur_width_26_6);
+            widths[i] = cur_width;
             if ( !isHyphen ) // avoid soft hyphens inside text string
-                prev_width_26_6 = cur_width_26_6;
-            if ( FONT_METRIC_TO_PX(prev_width_26_6) > max_width ) {
+                prev_width = cur_width;
+            if ( prev_width > max_width ) {
                 if ( lastFitChar < i + 7)
                     break;
             }
@@ -1674,7 +1670,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
             // do just what would be done below if zero width (no change
             // in prev_width), and don't get involved in kerning
             flags[i] = 0; // no LCHAR_ALLOW_WRAP_AFTER, will be dealt with by hyphenate()
-            widths[i] = FONT_METRIC_TO_PX(prev_width_26_6);
+            widths[i] = prev_width;
             lastFitChar = i + 1;
             continue;
         }
@@ -1706,7 +1702,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                 w = glyph.width;
                 _wcache.put(ch, w);
             } else {
-                widths[i] = FONT_METRIC_TO_PX(prev_width_26_6);
+                widths[i] = prev_width;
                 lastFitChar = i + 1;
                 continue;  /* ignore errors */
             }
@@ -1716,19 +1712,18 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                 ch_glyph_index = getCharIndex( ch, 0 );
             previous = ch_glyph_index;
         }
-        cur_width_26_6 += PX_TO_FONT_METRIC(w) + kerning;
+        cur_width += w + (kerning>>6);
         if ( w == 0 ) {
             // Assume zero advance means it's a diacritic, and we should not apply
             // any letter spacing on this char (now, and when justifying)
             flags[i] |= LCHAR_IS_CLUSTER_TAIL;
+        } else {
+            cur_width += letter_spacing_w;
         }
-        else {
-            cur_width_26_6 += letter_spacing_26_6;
-        }
-        widths[i] = FONT_METRIC_TO_PX(cur_width_26_6);
+        widths[i] = cur_width;
         if ( !isHyphen ) // avoid soft hyphens inside text string
-            prev_width_26_6 = cur_width_26_6;
-        if ( FONT_METRIC_TO_PX(prev_width_26_6) > max_width ) {
+            prev_width = cur_width;
+        if ( prev_width > max_width ) {
             if ( lastFitChar < i + 7)
                 break;
         } else {
@@ -1865,7 +1860,7 @@ LVFontGlyphCacheItem *LVFreeTypeFace::getGlyph(lUInt32 ch, lChar32 def_char, lUI
                 // The width of the character above/below which
                 // the diacritical mark is located has changed,
                 // so the position of this mark must also be changed.
-                if (item->origin_x < 0 && item->advance_26_6 == 0)
+                if (item->origin_x < 0 && item->advance == 0)
                     item->origin_x -= FONT_METRIC_TO_PX(_synth_weight_strength);
             }
             _glyph_cache.put(item);
@@ -2010,7 +2005,7 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
     else if ( letter_spacing > MAX_LETTER_SPACING ) {
         letter_spacing = MAX_LETTER_SPACING;
     }
-    FT_Pos letter_spacing_26_6 = PX_TO_FONT_METRIC(letter_spacing) + _synth_weight_strength;
+    int letter_spacing_w = letter_spacing + FONT_METRIC_TO_PX(_synth_weight_strength);
     lvRect clip;
     buf->GetClipRect(&clip);
     updateTransform(); // no-op
@@ -2023,7 +2018,6 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
     // measure character widths
     bool isHyphen = false;
     int x0 = x;
-    FT_Pos x_26_6 = PX_TO_FONT_METRIC(x);
 #if USE_HARFBUZZ == 1
     if (_shapingMode == SHAPING_MODE_HARFBUZZ) {
         // Full HarfBuzz text shaping
@@ -2073,11 +2067,11 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
         hb_buffer_guess_segment_properties(_hb_buffer);
 
         // See measureText() for details
-        if ( letter_spacing_26_6 != 0 ) {
+        if ( letter_spacing_w != 0 ) {
             // Don't apply letter-spacing if the script is cursive
             hb_script_t script = hb_buffer_get_script(_hb_buffer);
             if ( isHBScriptCursive(script) )
-                letter_spacing_26_6 = 0;
+                letter_spacing_w = 0;
         }
 
         // Shape
@@ -2234,11 +2228,11 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
                 int fb_len = fb_t_end - fb_t_start;
                 // (width and text_decoration_back_gap are only used for
                 // text decoration, that we dropped: no update needed)
-                int fb_advance = fallbackFont->DrawTextString( buf, FONT_METRIC_TO_PX(x_26_6),
+                int fb_advance = fallbackFont->DrawTextString( buf, x,
                    fb_y, fb_text, fb_len,
                    def_char, palette, fb_addHyphen, lang_cfg, fb_flags, letter_spacing,
                    width, text_decoration_back_gap, fallbackPassMask | _fallback_mask );
-                x_26_6 += PX_TO_FONT_METRIC(fb_advance);
+                x += fb_advance;
                 #ifdef DEBUG_DRAW_TEXT
                     printf("DTHB ### drawn past notdef > X+= %d\n[...]", fb_advance);
                 #endif
@@ -2248,21 +2242,21 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
                     printf("regular g%d>%d: ", hg, hg2);
                 #endif
                 // Draw glyphs of this same cluster
-                int prev_x_26_6 = x_26_6;
+                int prev_x = x;
                 for (i = hg; i < hg2; i++) {
                     LVFontGlyphCacheItem *item = getGlyphByIndex(glyph_info[i].codepoint);
                     if (item) {
                         #ifdef DEBUG_DRAW_TEXT
                             printf("%x(x=%d+%d,w=%d) ", glyph_info[i].codepoint, x,
-                                    item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset), w);
+                                    item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset), FONT_METRIC_TO_PX(glyph_pos[i].x_advance));
                         #endif
-                        buf->Draw(FONT_METRIC_TO_PX(x_26_6 + glyph_pos[i].x_offset) + item->origin_x,
+                        buf->Draw(x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
                                   y + _baseline - item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
                                   item->bmp,
                                   item->bmp_width,
                                   item->bmp_height,
                                   palette);
-                        x_26_6 += glyph_pos[i].x_advance;
+                        x += FONT_METRIC_TO_PX(glyph_pos[i].x_advance);
                     }
                     #ifdef DEBUG_DRAW_TEXT
                     else
@@ -2270,11 +2264,11 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
                     #endif
                 }
                 // Whole cluster drawn: add letter spacing
-                if ( x_26_6 > prev_x_26_6 ) {
+                if ( x > prev_x ) {
                     // But only if this cluster has some advance
                     // (e.g. a soft-hyphen makes its own cluster, that
                     // draws a space glyph, but with no advance)
-                    x_26_6 += letter_spacing_26_6;
+                    x += letter_spacing_w;
                 }
             }
             hg = hg2;
@@ -2293,13 +2287,13 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
             ch = UNICODE_SOFT_HYPHEN_CODE;
             LVFontGlyphCacheItem *item = getGlyph(ch, def_char);
             if (item) {
-                buf->Draw( FONT_METRIC_TO_PX(x_26_6) + item->origin_x,
+                buf->Draw( x + item->origin_x,
                            y + _baseline - item->origin_y,
                            item->bmp,
                            item->bmp_width,
                            item->bmp_height,
                            palette);
-                x_26_6  += item->advance_26_6; // + letter_spacing; (let's not add any letter-spacing after hyphen)
+                x += item->advance; // + letter_spacing; (let's not add any letter-spacing after hyphen)
             }
         }
     } else if (_shapingMode == SHAPING_MODE_HARFBUZZ_LIGHT) {
@@ -2335,23 +2329,23 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
                     triplet.nextChar = 0;
                 if (!_width_cache2.get(triplet, posInfo)) {
                     if (!hbCalcCharWidth(&posInfo, triplet, def_char, fallbackPassMask)) {
-                        posInfo.offset_26_6 = 0;
-                        posInfo.advance_26_6 = item->advance_26_6;
+                        posInfo.offset = 0;
+                        posInfo.advance = item->advance;
                     }
                     _width_cache2.set(triplet, posInfo);
                 }
-                buf->Draw(FONT_METRIC_TO_PX(x_26_6 + posInfo.offset_26_6) + item->origin_x,
+                buf->Draw(x + item->origin_x + posInfo.offset,
                     y + _baseline - item->origin_y,
                     item->bmp,
                     item->bmp_width,
                     item->bmp_height,
                     palette);
 
-                if ( posInfo.advance_26_6 == 0 ) {
+                if ( posInfo.advance == 0 ) {
                     // Assume zero advance means it's a diacritic, and we should not apply
                     // any letter spacing on this char (now, and when justifying)
                 } else {
-                    x_26_6 += posInfo.advance_26_6 + letter_spacing_26_6;
+                    x += posInfo.advance + letter_spacing_w;
                 }
             }
         }
@@ -2393,19 +2387,19 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
         if ( !item )
             continue;
         if ( (item && !isHyphen) || i>=len-1 ) { // avoid soft hyphens inside text string
-            lInt32 w_26_6 = item->advance_26_6 + kerning_26_6;
-            buf->Draw( FONT_METRIC_TO_PX(x_26_6 + kerning_26_6) + item->origin_x,
+            lInt32 w = item->advance + FONT_METRIC_TRUNC(kerning_26_6);
+            buf->Draw( x + FONT_METRIC_TRUNC(kerning_26_6) + item->origin_x,
                        y + _baseline - item->origin_y,
                        item->bmp,
                        item->bmp_width,
                        item->bmp_height,
                        palette);
 
-            if ( w_26_6 == 0 ) {
+            if ( w == 0 ) {
                 // Assume zero advance means it's a diacritic, and we should not apply
                 // any letter spacing on this char (now, and when justifying)
             } else {
-                x_26_6  += w_26_6 + letter_spacing_26_6;
+                x  += w + letter_spacing_w;
             }
             previous = ch_glyph_index;
         }
@@ -2415,7 +2409,6 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
     } // else fallback to the non harfbuzz code
 #endif
 
-    x = FONT_METRIC_TO_PX(x_26_6);
     int advance = x - x0;
     if ( flags & LFNT_DRAW_DECORATION_MASK ) {
         // text decoration: underline, etc.

--- a/crengine/src/private/lvfreetypeface.h
+++ b/crengine/src/private/lvfreetypeface.h
@@ -125,8 +125,8 @@ protected:
     int _height; // full line height in pixels
     int _hyphen_width;
     int _baseline;
-    int _weight;
-    int _italic;
+    int _weight; // original font weight 400: normal, 700: bold, 100..900 thin..black
+    int _italic; // 0: regular, 1: italic, 2: fake/synthesized italic
     LVFontGlyphUnsignedMetricCache _wcache;
     LVFontGlyphSignedMetricCache _lsbcache; // glyph left side bearing cache
     LVFontGlyphSignedMetricCache _rsbcache; // glyph right side bearing cache
@@ -142,9 +142,9 @@ protected:
      * <any> - A mask with only one bit set, the number of which corresponds to the number in the fallback font chain.
      */
     lUInt32 _fallback_mask;
-    int            _synth_weight; // fake/synthetized weight
+    int            _synth_weight; // fake/synthesized weight
     bool           _allowKerning;
-    FT_Pos         _synth_weight_strength;   // for emboldening with Harfbuzz
+    FT_Pos         _synth_weight_strength;   // for emboldening with FT_Outline_Embolden()
     FT_Pos         _synth_weight_half_strength;
     int _features; // requested OpenType features bitmap
 #if USE_HARFBUZZ == 1

--- a/crengine/src/private/lvfreetypefontman.cpp
+++ b/crengine/src/private/lvfreetypefontman.cpp
@@ -1028,16 +1028,19 @@ void LVFreeTypeFontManager::UnregisterDocumentFonts(int documentId) {
     _cache.removeDocumentFonts(documentId);
 }
 
-bool LVFreeTypeFontManager::RegisterExternalFont(lString32 name, lString8 family_name, bool bold,
+bool LVFreeTypeFontManager::RegisterExternalFont(int documentId, lString32 name, lString8 family_name, bool bold,
                                                  bool italic) {
     if (name.startsWithNoCase(lString32("res://")))
         name = name.substr(6);
     else if (name.startsWithNoCase(lString32("file://")))
         name = name.substr(7);
     lString8 fname = UnicodeToUtf8(name);
+    CRLog::debug("RegisterExternalFont(documentId=%d, path=%s)", documentId, fname.c_str());
+    if (_cache.findDocumentFontDuplicate(documentId, fname)) {
+        return false;
+    }
 
     bool res = false;
-
     int index = 0;
 
     FT_Face face = NULL;
@@ -1091,7 +1094,8 @@ bool LVFreeTypeFontManager::RegisterExternalFont(lString32 name, lString8 family
                 -1, // OpenType features = -1 for not yet instantiated fonts
                 fontFamily,
                 family_name,
-                index
+                index,
+                documentId
         );
 #if (DEBUG_FONT_MAN == 1)
         if ( _log ) {

--- a/crengine/src/private/lvfreetypefontman.cpp
+++ b/crengine/src/private/lvfreetypefontman.cpp
@@ -190,7 +190,6 @@ LVFontRef LVFreeTypeFontManager::GetFallbackFont(int size, int weight, bool ital
     // assuming the fallback font is a standalone regular font
     // without any bold/italic sibling.
     // GetFont() works just as fine when we need specified weigh and italic.
-    weight &= 0xFFFE;
     LVFontRef fontRef = GetFont(size, weight, italic, css_ff_sans_serif, _fallbackFontFaces[index], 0, -1, false);
     if (!fontRef.isNull())
         fontRef->setFallbackMask(1 << index);

--- a/crengine/src/private/lvfreetypefontman.h
+++ b/crengine/src/private/lvfreetypefontman.h
@@ -132,7 +132,7 @@ public:
     /// unregisters all document fonts
     virtual void UnregisterDocumentFonts(int documentId);
 
-    virtual bool RegisterExternalFont(lString32 name, lString8 family_name, bool bold, bool italic);
+    virtual bool RegisterExternalFont(int documentId, lString32 name, lString8 family_name, bool bold, bool italic);
 
     virtual bool RegisterFont(lString8 name);
 


### PR DESCRIPTION
* **koreader/crengine**: Fonts: RegisterExternalFont() should take a documentId
* **koreader/crengine**: Fonts: keep hinting with synthetic weight
* **koreader/crengine**: Fonts: fix synthesized weight inconsitencies
* Reverted the use of 26.6 units to accumulate glyph positions.
* Added intermediate values for property PROP_INTERLINE_SPACE in program setings dialog.