### PR TITLE
ZIP64 fixes & other...

### DIFF
--- a/cr3wx/src/view.cpp
+++ b/cr3wx/src/view.cpp
@@ -307,33 +307,73 @@ void cr3view::OnTimer(wxTimerEvent& event)
     }
 }
 
+static bool getBatteryState(int& state, int& chargingConn, int& level)
+{
+#ifdef _WIN32
+    // update battery state
+    SYSTEM_POWER_STATUS bstatus;
+    BOOL pow = GetSystemPowerStatus(&bstatus);
+    if (pow) {
+        state = CR_BATTERY_STATE_DISCHARGING;
+        if (bstatus.BatteryFlag & 128)
+            state = CR_BATTERY_STATE_NO_BATTERY;  // no system battery
+        else if (bstatus.BatteryFlag & 8)
+            state = CR_BATTERY_STATE_CHARGING;    // charging
+        chargingConn = CR_BATTERY_CHARGER_NO;
+        if (bstatus.ACLineStatus==1)
+            chargingConn = CR_BATTERY_CHARGER_AC; // AC power charging connected
+        if (bstatus.BatteryLifePercent>=0 && bstatus.BatteryLifePercent<=100)
+            level = bstatus.BatteryLifePercent;
+        return true;
+    }
+    return false;
+#else
+    wxPowerType wxpwrtype = wxGetPowerType();
+    switch (wxpwrtype) {
+        case wxPOWER_SOCKET:
+            state = CR_BATTERY_STATE_CHARGING;
+            chargingConn = CR_BATTERY_CHARGER_AC;
+            break;
+        case wxPOWER_BATTERY:
+            state = CR_BATTERY_STATE_DISCHARGING;
+            chargingConn = CR_BATTERY_CHARGER_NO;
+            break;
+        default:
+            state = CR_BATTERY_STATE_NO_BATTERY;
+            chargingConn = CR_BATTERY_CHARGER_NO;
+            break;
+    }
+    wxBatteryState wxbatstate = wxGetBatteryState();
+    switch (wxbatstate) {
+        case wxBATTERY_NORMAL_STATE:
+            level = 100;
+            break;
+        case wxBATTERY_LOW_STATE:
+            level = 50;
+            break;
+        case wxBATTERY_CRITICAL_STATE:
+            level = 5;
+            break;
+        case wxBATTERY_SHUTDOWN_STATE:
+            level = 0;
+            break;
+        default:
+            level = 0;
+            break;
+    }
+    return true;
+#endif
+}
+
 void cr3view::Paint()
 {
     //printf("cr3view::Paint() \n");
-    int battery_state = -1;
-#ifdef _WIN32
-    SYSTEM_POWER_STATUS bstatus;
-    BOOL pow = GetSystemPowerStatus(&bstatus);
-    if (bstatus.BatteryFlag & 128)
-        pow = FALSE;
-    if (bstatus.ACLineStatus!=0 || bstatus.BatteryLifePercent==255)
-        pow = FALSE;
-    if ( pow )
-        battery_state = bstatus.BatteryLifePercent;
-#else
-    if ( ::wxGetPowerType() == wxPOWER_BATTERY ) {
-        int n = ::wxGetBatteryState();
-        if ( n == wxBATTERY_NORMAL_STATE )
-            battery_state = 100;
-        else if ( n == wxBATTERY_LOW_STATE )
-            battery_state = 50;
-        else if ( n == wxBATTERY_CRITICAL_STATE )
-            battery_state = 0;
-        else if ( n == wxBATTERY_SHUTDOWN_STATE )
-            battery_state = 0;
-    };
-#endif
-    getDocView()->setBatteryState( battery_state );
+    int battery_state;
+    int charging_conn;
+    int charge_level;
+    if (getBatteryState(battery_state, charging_conn, charge_level)) {
+        getDocView()->setBatteryState( battery_state, charging_conn, charge_level );
+    }
     //_docview->Draw();
     UpdateScrollBar();
     Refresh( FALSE );

--- a/crengine/Tools/blend-algo-test/blend_over_gray_test.c
+++ b/crengine/Tools/blend-algo-test/blend_over_gray_test.c
@@ -165,7 +165,11 @@ int main() {
         // build input test file
         printf("Preparing data (random)... ");
         fflush(stdout);
+#ifdef _WIN32
+        srand(time(0));
+#else
         srandom(time(0));
+#endif
         int* test_inp_data = (int*)malloc(TEST_POINTS_COUNT*sizeof(int));
         int* test_alpha_data = (int*)malloc(TEST_POINTS_COUNT*sizeof(int));
         int* test_color_data = (int*)malloc(TEST_POINTS_COUNT*sizeof(int));
@@ -175,13 +179,19 @@ int main() {
         }
         long j;
         for (j = 0; j < TEST_POINTS_COUNT; j++) {
+#ifdef _WIN32
+            test_inp_data[j] = (int)(300L*rand()/RAND_MAX);
+            test_alpha_data[j] = (int)(300L*rand()/RAND_MAX);
+            test_color_data[j] = (int)(300L*rand()/RAND_MAX);
+#else
             test_inp_data[j] = (int)(300L*random()/RAND_MAX);
+            test_alpha_data[j] = (int)(300L*random()/RAND_MAX);
+            test_color_data[j] = (int)(300L*random()/RAND_MAX);
+#endif
             if (test_inp_data[j] > 255)
                 test_inp_data[j] = 255;
-            test_alpha_data[j] = (int)(300L*random()/RAND_MAX);
             if (test_alpha_data[j] > 255)
                 test_alpha_data[j] = 255;
-            test_color_data[j] = (int)(300L*random()/RAND_MAX);
             if (test_color_data[j] > 255)
                 test_color_data[j] = 255;
         }

--- a/crengine/Tools/blend-algo-test/blend_over_rgb_test.c
+++ b/crengine/Tools/blend-algo-test/blend_over_rgb_test.c
@@ -203,7 +203,11 @@ int main() {
         // build input test file
         printf("Preparing data (random)... ");
         fflush(stdout);
+#ifdef _WIN32
+        srand(time(0));
+#else
         srandom(time(0));
+#endif
         uint32_t* test_inp_data = (uint32_t*)malloc(TEST_POINTS_COUNT*sizeof(int));
         uint32_t* test_color_data = (uint32_t*)malloc(TEST_POINTS_COUNT*sizeof(int));
         int* test_alpha_r_data = (int*)malloc(TEST_POINTS_COUNT*sizeof(int));
@@ -216,34 +220,49 @@ int main() {
         long j;
         long r, g, b;
         for (j = 0; j < TEST_POINTS_COUNT; j++) {
+#ifdef _WIN32
+            r = 300L*rand()/RAND_MAX;
+            g = 300L*rand()/RAND_MAX;
+            b = 300L*rand()/RAND_MAX;
+            test_alpha_r_data[j] = (int)(300L*rand()/RAND_MAX);
+            test_alpha_g_data[j] = (int)(300L*rand()/RAND_MAX);
+            test_alpha_b_data[j] = (int)(300L*rand()/RAND_MAX);
+#else
             r = 300L*random()/RAND_MAX;
+            g = 300L*random()/RAND_MAX;
+            b = 300L*random()/RAND_MAX;
+            test_alpha_r_data[j] = (int)(300L*random()/RAND_MAX);
+            test_alpha_g_data[j] = (int)(300L*random()/RAND_MAX);
+            test_alpha_b_data[j] = (int)(300L*random()/RAND_MAX);
+#endif
             if (r > 255)
                 r = 255;
-            g = 300L*random()/RAND_MAX;
             if (g > 255)
                 g = 255;
-            b = 300L*random()/RAND_MAX;
             if (b > 255)
                 b = 255;
             test_inp_data[j] = (uint32_t)((r << 16) | (g << 8) | b);
 
-            test_alpha_r_data[j] = (int)(300L*random()/RAND_MAX);
             if (test_alpha_r_data[j] > 255)
                 test_alpha_r_data[j] = 255;
-            test_alpha_g_data[j] = (int)(300L*random()/RAND_MAX);
             if (test_alpha_g_data[j] > 255)
                 test_alpha_g_data[j] = 255;
-            test_alpha_b_data[j] = (int)(300L*random()/RAND_MAX);
             if (test_alpha_b_data[j] > 255)
                 test_alpha_b_data[j] = 255;
 
+#ifdef _WIN32
+            r = 300L*rand()/RAND_MAX;
+            g = 300L*rand()/RAND_MAX;
+            b = 300L*rand()/RAND_MAX;
+#else
             r = 300L*random()/RAND_MAX;
+            g = 300L*random()/RAND_MAX;
+            b = 300L*random()/RAND_MAX;
+#endif
             if (r > 255)
                 r = 255;
-            g = 300L*random()/RAND_MAX;
             if (g > 255)
                 g = 255;
-            b = 300L*random()/RAND_MAX;
             if (b > 255)
                 b = 255;
             test_color_data[j] = (uint32_t)((r << 16) | (g << 8) | b);

--- a/crengine/Tools/zip-test/main.cpp
+++ b/crengine/Tools/zip-test/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[])
                 if ( item->IsContainer())
                     continue;
                 list.add( item->GetName() );
-                list.add( lString32::itoa(item->GetSize()) );
+                list.add( lString32::itoa((lUInt64)item->GetSize()) );
             }
         } else {
             printf("Failed to open archive!\n");

--- a/crengine/Tools/zip-test/main.cpp
+++ b/crengine/Tools/zip-test/main.cpp
@@ -10,8 +10,11 @@
 int main(int argc, char* argv[])
 {
     const char* fname;
+    const char* inner_fname = 0;
     if (argc > 1) {
         fname = argv[1];
+    if (argc > 2)
+        inner_fname = argv[2];
     } else {
         printf("You must specify path to archive!\n");
         return 1;
@@ -22,8 +25,9 @@ int main(int argc, char* argv[])
 
     lString32Collection list;
     LVStreamRef stream = LVOpenFileStream( fname, LVOM_READ );
+    LVContainerRef arc;
     if ( !stream.isNull() ) {
-        LVContainerRef arc = LVOpenArchieve(stream);
+        arc = LVOpenArchieve(stream);
         if ( !arc.isNull() ) {
             // convert
             for ( int i=0; i<arc->GetObjectCount(); i++ ) {
@@ -42,11 +46,54 @@ int main(int argc, char* argv[])
         return 1;
     }
 
+#if 0
+    if (!arc.isNull()) {
+        if (NULL != inner_fname) {
+            printf("Open file inside archive...\n");
+            lString32 inner_fname32 = LocalToUnicode(lString8(inner_fname));
+            LVStreamRef inner_stream = arc->OpenStream(inner_fname32.c_str(), LVOM_READ);
+            if (!inner_stream.isNull()) {
+                printf("  ok\n");
+                LVStreamRef out_stream = LVOpenFileStream(inner_fname32.c_str(), LVOM_WRITE);
+                if (!out_stream.isNull()) {
+                    printf("output file opened...\n");
+                    lUInt8 buff[4096];
+                    lvsize_t ReadSize;
+                    lvsize_t WriteSize;
+                    while (true) {
+                        if (inner_stream->Read(buff, 4096, &ReadSize) != LVERR_OK) {
+                            printf("Read error!\n");
+                            break;
+                        }
+                        if (0 == ReadSize) {
+                            break;
+                        }
+                        if (out_stream->Write(buff, ReadSize, &WriteSize) != LVERR_OK) {
+                            printf("Write error!\n");
+                            break;
+                        }
+                    }
+                } else {
+                    printf("Failed top open output file!\n");
+                }
+            } else {
+                printf("  failed\n");
+            }
+        } else {
+            printf("Inner filename must be specified from command line!\n");
+        }
+    }
+#endif
+
+#if 1
     printf("Archive contents:\n");
     for (int i = 0; i < list.length()/2; i++) {
         lString32 name = list[i*2];
-        int size = lString32(list[i*2+1]).atoi();
-        printf("  %s: %u\n", LCSTR(name), size);
+        lInt64 size;
+        if (!list[i*2+1].atoi(size))
+            size = 0;
+        printf("  %s: %lld\n", LCSTR(name), size);
     }
+#endif
     return 0;
 }

--- a/crengine/include/lvcommoncontaineriteminfo.h
+++ b/crengine/include/lvcommoncontaineriteminfo.h
@@ -32,18 +32,18 @@ protected:
     lString32    m_name;
     lUInt32      m_flags;
     bool         m_is_container;
-    lUInt32      m_srcpos;
-    lUInt32      m_srcsize;
+    lvpos_t      m_srcpos;
+    lvsize_t     m_srcsize;
     lUInt32      m_srcflags;
 public:
     virtual lvsize_t        GetSize() const { return m_size; }
     virtual const lChar32 * GetName() const { return m_name.empty()?NULL:m_name.c_str(); }
     virtual lUInt32         GetFlags() const  { return m_flags; }
     virtual bool            IsContainer() const  { return m_is_container; }
-    lUInt32 GetSrcPos() { return m_srcpos; }
-    lUInt32 GetSrcSize() { return m_srcsize; }
+    lvpos_t GetSrcPos() { return m_srcpos; }
+    lvsize_t GetSrcSize() { return m_srcsize; }
     lUInt32 GetSrcFlags() { return m_srcflags; }
-    void SetSrc( lUInt32 pos, lUInt32 size, lUInt32 flags )
+    void SetSrc( lvpos_t pos, lvsize_t size, lUInt32 flags )
     {
         m_srcpos = pos;
         m_srcsize = size;

--- a/crengine/src/lvstream/lvziparc.cpp
+++ b/crengine/src/lvstream/lvziparc.cpp
@@ -271,14 +271,12 @@ int LVZipArc::ReadContents()
         
         long SeekLen=ZipHeader.AddLen+ZipHeader.CommLen;
         
-        LVCommonContainerItemInfo * item = new LVCommonContainerItemInfo();
-        
         if (truncated)
             SeekLen+=ZipHeader.PackSize;
         
         NextOffset = (lvoffset_t)m_stream->GetPos();
         NextOffset += SeekLen;
-        if (NextOffset >= sz) {
+        if (NextOffset >= (lvoffset_t)sz) {
             CRLog::error("invalid offset, stop to read content.");
             break;
         }
@@ -307,6 +305,7 @@ int LVZipArc::ReadContents()
             }
         }
         
+        LVCommonContainerItemInfo * item = new LVCommonContainerItemInfo();
         item->SetItemInfo(fName.c_str(), ZipHeader.UnpSize, (ZipHeader.getAttr() & 0x3f));
         item->SetSrc( ZipHeader.getOffset(), ZipHeader.PackSize, ZipHeader.Method );
         

--- a/crengine/src/lvstream/lvziparc.cpp
+++ b/crengine/src/lvstream/lvziparc.cpp
@@ -68,60 +68,54 @@ LVStreamRef LVZipArc::OpenStream(const char32_t *fname, lvopen_mode_t)
     return stream;
 }
 
-int LVZipArc::ReadContents()
-{
+int LVZipArc::ReadContents() {
     lvByteOrderConv cnv;
     //bool arcComment = false;
     bool truncated = false;
-    
+
     m_list.clear();
-    if (!m_stream || m_stream->Seek(0, LVSEEK_SET, NULL)!=LVERR_OK)
-        return 0;
-    
-    SetName( m_stream->GetName() );
-    
-    
-    lvsize_t sz = 0;
-    if (m_stream->GetSize( &sz )!=LVERR_OK)
-        return 0;
-    lvsize_t fileSize = sz;
-    
+    if (!m_stream || m_stream->Seek(0, LVSEEK_SET, NULL) != LVERR_OK)
+        return -1;
+
+    SetName(m_stream->GetName());
+
+    lvsize_t fileSize = 0;
+    if (m_stream->GetSize(&fileSize) != LVERR_OK)
+        return -1;
+
     char ReadBuf[1024];
     lUInt32 NextPosition;
     lvoffset_t NextOffset;
     lvpos_t CurPos;
     lvsize_t ReadSize;
-    int Buf;
     bool found = false;
-#if LVLONG_FILE_SUPPORT==1
     bool found64 = false;
     bool require64 = false;
+    bool zip64 = false;
     lUInt64 NextPosition64 = 0;
-#endif
-    CurPos = (lvpos_t)fileSize;
+    CurPos = 0;
     NextPosition = 0;
-    if (CurPos < sizeof(ReadBuf)-18)
-        CurPos = 0;
+    if (fileSize < sizeof(ReadBuf) - 18)
+        CurPos = -(lvpos_t)fileSize;
     else
-        CurPos -= sizeof(ReadBuf)-18;
+        CurPos = -(lvpos_t)sizeof(ReadBuf) + 18;
     // Find End of central directory record (EOCD)
-    for ( Buf=0; Buf<64 && !found; Buf++ )
-    {
-        //SetFilePointer(ArcHandle,CurPos,NULL,FILE_BEGIN);
-        m_stream->Seek( CurPos, LVSEEK_SET, NULL );
-        m_stream->Read( ReadBuf, sizeof(ReadBuf), &ReadSize);
-        if (ReadSize==0)
+    for (int bufNo = 0; bufNo < 64; bufNo++) {
+        if (m_stream->Seek(CurPos, LVSEEK_END, NULL) != LVERR_OK)
             break;
-        for (int I=(int)ReadSize-4;I>=0;I--)
-        {
-            if (ReadBuf[I]==0x50 && ReadBuf[I+1]==0x4b &&
-                ReadBuf[I+2]==0x05 && ReadBuf[I+3]==0x06)
-            {
-                m_stream->Seek( CurPos+I+16, LVSEEK_SET, NULL );
-                m_stream->Read( &NextPosition, sizeof(NextPosition), &ReadSize);
-                cnv.lsf( &NextPosition );
-                found=true;
-#if LVLONG_FILE_SUPPORT==1
+        if (m_stream->Read(ReadBuf, sizeof(ReadBuf), &ReadSize) != LVERR_OK)
+            break;
+        if (ReadSize == 0)
+            break;
+        for (int i = (int)ReadSize - 4; i >= 0; i--) {
+            if (ReadBuf[i] == 0x50 && ReadBuf[i + 1] == 0x4b &&
+                ReadBuf[i + 2] == 0x05 && ReadBuf[i + 3] == 0x06) {
+                if (m_stream->Seek(CurPos + i + 16, LVSEEK_END, NULL) != LVERR_OK)
+                    break;
+                if (m_stream->Read(&NextPosition, sizeof(NextPosition), &ReadSize) != LVERR_OK)
+                    break;
+                cnv.lsf(&NextPosition);
+                found = true;
                 if (0xFFFFFFFFUL == NextPosition) {
                     require64 = true;
                     if (found64)
@@ -129,40 +123,39 @@ int LVZipArc::ReadContents()
                 } else {
                     break;
                 }
-#else
-                break;
-#endif
             }
-#if LVLONG_FILE_SUPPORT==1
-            if (ReadBuf[I]==0x50 && ReadBuf[I+1]==0x4b &&
-                ReadBuf[I+2]==0x06 && ReadBuf[I+3]==0x06)
-            {
-                m_stream->Seek( CurPos+I+48, LVSEEK_SET, NULL );
-                m_stream->Read( &NextPosition64, sizeof(NextPosition64), &ReadSize);
-                cnv.lsf( &NextPosition64 );
-                found64=true;
+            if (ReadBuf[i] == 0x50 && ReadBuf[i + 1] == 0x4b &&
+                ReadBuf[i + 2] == 0x06 && ReadBuf[i + 3] == 0x06) {
+                if (m_stream->Seek(CurPos + i + 48, LVSEEK_END, NULL) != LVERR_OK)
+                    break;
+                if (m_stream->Read(&NextPosition64, sizeof(NextPosition64), &ReadSize) != LVERR_OK)
+                    break;
+                cnv.lsf(&NextPosition64);
+                found64 = true;
                 break;
             }
-#endif
         }
-        if (CurPos==0)
+        if (CurPos <= -fileSize)
             break;
-        if (CurPos<sizeof(ReadBuf)-4)
-            CurPos=0;
+        if (fileSize < sizeof(ReadBuf) - 4)
+            CurPos = -fileSize;
         else
-            CurPos-=sizeof(ReadBuf)-4;
+            CurPos -= (lvpos_t)sizeof(ReadBuf) - 4;
     }
+    zip64 = found64 || require64;
 
-#if LVLONG_FILE_SUPPORT==1
-    if (found64 || (found && !require64))
-        truncated = false;
-    else
-        truncated = true;
+#if LVLONG_FILE_SUPPORT == 1
     if (found64)
         NextOffset = NextPosition64;
     else if (found && !require64)
         NextOffset = NextPosition;
+    else
+        truncated = true;
 #else
+    if (zip64) {
+        CRLog::error("zip64 signature found, but large file support is not enabled, stop processing.");
+        return -1;
+    }
     truncated = !found;
     NextOffset = NextPosition;
 #endif
@@ -177,107 +170,149 @@ int LVZipArc::ReadContents()
         // flag that, so there's no need to try that alt method,
         // as it was used on first scan
         m_alt_reading_method = true;
-    
+
     if (truncated)
-        NextOffset=0;
-    
+        NextOffset = 0;
+
     //================================================================
-    // get files
-    
-    
+    // get file list
+
+    lverror_t err;
     ZipLocalFileHdr ZipHd1;
     ZipHd2 ZipHeader = { 0 };
     unsigned ZipHeader_size = 0x2E; //sizeof(ZipHd2); //0x34; //
     unsigned ZipHd1_size = 0x1E; //sizeof(ZipHd1); //sizeof(ZipHd1)
-    //lUInt32 ReadSize;
-    
+
     for (;;) {
-        
-        if (m_stream->Seek( NextOffset, LVSEEK_SET, NULL )!=LVERR_OK)
+        if (m_stream->Seek(NextOffset, LVSEEK_SET, NULL) != LVERR_OK)
             return 0;
-        
-        if (truncated)
-        {
+        if (truncated) {
             // The offset (that we don't find in a local header, but
             // that we will store in the ZipHeader we're building)
             // happens to be the current position here.
             lUInt32 offset = (lUInt32)m_stream->GetPos();
-            
-            m_stream->Read( &ZipHd1, ZipHd1_size, &ReadSize);
+
+            err = m_stream->Read(&ZipHd1, ZipHd1_size, &ReadSize);
             ZipHd1.byteOrderConv();
-            
-            //ReadSize = fread(&ZipHd1, 1, sizeof(ZipHd1), f);
-            if (ReadSize != ZipHd1_size) {
-                //fclose(f);
-                if (ReadSize==0 && NextOffset==(lvoffset_t)fileSize)
+            if (err != LVERR_OK || ReadSize != ZipHd1_size) {
+                if (ReadSize == 0 && NextOffset == (lvoffset_t)fileSize)
                     return m_list.length();
-                if ( ReadSize==0 )
+                if (ReadSize == 0)
                     return m_list.length();
                 return 0;
             }
-            
-            ZipHeader.UnpVer=ZipHd1.UnpVer;
-            ZipHeader.UnpOS=ZipHd1.UnpOS;
-            ZipHeader.Flags=ZipHd1.Flags;
-            ZipHeader.ftime=ZipHd1.getftime();
-            ZipHeader.PackSize=ZipHd1.getPackSize();
-            ZipHeader.UnpSize=ZipHd1.getUnpSize();
-            ZipHeader.NameLen=ZipHd1.getNameLen();
-            ZipHeader.AddLen=ZipHd1.getAddLen();
-            ZipHeader.Method=ZipHd1.getMethod();
+
+            ZipHeader.UnpVer = ZipHd1.UnpVer;
+            ZipHeader.UnpOS = ZipHd1.UnpOS;
+            ZipHeader.Flags = ZipHd1.Flags;
+            ZipHeader.ftime = ZipHd1.getftime();
+            ZipHeader.PackSize = ZipHd1.getPackSize();
+            ZipHeader.UnpSize = ZipHd1.getUnpSize();
+            ZipHeader.NameLen = ZipHd1.getNameLen();
+            ZipHeader.AddLen = ZipHd1.getAddLen();
+            ZipHeader.Method = ZipHd1.getMethod();
             ZipHeader.setOffset(offset);
             // We may get a last invalid record with NameLen=0, which shouldn't hurt.
             // If it does, use:
             // if (ZipHeader.NameLen == 0) break;
         } else {
-            
-            m_stream->Read( &ZipHeader, ZipHeader_size, &ReadSize);
-            
+            err = m_stream->Read(&ZipHeader, ZipHeader_size, &ReadSize);
             ZipHeader.byteOrderConv();
-            //ReadSize = fread(&ZipHeader, 1, sizeof(ZipHeader), f);
-            if (ReadSize!=ZipHeader_size) {
-                if (ReadSize>16 && ZipHeader.Mark==0x06054B50 ) {
+            if (err != LVERR_OK || ReadSize != ZipHeader_size) {
+                if (ReadSize > 16 && (ZipHeader.Mark == 0x06054B50 || ZipHeader.Mark == 0x06064b50)) {
                     break;
                 }
-                //fclose(f);
                 return 0;
             }
         }
-        
-        if (ReadSize==0 || ZipHeader.Mark==0x06054b50 || ZipHeader.Mark==0x06064b50 ||
-            (truncated && ZipHeader.Mark==0x02014b50) )
-        {
+        if (ReadSize == 0 || ZipHeader.Mark == 0x06054b50 || ZipHeader.Mark == 0x06064b50 ||
+            (truncated && ZipHeader.Mark == 0x02014b50)) {
             //                if (!truncated && *(lUInt16 *)((char *)&ZipHeader+20)!=0)
             //                    arcComment=true;
             break; //(GETARC_EOF);
         }
-        
-        //const int NM = 513;
-        const int max_NM = 4096;
-        if ( ZipHeader.NameLen>max_NM ) {
-            CRLog::error("ZIP entry name length is too big: %d", (int)ZipHeader.NameLen);
-            return 0;
+#if LVLONG_FILE_SUPPORT == 1
+        int extraPosUnpSize = -1;
+        int extraPosPackSize = -1;
+        int extraPosOffset = -1;
+        int extraLastPos = 0;
+        Zip64ExtInfo *zip64ExtInfo = NULL;
+        if (0xFFFFFFFF == ZipHeader.UnpSize) {
+            extraPosUnpSize = extraLastPos;
+            extraLastPos += 8;
         }
-        lUInt32 SizeToRead=(ZipHeader.NameLen<max_NM) ? ZipHeader.NameLen : max_NM;
-        char fnbuf[max_NM+1];
-        m_stream->Read( fnbuf, SizeToRead, &ReadSize);
-        
-        if (ReadSize!=SizeToRead) {
+        if (0xFFFFFFFF == ZipHeader.PackSize) {
+            extraPosPackSize = extraLastPos;
+            extraLastPos += 8;
+        }
+        if (0xFFFFFFFF == ZipHeader.getOffset()) {
+            extraPosOffset = extraLastPos;
+            extraLastPos += 8;
+        }
+        if (!zip64 && extraLastPos > 0)
+            zip64 = true;
+#endif
+
+        //const lvsize_t NM = 513;
+        const lvsize_t max_NM = 4096;
+        if (ZipHeader.NameLen > max_NM) {
+            CRLog::error("ZIP entry name length is too big: %d, trunc to %d",
+                         (int)ZipHeader.NameLen, (int)max_NM);
+        }
+        lvsize_t fnameSizeToRead = (ZipHeader.NameLen < max_NM) ? ZipHeader.NameLen : max_NM;
+        lvoffset_t NM_skipped_sz = (ZipHeader.NameLen > max_NM) ? (lvoffset_t)(ZipHeader.NameLen - max_NM) : 0;
+        char fnbuf[max_NM + 1];
+        err = m_stream->Read(fnbuf, fnameSizeToRead, &ReadSize);
+        if (err != LVERR_OK || ReadSize != fnameSizeToRead) {
             CRLog::error("error while reading zip entry name");
             return 0;
         }
-        
-        fnbuf[SizeToRead]=0;
-        
-        long SeekLen=ZipHeader.AddLen+ZipHeader.CommLen;
-        
+        fnbuf[fnameSizeToRead] = 0;
+        if (NM_skipped_sz > 0) {
+            if (m_stream->Seek(NM_skipped_sz, LVSEEK_CUR, NULL) != LVERR_OK) {
+                CRLog::error("error while skipping the long zip entry name");
+                return 0;
+            }
+        }
+
+        // read extra data
+        const lvsize_t max_EXTRA = 512;
+        if (ZipHeader.AddLen > max_EXTRA) {
+            CRLog::error("ZIP entry extra length is too big: %d", (int)ZipHeader.AddLen);
+            return 0;
+        }
+        lvsize_t extraSizeToRead = (ZipHeader.AddLen < max_EXTRA) ? ZipHeader.AddLen : max_EXTRA;
+        lUInt8 extra[max_EXTRA];
+        err = m_stream->Read(extra, extraSizeToRead, &ReadSize);
+        if (err != LVERR_OK || ReadSize != extraSizeToRead) {
+            CRLog::error("error while reading zip entry extra data");
+            return 0;
+        }
+#if LVLONG_FILE_SUPPORT == 1
+        // Find Zip64 extension if required
+        lvsize_t offs = 0;
+        Zip64ExtInfo *ext;
+        if (zip64) {
+            while (offs + 4 < extraSizeToRead) {
+                ext = (Zip64ExtInfo *)&extra[offs];
+                ext->byteOrderConv();
+                if (0x0001 == ext->Tag) {
+                    zip64ExtInfo = ext;
+                    break;
+                } else {
+                    offs += 4 + ext->Size;
+                }
+            }
+        }
+#endif
+
+        lUInt32 SeekLen = ZipHeader.CommLen;
         if (truncated)
-            SeekLen+=ZipHeader.PackSize;
-        
+            SeekLen += ZipHeader.PackSize;
         NextOffset = (lvoffset_t)m_stream->GetPos();
         NextOffset += SeekLen;
-        if (NextOffset >= (lvoffset_t)sz) {
-            CRLog::error("invalid offset, stop to read content.");
+        if (NextOffset >= (lvoffset_t)fileSize) {
+            CRLog::error("invalid offset, stop to read contents.");
             break;
         }
 
@@ -289,7 +324,7 @@ int LVZipArc::ReadContents()
             //CRLog::trace("ZIP 6.3: Language encoding flag (EFS) enabled, using UTF-8 encoding.");
             fName = Utf8ToUnicode(fnbuf);
         } else {
-            if (isValidUtf8Data((const unsigned char *)fnbuf, SizeToRead)) {
+            if (isValidUtf8Data((const unsigned char *)fnbuf, fnameSizeToRead)) {
                 //CRLog::trace("autodetected UTF-8 encoding.");
                 fName = Utf8ToUnicode(fnbuf);
             } else {
@@ -298,28 +333,58 @@ int LVZipArc::ReadContents()
                 //  "Win32","SMS/QDOS","Acorn RISC OS","Win32 VFAT","MVS",
                 //  "BeOS","Tandem"};
                 // TODO: try to detect proper charset using 0x0008 Extra Field (InfoZip APPNOTE-6.3.5, Appendix D.4).
-                const lChar32 * enc_name = (ZipHeader.PackOS==0) ? U"cp866" : U"cp1251";
+                const lChar32 *enc_name = (ZipHeader.PackOS == 0) ? U"cp866" : U"cp1251";
                 //CRLog::trace("detected encoding %s", LCSTR(enc_name));
-                const lChar32 * table = GetCharsetByte2UnicodeTable( enc_name );
-                fName = ByteToUnicode( lString8(fnbuf), table );
+                const lChar32 *table = GetCharsetByte2UnicodeTable(enc_name);
+                fName = ByteToUnicode(lString8(fnbuf), table);
             }
         }
-        
-        LVCommonContainerItemInfo * item = new LVCommonContainerItemInfo();
+
+        LVCommonContainerItemInfo *item = new LVCommonContainerItemInfo();
+#if LVLONG_FILE_SUPPORT == 1
+        lvsize_t fileUnpSize = (lvsize_t)ZipHeader.UnpSize;
+        lvsize_t filePackSize = (lvsize_t)ZipHeader.PackSize;
+        lvpos_t fileOffset = (lvpos_t)ZipHeader.getOffset();
+        if (zip64ExtInfo != NULL) {
+            if (extraPosUnpSize >= 0)
+                fileUnpSize = zip64ExtInfo->getField64(extraPosUnpSize);
+            if (extraPosPackSize >= 0)
+                filePackSize = zip64ExtInfo->getField64(extraPosPackSize);
+            if (extraPosOffset >= 0)
+                fileOffset = zip64ExtInfo->getField64(extraPosOffset);
+        }
+        item->SetItemInfo(fName.c_str(), fileUnpSize, (ZipHeader.getAttr() & 0x3f));
+        item->SetSrc(fileOffset, filePackSize, ZipHeader.Method);
+#else
         item->SetItemInfo(fName.c_str(), ZipHeader.UnpSize, (ZipHeader.getAttr() & 0x3f));
-        item->SetSrc( ZipHeader.getOffset(), ZipHeader.PackSize, ZipHeader.Method );
-        
+        item->SetSrc(ZipHeader.getOffset(), ZipHeader.PackSize, ZipHeader.Method);
+#endif
+        m_list.add(item);
+
         //#define DUMP_ZIP_HEADERS
 #ifdef DUMP_ZIP_HEADERS
-        CRLog::trace("ZIP entry '%s' unpSz=%d, pSz=%d, m=%x, offs=%x, zAttr=%x, flg=%x", LCSTR(fName), (int)ZipHeader.UnpSize, (int)ZipHeader.PackSize, (int)ZipHeader.Method, (int)ZipHeader.getOffset(), (int)ZipHeader.getZIPAttr(), (int)ZipHeader.getAttr());
+#if LVLONG_FILE_SUPPORT == 1
+        CRLog::trace("ZIP entry '%s' unpSz=%llu, pSz=%llu, m=%x, offs=%llu, zAttr=%x, flg=%x, addL=%d, commL=%d, dn=%d", LCSTR(fName), fileUnpSize, filePackSize, (int)ZipHeader.Method, fileOffset, (int)ZipHeader.getZIPAttr(), (int)ZipHeader.getAttr(), (int)ZipHeader.AddLen, (int)ZipHeader.CommLen, (int)ZipHeader.DiskNum);
+#else
+        CRLog::trace("ZIP entry '%s' unpSz=%d, pSz=%d, m=%x, offs=%x, zAttr=%x, flg=%x, addL=%d, commL=%d, dn=%d", LCSTR(fName), (int)ZipHeader.UnpSize, (int)ZipHeader.PackSize, (int)ZipHeader.Method, (int)ZipHeader.getOffset(), (int)ZipHeader.getZIPAttr(), (int)ZipHeader.getAttr(), (int)ZipHeader.AddLen, (int)ZipHeader.CommLen, (int)ZipHeader.DiskNum);
+#endif
         //, addL=%d, commL=%d, dn=%d
         //, (int)ZipHeader.AddLen, (int)ZipHeader.CommLen, (int)ZipHeader.DiskNum
+#define EXTRA_DEC_MAX   (1536+1)
+        if (extraSizeToRead > 0) {
+            char extra_buff[EXTRA_DEC_MAX];
+            memset(extra_buff, 0, EXTRA_DEC_MAX);
+            char* ptr = &extra_buff[0];
+            for (lvsize_t i = 0; i < extraSizeToRead; i++) {
+                sprintf(ptr, ":%02X", extra[i]);
+                ptr += 3;
+            }
+            *ptr = 0;
+            CRLog::trace("  ZIP entry extra data: %s", extra_buff);
+        }
 #endif
-        
-        m_list.add(item);
     }
-    int sz2 = m_list.length();
-    return sz2;
+    return m_list.length();
 }
 
 LVArcContainerBase *LVZipArc::OpenArchieve(LVStreamRef stream)
@@ -340,7 +405,7 @@ LVArcContainerBase *LVZipArc::OpenArchieve(LVStreamRef stream)
     if ( itemCount > 0 && arc->isAltReadingMethod() ) {
         CRLog::warn("Zip file truncated: going on with possibly partial content.");
     }
-    else if ( itemCount <= 0 && !arc->isAltReadingMethod() ) {
+    else if ( itemCount == 0 && !arc->isAltReadingMethod() ) {
         CRLog::warn("Zip file corrupted or invalid: trying alternative processing...");
         arc->setAltReadingMethod();
         itemCount = arc->ReadContents();

--- a/crengine/src/lvstream/lvzipdecodestream.h
+++ b/crengine/src/lvstream/lvzipdecodestream.h
@@ -101,7 +101,7 @@ public:
     {
         return LVERR_NOTIMPL;
     }
-    static LVStream * Create( LVStreamRef stream, lvpos_t pos, lString32 name, lUInt32 srcPackSize, lUInt32 srcUnpSize );
+    static LVStream * Create( LVStreamRef stream, lvpos_t pos, lString32 name, lvsize_t srcPackSize, lvsize_t srcUnpSize );
 };
 
 #endif  // (USE_ZLIB==1)

--- a/crengine/src/lvstream/ziphdr.h
+++ b/crengine/src/lvstream/ziphdr.h
@@ -16,6 +16,7 @@
 #include "lvtypes.h"
 
 #pragma pack(push, 1)
+
 typedef struct {
     lUInt32  Mark;      // 0
     lUInt8   UnpVer;    // 4
@@ -57,6 +58,9 @@ typedef struct {
             //cnv.rev( &AddLen );
         }
     }
+    //  Omitted fields (which follow this structure):
+    // FileName (size = NameLen)
+    // ExtraField (size = AddLen)
 } ZipLocalFileHdr;
 
 struct ZipHd2
@@ -70,8 +74,8 @@ struct ZipHd2
     lUInt16     Method; // A
     lUInt32    ftime;   // C
     lUInt32    CRC;     // 10
-    lUInt32    PackSize;// 14
-    lUInt32    UnpSize; // 18
+    lUInt32    PackSize;// 14, ZIP64: if == 0xFFFFFFFF use Zip64ExtInfo
+    lUInt32    UnpSize; // 18, ZIP64: if == 0xFFFFFFFF use Zip64ExtInfo
     lUInt16     NameLen;// 1C
     lUInt16     AddLen; // 1E
     lUInt16     CommLen;// 20
@@ -82,7 +86,7 @@ struct ZipHd2
     lUInt16     _Attr_and_Offset[5];   // 24
     lUInt16     getZIPAttr() { return _Attr_and_Offset[0]; }
     lUInt32     getAttr() { return _Attr_and_Offset[1] | ((lUInt32)_Attr_and_Offset[2]<<16); }
-    lUInt32     getOffset() { return _Attr_and_Offset[3] | ((lUInt32)_Attr_and_Offset[4]<<16); }
+    lUInt32     getOffset() { return _Attr_and_Offset[3] | ((lUInt32)_Attr_and_Offset[4]<<16); }    // ZIP64: if == 0xFFFFFFFF use Zip64ExtInfo
     void        setOffset(lUInt32 offset) {
         _Attr_and_Offset[3] = (lUInt16)(offset & 0xFFFF);
         _Attr_and_Offset[4] = (lUInt16)(offset >> 16);
@@ -111,7 +115,43 @@ struct ZipHd2
             cnv.rev( &_Attr_and_Offset[4] );
         }
     }
+    //  Omitted fields (which follow this structure):
+    // FileName (size = NameLen)
+    // ExtraField (size = AddLen)
+    // FileComment (size = CommLen)
 };
+
+struct Zip64ExtInfo
+{
+    lUInt16 Tag;        // 0x0001
+    lUInt16 Size;       // 4-28
+    lUInt8 data[28];
+
+    void byteOrderConv() {
+        lvByteOrderConv cnv;
+        if ( cnv.msf() ) {
+            cnv.rev( &Tag );
+            cnv.rev( &Size );
+        }
+    }
+    lUInt32 getField32(int pos) {
+        if (pos >= 0 && pos + 3 < Size) {
+            return (lUInt32)data[pos] | (((lUInt32)data[pos + 1]) << 8) |
+                    (((lUInt32)data[pos + 2]) << 16) | (((lUInt32)data[pos + 3]) << 24);
+        }
+        return 0UL;
+    }
+    lUInt64 getField64(int pos) {
+        if (pos >= 0 && pos + 7 < Size) {
+            return (lUInt64)data[pos] | (((lUInt64)data[pos + 1]) << 8) |
+                    (((lUInt64)data[pos + 2]) << 16) | (((lUInt64)data[pos + 3]) << 24) |
+                    (((lUInt64)data[pos + 4]) << 32) | (((lUInt64)data[pos + 5]) << 40) |
+                    (((lUInt64)data[pos + 6]) << 48) | (((lUInt64)data[pos + 7]) << 56);
+        }
+        return 0UL;
+    }
+};
+
 #pragma pack(pop)
 
 #endif  // __ZIPHDR_H_INCLUDED__

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1515,6 +1515,7 @@ bool lString32::atoi( int &n ) const
 
 bool lString32::atoi( lInt64 &n ) const
 {
+    n = 0;
     int sgn = 1;
     const lChar32 * s = c_str();
     while (*s == ' ' || *s == '\t')


### PR DESCRIPTION
ZIP64 fixes:
* Potential memory leak fixed in crengine/src/lvstream/lvziparc.cpp.
Introduced in 01181eb40532ee191a1f8cf4b1f430ddee7876d9 (PR #310).
Thanks to @poire-z : https://github.com/koreader/crengine/pull/454#issuecomment-913805804
* Allows to open/extract inner files beyond 4G limit.
* If a zip64 signature is found but 'large file support' is disabled, do not attempt to scan the zip as a corrupted file (if the OS is capable of handling large files).

Other:
* Fixed wxWidgets build failure: compilation error due to API change. Introduced in c47cab44799475a48230312b8e97cd7a71edddb0.