### PR TITLE
Fixes for 3.2.58

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:7.0.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/android/jni/cr3engine.cpp
+++ b/android/jni/cr3engine.cpp
@@ -824,6 +824,32 @@ JNIEXPORT jbyteArray JNICALL Java_org_coolreader_crengine_Engine_scanBookCoverIn
 
 /*
  * Class:     org_coolreader_crengine_Engine
+ * Method:    isArchiveInternal
+ * Signature: (Ljava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_coolreader_crengine_Engine_isArchiveInternal
+  (JNIEnv * _env, jclass, jstring jarcName)
+{
+    jboolean res = JNI_FALSE;
+    CRJNIEnv env(_env);
+    lString32 arcName = env.fromJavaString(jarcName);
+    LVStreamRef stream = LVOpenFileStream(arcName.c_str(), LVOM_READ);
+    if (!stream.isNull()) {
+        LVContainerRef arc = LVOpenArchieve(stream);
+        if (!arc.isNull()) {
+            if (!DetectEpubFormat(stream) &&
+                !DetectFb3Format(stream) &&
+                !DetectDocXFormat(stream) &&
+                !DetectOpenDocumentFormat(stream)) {
+                res = JNI_TRUE;
+            }
+        }
+    }
+    return res;
+}
+
+/*
+ * Class:     org_coolreader_crengine_Engine
  * Method:    getArchiveItemsInternal
  * Signature: (Ljava/lang/String;)[Ljava/lang/String;
  */
@@ -1179,6 +1205,7 @@ static JNINativeMethod sEngineMethods[] = {
   {"setCacheDirectoryInternal", "(Ljava/lang/String;I)Z", (void*)Java_org_coolreader_crengine_Engine_setCacheDirectoryInternal},
   {"scanBookPropertiesInternal", "(Lorg/coolreader/crengine/FileInfo;)Z", (void*)Java_org_coolreader_crengine_Engine_scanBookPropertiesInternal},
   {"updateFileCRC32Internal", "(Lorg/coolreader/crengine/FileInfo;)Z", (void*)Java_org_coolreader_crengine_Engine_updateFileCRC32Internal},
+  {"isArchiveInternal", "(Ljava/lang/String;)Z", (void*)Java_org_coolreader_crengine_Engine_isArchiveInternal},
   {"getArchiveItemsInternal", "(Ljava/lang/String;)[Ljava/lang/String;", (void*)Java_org_coolreader_crengine_Engine_getArchiveItemsInternal},
   {"isLink", "(Ljava/lang/String;)Ljava/lang/String;", (void*)Java_org_coolreader_crengine_Engine_isLink},
   {"suspendLongOperationInternal", "()V", (void*)Java_org_coolreader_crengine_Engine_suspendLongOperationInternal},
@@ -1208,7 +1235,7 @@ static JNINativeMethod sDocViewMethods[] = {
   {"getCurrentPageBookmarkInternal", "()Lorg/coolreader/crengine/Bookmark;", (void*)Java_org_coolreader_crengine_DocView_getCurrentPageBookmarkInternal},
   {"goToPositionInternal", "(Ljava/lang/String;Z)Z", (void*)Java_org_coolreader_crengine_DocView_goToPositionInternal},
   {"getPositionPropsInternal", "(Ljava/lang/String;Z)Lorg/coolreader/crengine/PositionProperties;", (void*)Java_org_coolreader_crengine_DocView_getPositionPropsInternal},
-  {"updateBookInfoInternal", "(Lorg/coolreader/crengine/BookInfo;)V", (void*)Java_org_coolreader_crengine_DocView_updateBookInfoInternal},
+  {"updateBookInfoInternal", "(Lorg/coolreader/crengine/BookInfo;Z)V", (void*)Java_org_coolreader_crengine_DocView_updateBookInfoInternal},
   {"getTOCInternal", "()Lorg/coolreader/crengine/TOCItem;", (void*)Java_org_coolreader_crengine_DocView_getTOCInternal},
   {"clearSelectionInternal", "()V", (void*)Java_org_coolreader_crengine_DocView_clearSelectionInternal},
   {"findTextInternal", "(Ljava/lang/String;III)Z", (void*)Java_org_coolreader_crengine_DocView_findTextInternal},

--- a/android/jni/cr3java.h
+++ b/android/jni/cr3java.h
@@ -186,6 +186,26 @@ public:
 	void set(lInt64 v) { objacc->SetLongField(objacc.getObject(), fieldid, v); } 
 };
 
+class CRBooleanField : public CRFieldAccessor {
+public:
+	CRBooleanField( CRObjectAccessor & acc, const char * fieldName )
+			: CRFieldAccessor( acc, fieldName, "Z" )
+	{
+	}
+	bool get() { return objacc->GetBooleanField(objacc.getObject(), fieldid); }
+	void set(bool v) { objacc->SetBooleanField(objacc.getObject(), fieldid, v); }
+};
+
+class CRObjectField : public CRFieldAccessor {
+public:
+	CRObjectField( CRObjectAccessor & acc, const char * fieldName, const char* signature )
+			: CRFieldAccessor( acc, fieldName, signature )
+	{
+	}
+	jobject get() { return objacc->GetObjectField(objacc.getObject(), fieldid); }
+	void set(jobject v) { objacc->SetObjectField(objacc.getObject(), fieldid, v); }
+};
+
 class BitmapAccessor : public CRJNIEnv {
 private:
     jobject bitmap;

--- a/android/jni/docview.h
+++ b/android/jni/docview.h
@@ -28,9 +28,9 @@ public:
 	bool closeBook();
 	bool loadHistory( lString32 filename );
 	bool saveHistory( lString32 filename );
-	void createDefaultDocument( lString32 title, lString32 message );
-	bool loadDocument( lString32 filename );
-	bool loadDocument( LVStreamRef stream, lString32 contentPath );
+	void createDefaultDocument( const lString32& title, const lString32& message );
+	bool loadDocument( const lString32& filename );
+	bool loadDocument( LVStreamRef stream, const lString32& contentPath );
 	int doCommand( int cmd, int param );
     bool findText( lString32 pattern, int origin, bool reverse, bool caseInsensitive );
     void clearSelection();

--- a/android/jni/org_coolreader_crengine_DocView.h
+++ b/android/jni/org_coolreader_crengine_DocView.h
@@ -136,10 +136,10 @@ JNIEXPORT jobject JNICALL Java_org_coolreader_crengine_DocView_getPositionPropsI
 /*
  * Class:     org_coolreader_crengine_DocView
  * Method:    updateBookInfoInternal
- * Signature: (Lorg/coolreader/crengine/BookInfo;)V
+ * Signature: (Lorg/coolreader/crengine/BookInfo;Z)V
  */
 JNIEXPORT void JNICALL Java_org_coolreader_crengine_DocView_updateBookInfoInternal
-  (JNIEnv *, jobject, jobject);
+  (JNIEnv *, jobject, jobject, jboolean);
 
 /*
  * Class:     org_coolreader_crengine_DocView

--- a/android/jni/org_coolreader_crengine_Engine.h
+++ b/android/jni/org_coolreader_crengine_Engine.h
@@ -85,6 +85,14 @@ JNIEXPORT jintArray JNICALL Java_org_coolreader_crengine_Engine_getAvailableSynt
 
 /*
  * Class:     org_coolreader_crengine_Engine
+ * Method:    isArchiveInternal
+ * Signature: (Ljava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_coolreader_crengine_Engine_isArchiveInternal
+  (JNIEnv *, jclass, jstring);
+
+/*
+ * Class:     org_coolreader_crengine_Engine
  * Method:    getArchiveItemsInternal
  * Signature: (Ljava/lang/String;)[Ljava/lang/String;
  */

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -735,4 +735,5 @@
     <string name="filter_by_book_language_s">Отфильтровать по языку книги (%s)</string>
     <string name="scanning_font_files">Сканирование файлов шрифтов…</string>
     <string name="undetermined">Неопределенный</string>
+    <string name="failed_to_save_memory_stream">Не удалось сохранить внешний поток в хранилище устройства!</string>
 </resources>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -774,4 +774,5 @@
     <string name="filter_by_book_language_s">Filter by book language (%s)</string>
     <string name="scanning_font_files">Scanning font files…</string>
     <string name="undetermined">Undetermined</string>
+    <string name="failed_to_save_memory_stream">Failed to save memory stream to device storage!</string>
 </resources>

--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -728,11 +728,10 @@ public class CoolReader extends BaseActivity {
 			}, 500), true);
 			return true;
 		} else if (null != uri) {
-			// TODO: calculate fingerprint for uri and find fileInfo in DB
 			log.d("URI_TO_OPEN = " + uri);
 			final String uriString = uri.toString();
 			mFileToOpenFromExt = uriString;
-			loadDocumentFromUri(uri, () -> showToast(R.string.opened_from_stream), () -> BackgroundThread.instance().postGUI(() -> {
+			loadDocumentFromUri(uri, null, () -> BackgroundThread.instance().postGUI(() -> {
 				// if document not loaded show error & then root window
 				ErrorDialog errDialog = new ErrorDialog(CoolReader.this, CoolReader.this.getString(R.string.error), CoolReader.this.getString(R.string.cant_open_file, uriString));
 				errDialog.setOnDismissListener(dialog -> showRootWindow());
@@ -1422,6 +1421,7 @@ public class CoolReader extends BaseActivity {
 			InputStream inputStream;
 			try {
 				inputStream = contentResolver.openInputStream(uri);
+				// TODO: Fix this
 				// Don't save the last opened document from the stream in the cloud, since we still cannot open it later in this program.
 				mReaderView.loadDocumentFromStream(inputStream, uri.getPath(), doneCallback, errorCallback);
 			} catch (Exception e) {

--- a/android/src/org/coolreader/crengine/DocView.java
+++ b/android/src/org/coolreader/crengine/DocView.java
@@ -143,7 +143,6 @@ public class DocView {
 	 * create empty document with specified message (e.g. to show errors)
 	 * @param title
 	 * @param message
-	 * @return
 	 */
 	public void createDefaultDocument(String title, String message)
 	{
@@ -164,36 +163,15 @@ public class DocView {
 	}
 
 	/**
-	 * Load document from input stream.
-	 * @param inputStream
-	 * @param contentPath
-	 * @return
+	 * Load document from memory buffer.
+	 * @param buffer document content as byte buffer
+	 * @param contentPath Non empty stream name
+	 * @return true if operation successful, false otherwise.
 	 */
-	public boolean loadDocumentFromStream(InputStream inputStream, String contentPath) {
-		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		int errorCode = 0;
-		try {
-			byte [] buf = new byte [4096];
-			int readBytes;
-			while (true) {
-				readBytes = inputStream.read(buf);
-				if (readBytes > 0)
-					outputStream.write(buf, 0, readBytes);
-				else
-					break;
-			}
-		} catch (IOException e1) {
-			errorCode = 1;
-		} catch (OutOfMemoryError e2) {
-			errorCode = 2;
+	public boolean loadDocumentFromBuffer(byte[] buffer, String contentPath) {
+		synchronized (mutex) {
+			return loadDocumentFromMemoryInternal(buffer, contentPath);
 		}
-		if (0 == errorCode) {
-			synchronized (mutex) {
-				return loadDocumentFromMemoryInternal(outputStream.toByteArray(), contentPath);
-			}
-		}
-		// TODO: pass error code to caller to show message for user.
-		return false;
 	}
 
 	/**
@@ -317,10 +295,11 @@ public class DocView {
 	/**
 	 * Fill book info fields using metadata from current book. 
 	 * @param info
+	 * @param updatePath
 	 */
-	public void updateBookInfo(BookInfo info) {
+	public void updateBookInfo(BookInfo info, boolean updatePath) {
 		synchronized(mutex) {
-			updateBookInfoInternal(info);
+			updateBookInfoInternal(info, updatePath);
 		}
 	}
 
@@ -475,7 +454,7 @@ public class DocView {
 
 	private native PositionProperties getPositionPropsInternal(String xPath, boolean precise);
 
-	private native void updateBookInfoInternal(BookInfo info);
+	private native void updateBookInfoInternal(BookInfo info, boolean updatePath);
 
 	private native TOCItem getTOCInternal();
 

--- a/android/src/org/coolreader/crengine/DocumentFileCache.java
+++ b/android/src/org/coolreader/crengine/DocumentFileCache.java
@@ -1,0 +1,75 @@
+package org.coolreader.crengine;
+
+import android.app.Activity;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+
+public final class DocumentFileCache {
+	public static final Logger log = L.create("dfc");
+
+	String mBasePath = null;
+
+	public DocumentFileCache(Activity activity) {
+		File fd = activity.getCacheDir();
+		File dir = new File(fd, "bookCache");
+		if (dir.isDirectory() || dir.mkdirs()) {
+			mBasePath = dir.getAbsolutePath();
+		} else {
+			log.e("Failed to obtain private app cache directory!");
+		}
+	}
+
+	public final String getBasePath() {
+		return mBasePath;
+	}
+
+	public BookInfo saveStream(FileInfo fileInfo, InputStream inputStream) {
+		if (null == mBasePath) {
+			log.e("Attempt to save stream while private app cache directory uninitialized!");
+			return null;
+		}
+		BookInfo bookInfo = null;
+		String extension;
+		long codebase;
+		if (0 != fileInfo.crc32)
+			codebase = fileInfo.crc32;
+		else
+			codebase = android.os.SystemClock.uptimeMillis();
+		if (null != fileInfo.format)
+			extension = fileInfo.format.getExtensions()[0];
+		else
+			extension = ".fb2";
+		if (fileInfo.isArchive) {
+			// No info about archive type
+			extension += ".pack";
+		}
+		String filename = Long.valueOf(codebase).toString() + extension;
+		try {
+			File file = new File(mBasePath, filename);
+			FileOutputStream outputStream = new FileOutputStream(file);
+			inputStream.reset();
+			long size = Utils.copyStreamContent(outputStream, inputStream);
+			outputStream.close();
+			if (size > 0) {
+				FileInfo newFileInfo = new FileInfo(fileInfo);
+				// Set new path & name
+				if (fileInfo.isArchive) {
+					newFileInfo.arcname = file.getAbsolutePath();
+					newFileInfo.arcsize = size;
+				} else {
+					newFileInfo.filename = file.getName();
+					newFileInfo.path = file.getParent();
+					newFileInfo.pathname = file.getAbsolutePath();
+					newFileInfo.createTime = file.lastModified();
+					newFileInfo.size = size;
+				}
+				bookInfo = new BookInfo(newFileInfo);
+			}
+		} catch (Exception e) {
+			log.e("Exception while saving stream: " + e.getMessage());
+		}
+		return bookInfo;
+	}
+}

--- a/android/src/org/coolreader/crengine/Engine.java
+++ b/android/src/org/coolreader/crengine/Engine.java
@@ -103,6 +103,12 @@ public class Engine {
 		return mountRoot;
 	}
 
+	private final Map<String, String> mAppPrivateDirs = new HashMap<String, String>();
+
+	public Map<String, String> getAppPrivateDirs() {
+		return mAppPrivateDirs;
+	}
+
 	public boolean isRootsMountPoint(String path) {
 		if (mountedRootsMap == null)
 			return false;
@@ -577,6 +583,12 @@ public class Engine {
 
 	private void setParams(BaseActivity activity) {
 		this.mActivity = activity;
+		File cacheDir = mActivity.getCacheDir();
+		File filesDir = mActivity.getFilesDir();
+		File bookCacheDir = new File(cacheDir, "bookCache");
+		File downloadDir = new File(filesDir, "downloads");
+		mAppPrivateDirs.put(downloadDir.getAbsolutePath(), "downloads");
+		mAppPrivateDirs.put(bookCacheDir.getAbsolutePath(), "cache");
 	}
 
 	/**
@@ -621,6 +633,8 @@ public class Engine {
 	private native static int[] getAvailableFontWeightInternal(String fontFace);
 
 	private native static int[] getAvailableSynthFontWeightInternal();
+
+	public native static boolean isArchiveInternal(String arcFileName);
 
 	private native static String[] getArchiveItemsInternal(String arcName); // pairs: pathname, size
 
@@ -720,6 +734,12 @@ public class Engine {
 	private static final int HYPH_ALGO = 1;
 	private static final int HYPH_DICT = 2;
 	private static final int HYPH_BOOK = 0;
+
+	public static boolean isArchive(String arcFileName) {
+		synchronized (lock) {
+			return isArchiveInternal(arcFileName);
+		}
+	}
 
 	public ArrayList<ZipEntry> getArchiveItems(String zipFileName) {
 		final int itemsPerEntry = 2;

--- a/android/src/org/coolreader/crengine/Scanner.java
+++ b/android/src/org/coolreader/crengine/Scanner.java
@@ -162,12 +162,12 @@ public class Scanner extends FileInfoChangeSource {
 							// skip mount root
 							continue;
 						}
-						boolean isZip = pathName.toLowerCase().endsWith(".zip");
+						boolean isArc = Engine.isArchive(pathName);
 						FileInfo item = !rescan ? mFileList.get(pathName) : null;
 						boolean isNew = false;
 						if ( item==null ) {
 							item = new FileInfo( f );
-							if ( scanzip && isZip ) {
+							if ( scanzip && isArc ) {
 								item = scanZip( item );
 								if ( item==null )
 									continue;
@@ -723,6 +723,8 @@ public class Scanner extends FileInfoChangeSource {
 			parent = findParentInternal(file, root);
 			if ( parent==null )
 				parent = findParentInternal(file, new FileInfo(mActivity.getFilesDir()));
+			if ( parent==null )
+				parent = findParentInternal(file, new FileInfo(mActivity.getCacheDir()));
 			if ( parent==null ) {
 				L.e("Cannot find root directory for file " + file.pathname);
 				return null;
@@ -829,7 +831,7 @@ public class Scanner extends FileInfoChangeSource {
 		return existingResults;
 	}
 	
-	public void initRoots(Map<String, String> fsRoots) {
+	public void initRoots(Map<String, String> fsRoots, Map<String, String> privateDirs) {
 		Log.d("cr3", "Scanner.initRoots(" + fsRoots + ")");
 		mRoot.clear();
 		// create recent books dir
@@ -837,6 +839,10 @@ public class Scanner extends FileInfoChangeSource {
 
 		// create system dirs
 		for (Map.Entry<String, String> entry : fsRoots.entrySet())
+			addRoot( entry.getKey(), entry.getValue(), true);
+
+		// App private dirs
+		for (Map.Entry<String, String> entry : privateDirs.entrySet())
 			addRoot( entry.getKey(), entry.getValue(), true);
 
 		// create OPDS dir

--- a/android/src/org/coolreader/crengine/Services.java
+++ b/android/src/org/coolreader/crengine/Services.java
@@ -14,6 +14,7 @@ public class Services {
 	private static CoverpageManager mCoverpageManager;
 	private static FileSystemFolders mFSFolders;
 	private static GenresCollection mGenresCollection;
+	private static DocumentFileCache mDocumentCache;
 
 	public static Engine getEngine() {
 		if (null != mEngine)
@@ -51,35 +52,36 @@ public class Services {
 		throw new RuntimeException("Services.getGenresCollection(): trying to get null object");
 	}
 
+	public static DocumentFileCache getDocumentCache() {
+		if (null != mDocumentCache)
+			return mDocumentCache;
+		throw new RuntimeException("Services.getDocumentCache(): trying to get null object");
+	}
+
 	public static boolean isStopped() {
-		return null == mEngine || null == mScanner || null == mHistory || null == mCoverpageManager || null == mFSFolders || null == mGenresCollection;
+		return null == mEngine || null == mScanner || null == mHistory || null == mCoverpageManager || null == mFSFolders || null == mGenresCollection || null == mDocumentCache;
 	}
 
 	public static void startServices(BaseActivity activity) {
 		log.i("First activity is created");
 		// testing background thread
 		//mSettings = activity.settings();
-
 		BackgroundThread.instance().setGUIHandler(new Handler());
-
 		mEngine = Engine.getInstance(activity);
-
 		mScanner = new Scanner(activity, mEngine);
-		mScanner.initRoots(Engine.getMountedRootsMap());
-
+		mScanner.initRoots(Engine.getMountedRootsMap(), mEngine.getAppPrivateDirs());
 		mHistory = new History(mScanner);
 		mScanner.setDirScanEnabled(activity.settings().getBool(ReaderView.PROP_APP_BOOK_PROPERTY_SCAN_ENABLED, true));
 		mCoverpageManager = new CoverpageManager();
-
 		mFSFolders = new FileSystemFolders(mScanner);
-
 		mGenresCollection = GenresCollection.getInstance(activity);
+		mDocumentCache = new DocumentFileCache(activity);
 	}
 
 	// called after user grant permissions for external storage
 	public static void refreshServices(BaseActivity activity) {
 		mEngine.initAgain();
-		mScanner.initRoots(Engine.getMountedRootsMap());
+		mScanner.initRoots(Engine.getMountedRootsMap(), mEngine.getAppPrivateDirs());
 	}
 
 	public static void stopServices() {
@@ -102,5 +104,6 @@ public class Services {
 		mCoverpageManager = null;
 		mFSFolders = null;
 		mGenresCollection = null;
+		mDocumentCache = null;
 	}
 }

--- a/android/src/org/coolreader/crengine/Utils.java
+++ b/android/src/org/coolreader/crengine/Utils.java
@@ -76,8 +76,8 @@ public class Utils {
 		return moveFile(oldPlace, newPlace, false);
 	}
 
-	public static int copyStreamContent(OutputStream os, InputStream is) throws IOException {
-		int totalSize = 0;
+	public static long copyStreamContent(OutputStream os, InputStream is) throws IOException {
+		long totalSize = 0;
 		byte[] buf = new byte[0x10000];
 		for (;;) {
 			int bytesRead = is.read(buf);

--- a/android/src/org/coolreader/plugins/litres/LitresConnection.java
+++ b/android/src/org/coolreader/plugins/litres/LitresConnection.java
@@ -306,7 +306,7 @@ public class LitresConnection {
 
 					try (InputStream inputStream = is;
 						 OutputStream outputStream = new FileOutputStream(contentHandler.fileToSave)) {
-						int bytesRead = Utils.copyStreamContent(outputStream, inputStream);
+						long bytesRead = Utils.copyStreamContent(outputStream, inputStream);
 						Log.i(TAG, "downloaded bytes: " + bytesRead);
 					}
 				} catch (IOException e) {

--- a/android/src/org/coolreader/tts/TTSControlService.java
+++ b/android/src/org/coolreader/tts/TTSControlService.java
@@ -367,7 +367,7 @@ public class TTSControlService extends BaseService {
 						} else {
 							log.e("Failed to build notification!");
 						}
-						if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 							// Workaround for API26+ bug:
 							// https://stackoverflow.com/questions/45960265/android-o-oreo-8-and-higher-media-buttons-issue
 							// https://issuetracker.google.com/issues/65344811

--- a/android/src/org/coolreader/tts/TTSControlServiceAccessor.java
+++ b/android/src/org/coolreader/tts/TTSControlServiceAccessor.java
@@ -12,11 +12,11 @@ import java.util.ArrayList;
 
 public class TTSControlServiceAccessor {
 	private final static String TAG = "ttssrv";
-	private Activity mActivity;
+	private final Activity mActivity;
 	private volatile TTSControlBinder mServiceBinder;
 	private volatile boolean mServiceBound;
-	private ArrayList<TTSControlBinder.Callback> onConnectCallbacks = new ArrayList<>();
-	private boolean bindIsCalled;
+	private volatile boolean bindIsCalled;
+	private final ArrayList<TTSControlBinder.Callback> onConnectCallbacks = new ArrayList<>();
 	private final Object mLocker = new Object();
 
 	public interface Callback {
@@ -60,6 +60,7 @@ public class TTSControlServiceAccessor {
 			mActivity.unbindService(mServiceConnection);
 			mServiceBound = false;
 			bindIsCalled = false;
+			mServiceBinder = null;
 		}
 	}
 
@@ -81,6 +82,8 @@ public class TTSControlServiceAccessor {
 
 		public void onServiceDisconnected(ComponentName className) {
 			synchronized (TTSControlServiceAccessor.this) {
+				mServiceBound = false;
+				bindIsCalled = false;
 				mServiceBinder = null;
 			}
 			Log.i(TAG, "Connection to the TTSControlService has been lost");

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -11,6 +11,10 @@
 #include "../include/crlog.h"
 #include <chm_lib.h>
 
+#include "../include/fb2def.h"
+#define XS_IMPLEMENT_SCHEME 1
+#include "../include/fb2def.h"
+
 #define DUMP_CHM_DOC 0
 
 struct crChmExternalFileStream : public chmExternalFileStream {
@@ -866,10 +870,10 @@ ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString32 defEncodingNa
     if ( stream.isNull() )
         return NULL;
 
+#if 0
     // detect encondig
     stream->SetPos(0);
 
-#if 0
     ldomDocument * encDetectionDoc = LVParseHTMLStream( stream );
     int encoding = 0;
     if ( encDetectionDoc!=NULL ) {
@@ -905,11 +909,14 @@ ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString32 defEncodingNa
     ldomDocument * doc;
     doc = new ldomDocument();
     doc->setDocFlags( 0 );
+    doc->setNodeTypes(fb2_elem_table);
+    doc->setAttributeTypes(fb2_attr_table);
+    doc->setNameSpaceTypes(fb2_ns_table);
 
     ldomDocumentWriterFilter writerFilter(doc, false, HTML_AUTOCLOSE_TABLE);
     writerFilter.setFlags(writerFilter.getFlags() | TXTFLG_CONVERT_8BIT_ENTITY_ENCODING);
 
-    /// FB2 format
+    /// HTML format
     LVFileFormatParser * parser = new LVHTMLParser(stream, &writerFilter);
     if ( !defEncodingName.empty() )
         parser->SetCharset(defEncodingName.c_str());
@@ -1109,11 +1116,11 @@ public:
                 return false;
             }
 
-    #if DUMP_CHM_DOC==1
-        LVStreamRef out = LVOpenFileStream(U"/tmp/chm-toc.html", LVOM_WRITE);
-        if ( !out.isNull() )
-            doc->saveToStream( out, NULL, true );
-    #endif
+#if DUMP_CHM_DOC==1
+            LVStreamRef out = LVOpenFileStream(U"chm-toc.xml", LVOM_WRITE);
+            if ( !out.isNull() )
+                doc->saveToStream( out, NULL, true );
+#endif
 
             ldomNode * body = doc->getRootNode(); //doc->createXPointer(cs32("/html[1]/body[1]"));
             bool res = false;

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -829,7 +829,7 @@ public:
     }
 
     lString32 getContentsFileName() {
-        if ( _binaryTOCURLTableId!=0 ) {
+        if ( _binaryTOCURLTableId!=0 && _urlTable != NULL ) {
             lString8 url = _urlTable->urlById(_binaryTOCURLTableId);
             if ( !url.empty() )
                 return decodeString(url);

--- a/thirdparty_unman/chmlib/src/lzx.c
+++ b/thirdparty_unman/chmlib/src/lzx.c
@@ -268,7 +268,7 @@ int LZXreset(struct LZXstate *pState)
 
 #define ENSURE_BITS(n)							\
   while (bitsleft < (n)) {						\
-    bitbuf |= ((inpos[1]<<8)|inpos[0]) << (ULONG_BITS-16 - bitsleft);	\
+    bitbuf |= (ULONG)((inpos[1]<<8)|inpos[0]) << (ULONG_BITS-16 - bitsleft);	\
     bitsleft += 16; inpos+=2;						\
   }
 


### PR DESCRIPTION
* crengine: fixed integer overflow when measuring text with fallback fonts (HarfBuzz render).
* Android: When opening an external stream, find the corresponding file in the database to find the last read position and load the saved bookmarks, and if not found, save it to the application's private directory and save the information to the database.
* Fixed incorrect parsing of content file in 'chm' files.

Screenshot with integer overflow with HarfBuzz render:
![device-2021-08-30-110202_sz](https://user-images.githubusercontent.com/36960933/131299943-5256488b-57ea-4724-9694-fdb926af4fd6.png)