### PR TITLE
Thirdparty repo fixes

### DIFF
--- a/thirdparty-deploy.sh
+++ b/thirdparty-deploy.sh
@@ -83,7 +83,7 @@ deploy_package()
 		then
 			rm -f "${SRCFILE}"
 		fi
-		curl -L -O ${URL} || die "Failed to fetch sources!"
+		curl -f -L -O ${URL} || die "Failed to fetch sources!"
 		if [ ! -f "${SRCFILE}" ]
 		then
 			die "Something wrong... source file not found!"
@@ -96,7 +96,7 @@ deploy_package()
 	then
 		# make sha512 sum file
 		echo "${SHA512} *${SRCFILE}" > "${SRCFILE}.sha512"
-		sha512sum -c "${SRCFILE}.sha512" || if [ "x" = "x" ]; then rm -f .downloaded; rm -f "${SRCFILE}.sha512"; die "Failed to verify checksum!"; fi
+                shasum -c "${SRCFILE}.sha512" || if [ "x" = "x" ]; then rm -f .downloaded; rm -f "${SRCFILE}.sha512"; die "Failed to verify checksum!"; fi
 		echo "1" > .verified
 		rm -f "${SRCFILE}.sha512"
 		echo "Checksum OK."

--- a/thirdparty_repo/libjpeg.meta.sh
+++ b/thirdparty_repo/libjpeg.meta.sh
@@ -7,7 +7,7 @@ PV="9.4.0"
 # when version changed, reset to "1".
 REV="1"
 SRCFILE="jpegsrc.v9d.tar.gz"
-SHA512="6515a6f617fc9da7a3d7b4aecc7d78c4ee76159d36309050b7bf9f9672b4e29c2f34b1f4c3d7d65d7f6e2c104c49f53dd2e3b45eac22b1576d2cc54503faf333"
+SHA512="c64d3ee269367351211c077a64b2395f2cfa49b9f8257fae62fa1851dc77933a44b436d8c70ceb52b73a5bedff6dbe560cc5d6e3ed5f2997d724e2ede9582bc3"
 
 URL="http://www.ijg.org/files/${SRCFILE}"
 

--- a/thirdparty_repo/zlib.meta.sh
+++ b/thirdparty_repo/zlib.meta.sh
@@ -2,12 +2,12 @@
 # Metadata for deploy script
 
 PN="zlib"
-PV="1.2.11"
+PV="1.2.12"
 # package revision: when patchset is changed (but not version), increase it
 # when version changed, reset to "1".
 REV="1"
 SRCFILE="${PN}-${PV}.tar.xz"
-SHA512="b7f50ada138c7f93eb7eb1631efccd1d9f03a5e77b6c13c8b757017b2d462e19d2d3e01c50fad60a4ae1bc86d431f6f94c72c11ff410c25121e571953017cb67"
+SHA512="12940e81e988f7661da52fa20bdc333314ae86a621fdb748804a20840b065a1d6d984430f2d41f3a057de0effc6ff9bcf42f9ee9510b88219085f59cbbd082bd"
 
 URL="http://www.zlib.net/${SRCFILE}"
 


### PR DESCRIPTION
* thirdparty management: use shasum instead of sha512sum.
* thirdparty management: when downloading, instruct curl not to save the output on failure.
* thirdparty libjpeg: for any reason remote file jpegsrc.v9d.tar.gz is changed but it's contents is NOT. So it is safely to update SHA512 sum for this file.
* thirdpart zlib: bump to 1.2.12.