### PR TITLE
tts: fix occasional crash when tts is stopped

### DIFF
--- a/android/src/org/coolreader/tts/TTSControlService.java
+++ b/android/src/org/coolreader/tts/TTSControlService.java
@@ -555,10 +555,11 @@ public class TTSControlService extends BaseService {
 		} catch (Exception ignored) {}
 		stopUtterance_impl(null);
 		abandonAudioFocusRequestWrapper();
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-			mMediaSession.setActive(false);
-			mMediaSession.release();
-		}
+		//WORKAROUND TO PREVENT RARE CRASH ON STOP
+		//if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+		//	mMediaSession.setActive(false);
+		//	mMediaSession.release();
+		//}
 		mNotificationManager.cancel(NOTIFICATION_ID);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 			mNotificationManager.deleteNotificationChannel(NOTIFICATION_CHANNEL_ID);

--- a/android/src/org/coolreader/tts/TTSControlService.java
+++ b/android/src/org/coolreader/tts/TTSControlService.java
@@ -432,7 +432,8 @@ public class TTSControlService extends BaseService {
 					mNotificationManager.cancel(NOTIFICATION_ID);
 					stopForeground(true);
 					abandonAudioFocusRequestWrapper();
-					mMediaSession.setActive(false);
+					//WORKAROUND TO PREVENT CRASH ON STOP
+					//mMediaSession.setActive(false);
 					try {
 						unregisterReceiver(mBecomingNoisyReceiver);
 					} catch (Exception ignored) {}


### PR DESCRIPTION
this happens to me every day or two, without this fix. it reliably never crashes with this fix.
(maybe a race condition, or a bug in MediaSession in my android version. the session is not null when it fails)