### PR TITLE
Fixes for 3.2.55 (tier 3)

### DIFF
--- a/android/src/org/coolreader/crengine/InputDialog.java
+++ b/android/src/org/coolreader/crengine/InputDialog.java
@@ -70,7 +70,7 @@ public class InputDialog extends BaseDialog {
 						String value = String.valueOf(progress + InputDialog.this.mMinValue);
 						try {
 							if (inputHandler.validate(value))
-								mEditText.setText(value);
+								mEditText.setTextKeepState(value);
 						} catch (Exception e) {
 							// ignore
 						}

--- a/android/src/org/coolreader/sync2/Synchronizer.java
+++ b/android/src/org/coolreader/sync2/Synchronizer.java
@@ -719,10 +719,12 @@ public class Synchronizer {
 	protected class CheckDownloadSettingsSyncOperation extends SyncOperation {
 		private final String localFilePath;
 		private final String remoteFilePath;
+		private boolean accepted;
 
 		CheckDownloadSettingsSyncOperation(String localFilePath, String remoteFilePath) {
 			this.localFilePath = localFilePath;
 			this.remoteFilePath = remoteFilePath;
+			this.accepted = false;
 		}
 
 		@Override
@@ -757,14 +759,18 @@ public class Synchronizer {
 								syncDirDialog.setPositiveButtonLabel(m_coolReader.getString(R.string.googledrive_load_remote));
 								syncDirDialog.setNegativeButtonLabel(m_coolReader.getString(R.string.googledrive_upload_local));
 								syncDirDialog.setOnPositiveClickListener( view -> {
+									accepted = true;
 									insertOperation(this_op, new DownloadSettingsSyncOperation(remoteFilePath));
 									onContinue.run();
 								} );
 								syncDirDialog.setOnNegativeClickListener( view -> {
+									accepted = true;
 									insertOperation(this_op, new UploadSettingsSyncOperation(localFilePath, remoteFilePath));
 									onContinue.run();
 								} );
 								syncDirDialog.setOnCancelListener(dialog -> {
+									if (accepted)
+										return;
 									log.e("CheckDownloadSettingsSyncOperation: canceled");
 									doneFailed("canceled");
 								} );

--- a/android/src/org/coolreader/sync2/Synchronizer.java
+++ b/android/src/org/coolreader/sync2/Synchronizer.java
@@ -255,21 +255,33 @@ public class Synchronizer {
 	}
 
 	protected void doneFailed(String error) {
-		BackgroundThread.instance().executeGUI(() -> {
-			if (null != m_onStatusListener) {
-				m_onStatusListener.onSyncError(m_syncDirection, error);
+		m_removeLockFileOp.setNext(new SyncOperation() {
+			@Override
+			void call(Runnable onContinue) {
+				BackgroundThread.instance().executeGUI(() -> {
+					if (null != m_onStatusListener) {
+						m_onStatusListener.onSyncError(m_syncDirection, error);
+					}
+				});
+				m_isBusy = false;
 			}
 		});
-		m_isBusy = false;
+		m_removeLockFileOp.exec();
 	}
 
 	protected void doneAborted() {
-		BackgroundThread.instance().executeGUI(() -> {
-			if (null != m_onStatusListener) {
-				m_onStatusListener.onAborted(m_syncDirection);
+		m_removeLockFileOp.setNext(new SyncOperation() {
+			@Override
+			void call(Runnable onContinue) {
+				BackgroundThread.instance().executeGUI(() -> {
+					if (null != m_onStatusListener) {
+						m_onStatusListener.onAborted(m_syncDirection);
+					}
+				});
+				m_isBusy = false;
 			}
 		});
-		m_isBusy = false;
+		m_removeLockFileOp.exec();
 	}
 
 	protected void setSyncStarted(SyncDirection dir) {
@@ -1537,6 +1549,7 @@ public class Synchronizer {
 		}
 	}
 
+	protected SyncOperation m_removeLockFileOp = new RemoveLockFileSyncOperation();
 	protected SyncOperation m_doneOp = new SyncOperation() {
 		@Override
 		void call(Runnable onContinue) {
@@ -1579,7 +1592,7 @@ public class Synchronizer {
 			addOperation(new DeleteOldDataSyncOperation());
 		if ((m_flags & SYNC_FLAG_FORCE) != 0 || hasTarget(SyncTarget.CURRENTBOOKINFO))
 			addOperation(new DownloadCurrentBookInfoSyncOperation());
-		addOperation(new RemoveLockFileSyncOperation());
+		addOperation(m_removeLockFileOp);
 		addOperation(m_doneOp);
 		startOperations();
 	}
@@ -1622,7 +1635,7 @@ public class Synchronizer {
 			// bookInfo of fileInfo is null, skipping all operations related to the current book
 			log.d("bookInfo or fileInfo is null, skipping all operations related to the current book");
 		}
-		addOperation(new RemoveLockFileSyncOperation());
+		addOperation(m_removeLockFileOp);
 		addOperation(m_doneOp);
 		startOperations();
 	}
@@ -1671,7 +1684,7 @@ public class Synchronizer {
 					break;
 			}
 		}
-		addOperation(new RemoveLockFileSyncOperation());
+		addOperation(m_removeLockFileOp);
 		addOperation(m_doneOp);
 		startOperations();
 	}
@@ -1723,7 +1736,7 @@ public class Synchronizer {
 					break;
 			}
 		}
-		addOperation(new RemoveLockFileSyncOperation());
+		addOperation(m_removeLockFileOp);
 		addOperation(m_doneOp);
 		startOperations();
 	}

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -350,7 +350,7 @@ LVFont *LVFreeTypeFace::getFallbackFont(lUInt32 fallbackPassMask) {
             index++;
             if (index == fallback_count)
                 index = 0;
-            _fallbackFont = fontMan->GetFallbackFont(_size, getWeight(), _italic, index);
+            _fallbackFont = fontMan->GetFallbackFont(_size, getWeight(), _italic != 0, index);
         }
         _fallbackFontIsSet = true;
     }
@@ -829,7 +829,7 @@ bool LVFreeTypeFace::hbCalcCharWidth(LVCharPosInfo *posInfo, const LVCharTriplet
     }
     hb_buffer_set_content_type(_hb_buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
     hb_buffer_guess_segment_properties(_hb_buffer);
-    hb_shape(_hb_font, _hb_buffer, _hb_features.ptr(), _hb_features.length());
+    hb_shape(_hb_font, _hb_buffer, _hb_features.ptr(), (unsigned int)_hb_features.length());
     unsigned int glyph_count = hb_buffer_get_length(_hb_buffer);
     if (segLen == glyph_count) {
         hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(_hb_buffer, &glyph_count);
@@ -851,8 +851,8 @@ bool LVFreeTypeFace::hbCalcCharWidth(LVCharPosInfo *posInfo, const LVCharTriplet
             // which will be the one that will be rendered
             FT_UInt ch_glyph_index = FT_Get_Char_Index( _face, triplet.Char );
             if ( glyph_info[cluster].codepoint == ch_glyph_index ) {
-                posInfo->offset = FONT_METRIC_TO_PX(glyph_pos[cluster].x_offset);
-                posInfo->advance = FONT_METRIC_TO_PX(glyph_pos[cluster].x_advance);
+                posInfo->offset = (lInt16)FONT_METRIC_TO_PX(glyph_pos[cluster].x_offset);
+                posInfo->advance = (lInt16)FONT_METRIC_TO_PX(glyph_pos[cluster].x_advance);
                 return true;
             }
         }
@@ -1043,7 +1043,7 @@ void LVFreeTypeFace::setupHBFeatures()
 
 bool LVFreeTypeFace::getGlyphInfo(lUInt32 code, LVFont::glyph_info_t *glyph, lChar32 def_char, lUInt32 fallbackPassMask) {
     //FONT_GUARD
-    int glyph_index = getCharIndex(code, 0);
+    FT_UInt glyph_index = getCharIndex(code, 0);
     if (glyph_index == 0) {
         LVFont *fallback = getFallbackFont(fallbackPassMask);
         if (NULL == fallback) {
@@ -1369,7 +1369,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
         // cf in *some* minikin repositories: libs/minikin/Layout.cpp
 
         // Shape
-        hb_shape(_hb_font, _hb_buffer, _hb_features.ptr(), _hb_features.length());
+        hb_shape(_hb_font, _hb_buffer, _hb_features.ptr(), (unsigned int)_hb_features.length());
 
         // Harfbuzz has guessed and set a direction even if we did not provide one.
         bool is_rtl = false;
@@ -1646,8 +1646,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
                 cur_width += letter_spacing_w;
             }
             widths[i] = cur_width;
-            if ( !isHyphen ) // avoid soft hyphens inside text string
-                prev_width = cur_width;
+            prev_width = cur_width;
             if ( prev_width > max_width ) {
                 if ( lastFitChar < i + 7)
                     break;
@@ -1722,8 +1721,7 @@ lUInt16 LVFreeTypeFace::measureText(const lChar32 *text,
             cur_width += letter_spacing_w;
         }
         widths[i] = cur_width;
-        if ( !isHyphen ) // avoid soft hyphens inside text string
-            prev_width = cur_width;
+        prev_width = cur_width;
         if ( prev_width > max_width ) {
             if ( lastFitChar < i + 7)
                 break;
@@ -2076,7 +2074,7 @@ int LVFreeTypeFace::DrawTextString(LVDrawBuf *buf, int x, int y, const lChar32 *
         }
 
         // Shape
-        hb_shape(_hb_font, _hb_buffer, _hb_features.ptr(), _hb_features.length());
+        hb_shape(_hb_font, _hb_buffer, _hb_features.ptr(), (unsigned int)_hb_features.length());
 
         // If direction is RTL, hb_shape() has reversed the order of the glyphs, so
         // they are in visual order and ready to be iterated and drawn. So,

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -863,6 +863,7 @@ bool LVFreeTypeFace::hbCalcCharWidth(LVCharPosInfo *posInfo, const LVCharTriplet
     if ( getGlyphInfo(triplet.Char, &glyph, def_char, fallbackPassMask) ) {
         posInfo->offset = 0;
         posInfo->advance = glyph.width;
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
* Don't call onCancel listener in 'check download setting' dialog if positive or negative button is pressed.
* Synchronization: deleting the lock file on failure or cancellation.
* Synchronizer related: fixed scanning of just downloaded books in zip-archive.
* InputDialog: the cursor position is retained while dragging the slider.