### PR TITLE
fix deflation of epub files with abnormal zip header

### DIFF
--- a/crengine/src/lvstream/lvzipdecodestream.cpp
+++ b/crengine/src/lvstream/lvzipdecodestream.cpp
@@ -380,11 +380,11 @@ LVStream *LVZipDecodeStream::Create(LVStreamRef stream, lvpos_t pos, lString32 n
     if ( stream->Seek( pos, LVSEEK_SET, NULL )!=LVERR_OK )
         return NULL;
 #endif
-    if ( packSize==0 && unpSize==0 ) {
-        // Can happen when local header does not carry these sizes
-        // Use the ones provided that come from zip central directory
-        packSize = srcPackSize;
-        unpSize = srcUnpSize;
+    {
+        // When local header does not carry these sizes, use the ones
+        // that come from zip central directory
+        if ( packSize==0 ) packSize = srcPackSize;
+        if ( unpSize==0 ) unpSize = srcUnpSize;
     }
     if ((lvpos_t)(pos + packSize) > (lvpos_t)stream->GetSize())
         return NULL;

--- a/crengine/src/lvstream/lvzipdecodestream.cpp
+++ b/crengine/src/lvstream/lvzipdecodestream.cpp
@@ -380,12 +380,12 @@ LVStream *LVZipDecodeStream::Create(LVStreamRef stream, lvpos_t pos, lString32 n
     if ( stream->Seek( pos, LVSEEK_SET, NULL )!=LVERR_OK )
         return NULL;
 #endif
-    {
-        // When local header does not carry these sizes, use the ones
-        // that come from zip central directory
-        if ( packSize==0 ) packSize = srcPackSize;
-        if ( unpSize==0 ) unpSize = srcUnpSize;
-    }
+
+    // When local header does not carry these sizes, use the ones
+    // that come from zip central directory
+    if ( packSize==0 ) packSize = srcPackSize;
+    if ( unpSize==0 ) unpSize = srcUnpSize;
+
     if ((lvpos_t)(pos + packSize) > (lvpos_t)stream->GetSize())
         return NULL;
     if (hdr.getMethod() == 0) {


### PR DESCRIPTION
This fixes zip deflation bug triggered by some watermarked, DRM-free epub file which I bought from a book store. It seems to have been created with Adobe Indesign 9.2.

Cool Reader standalone (as well as KOReader on my Tolino based on crengine, see related issue https://github.com/koreader/koreader/issues/8222) was unable to display it while other readers like the one from Calibre does not have issues. As soon as I extract all contents and re-compress them into a new epub file, Cool Reader did not have issues anymore, so the culprit lies in the binary zip structure of the epub file.

It turned out that packSize was detected as zero within LVZipDecodeStream::Create while unpSize was detected correctly, so the existing workaround did not kick in => I have separated it into two distinct if clauses.

Unfortunately I can't give you the epub due to the watermarking and copyright :-/