### PR TITLE
Cloud sync service has been remade to a bound service

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/android/src/org/coolreader/sync2/SyncServiceBinder.java
+++ b/android/src/org/coolreader/sync2/SyncServiceBinder.java
@@ -2,6 +2,8 @@ package org.coolreader.sync2;
 
 import android.os.Binder;
 
+import org.coolreader.crengine.BookInfo;
+
 /**
  * SyncService is used only by the local application and does not need to work across processes.
  * So just extending android.os.Binder class to work with service.
@@ -26,6 +28,22 @@ public class SyncServiceBinder extends Binder {
 
 	public void setOnSyncStatusListener(OnSyncStatusListener listener) {
 		mService.setOnSyncStatusListener(listener);
+	}
+
+	public void startSyncTo(BookInfo bookInfo, int flags) {
+		mService.startSyncTo(bookInfo, flags);
+	}
+
+	public void startSyncFrom(int flags) {
+		mService.startSyncFrom(flags);
+	}
+
+	public void startSyncFromOnly(int flags, Synchronizer.SyncTarget... targets) {
+		mService.startSyncFromOnly(flags, targets);
+	}
+
+	public void startSyncToOnly(BookInfo bookInfo, int flags, Synchronizer.SyncTarget... targets) {
+		mService.startSyncToOnly(bookInfo, flags, targets);
 	}
 
 }


### PR DESCRIPTION
Cloud sync service has been remade to a bound service.
This avoids the exceptions of the ContextWrapper.startService() function: https://developer.android.com/reference/android/content/ContextWrapper#startService(android.content.Intent)
For example, beginning from Android O (API 26) not allowed to start background services from the background.