### PR TITLE
tts: fix bug where prev/next while paused keeps old utterance in buffer

### DIFF
--- a/android/src/org/coolreader/crengine/TTSToolbarDlg.java
+++ b/android/src/org/coolreader/crengine/TTSToolbarDlg.java
@@ -384,38 +384,39 @@ public class TTSToolbarDlg implements Settings {
 
 				@Override
 				public void onNextSentenceRequested(TTSControlBinder ttsbinder) {
-					if (isSpeaking) {
-						moveSelection(ReaderCommand.DCMD_SELECT_NEXT_SENTENCE, new ReaderView.MoveSelectionCallback() {
-							@Override
-							public void onNewSelection(Selection selection) {
+					moveSelection(ReaderCommand.DCMD_SELECT_NEXT_SENTENCE, new ReaderView.MoveSelectionCallback() {
+						@Override
+						public void onNewSelection(Selection selection) {
+							boolean wasSpeaking = isSpeaking;
+							if (isSpeaking) {
 								ttsbinder.say(preprocessUtterance(selection.text), null);
+							} else {
+								ttsbinder.setCurrentUtterance(preprocessUtterance(selection.text));
 							}
+						}
 
-							@Override
-							public void onFail() {
-							}
-						});
-					} else {
-						moveSelection(ReaderCommand.DCMD_SELECT_NEXT_SENTENCE, null);
-					}
+						@Override
+						public void onFail() {
+						}
+					});
 				}
 
 				@Override
 				public void onPreviousSentenceRequested(TTSControlBinder ttsbinder) {
-					if (isSpeaking) {
-						moveSelection(ReaderCommand.DCMD_SELECT_PREV_SENTENCE, new ReaderView.MoveSelectionCallback() {
-							@Override
-							public void onNewSelection(Selection selection) {
+					moveSelection(ReaderCommand.DCMD_SELECT_PREV_SENTENCE, new ReaderView.MoveSelectionCallback() {
+						@Override
+						public void onNewSelection(Selection selection) {
+							if (isSpeaking) {
 								ttsbinder.say(preprocessUtterance(selection.text), null);
+							} else {
+								ttsbinder.setCurrentUtterance(preprocessUtterance(selection.text));
 							}
+						}
 
-							@Override
-							public void onFail() {
-							}
-						});
-					} else {
-						moveSelection(ReaderCommand.DCMD_SELECT_PREV_SENTENCE, null);
-					}
+						@Override
+						public void onFail() {
+						}
+					});
 				}
 
 				@Override

--- a/android/src/org/coolreader/tts/TTSControlBinder.java
+++ b/android/src/org/coolreader/tts/TTSControlBinder.java
@@ -54,6 +54,10 @@ public class TTSControlBinder extends Binder {
 		mService.say(utterance, callback, new Handler());
 	}
 
+	public void setCurrentUtterance(String utterance) {
+		mService.setCurrentUtterance(utterance);
+	}
+
 	public void pause(TTSControlService.BooleanResultCallback callback) {
 		mService.pause(callback, new Handler());
 	}

--- a/android/src/org/coolreader/tts/TTSControlService.java
+++ b/android/src/org/coolreader/tts/TTSControlService.java
@@ -1095,6 +1095,10 @@ public class TTSControlService extends BaseService {
 		});
 	}
 
+	public void setCurrentUtterance(String utterance) {
+		mCurrentUtterance = utterance;
+	}
+
 	public void pause(BooleanResultCallback callback, Handler handler) {
 		execTask(new Task("pause") {
 			@Override


### PR DESCRIPTION
this fixes the following bug: if you do prev/next while TTS is paused, the next time you hit play, you will get the old sentence.