### PR TITLE
Lazy HiDPI support for Qt5.

### DIFF
--- a/cr3qt/src/cr3widget.cpp
+++ b/cr3qt/src/cr3widget.cpp
@@ -9,6 +9,7 @@
 #include <qglobal.h>
 #if QT_VERSION >= 0x050000
 #include <QResizeEvent>
+#include <QtGui/QScreen>
 #include <QtWidgets/QScrollBar>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QStyleFactory>
@@ -358,6 +359,14 @@ void CR3View::updateDefProps()
     _data->_props->setStringDef( PROP_WINDOW_SHOW_STATUSBAR, "0" );
     _data->_props->setStringDef( PROP_APP_START_ACTION, "0" );
 
+    if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) {
+        QScreen* screen = QGuiApplication::primaryScreen();
+        lString32 str;
+        str.appendDecimal((int)screen->logicalDotsPerInch());
+        _data->_props->setString( PROP_RENDER_DPI, str );
+        // But we don't apply PROP_RENDER_SCALE_FONT_WITH_DPI property,
+        // since for now we are setting the font size in pixels.
+    }
 
     QStringList styles = QStyleFactory::keys();
     QStyle * s = QApplication::style();

--- a/cr3qt/src/main.cpp
+++ b/cr3qt/src/main.cpp
@@ -175,6 +175,13 @@ int main(int argc, char *argv[])
         //    return 3;
         //}
         {
+            if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) {
+                // Not allowed to scale widgets for HiDPI.
+                // crengine renders text to image using anti-aliasing,
+                // so scaling is prohibited after this rendering!
+                QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling, false);
+                QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
+            }
             QApplication a(argc, argv);
 #if MAC == 1
             QString exeDir = QDir::toNativeSeparators(qApp->applicationDirPath() + "/Contents/Resources/"); //QDir::separator();


### PR DESCRIPTION
Lazy HiDPI support for Qt5:
* Disabled scaling of the widget to prevent blurred text.
* Setted PROP_RENDER_DPI property for crengine to scale some engine's elements.
But we don't apply PROP_RENDER_SCALE_FONT_WITH_DPI property, since for now we are setting the font size in pixels.

This should closes #292.