### PR TITLE
android: add a simple state log file

### DIFF
--- a/android/src/org/coolreader/CoolReader.java
+++ b/android/src/org/coolreader/CoolReader.java
@@ -56,6 +56,7 @@ import org.coolreader.crengine.BookmarksDlg;
 import org.coolreader.crengine.BrowserViewLayout;
 import org.coolreader.crengine.CRRootView;
 import org.coolreader.crengine.CRToolBar;
+import org.coolreader.crengine.CRStateFileLogger;
 import org.coolreader.crengine.DeviceInfo;
 import org.coolreader.crengine.DocumentsContractWrapper;
 import org.coolreader.crengine.Engine;
@@ -212,6 +213,10 @@ public class CoolReader extends BaseActivity {
 	 */
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
+		CRStateFileLogger.init(getApplicationContext());
+		CRStateFileLogger.clear();
+		CRStateFileLogger.appendState("APP_CREATE");
+
 		startServices();
 
 		log.i("CoolReader.onCreate() entered");
@@ -283,6 +288,7 @@ public class CoolReader extends BaseActivity {
 
 	@Override
 	protected void onDestroy() {
+		CRStateFileLogger.appendState("APP_DESTROY");
 
 		log.i("CoolReader.onDestroy() entered");
 		if (!CLOSE_BOOK_ON_STOP && mReaderView != null)

--- a/android/src/org/coolreader/crengine/CRStateFileLogger.java
+++ b/android/src/org/coolreader/crengine/CRStateFileLogger.java
@@ -1,0 +1,50 @@
+package org.coolreader.crengine;
+
+import android.content.Context;
+import android.text.format.DateFormat;
+
+import org.coolreader.crengine.L;
+import org.coolreader.crengine.Logger;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import java.util.Date;
+
+public class CRStateFileLogger {
+    private static final String fileName = "cr-state-log.txt";
+    private static File appFilesDir;
+
+    public static final Logger log = L.create("state-logger");
+
+    public static void init(Context applicationContext){
+        appFilesDir = applicationContext.getFilesDir();
+    }
+
+    public static void clear(){
+        File file = new File(appFilesDir, fileName);
+        file.delete();
+    }
+
+    public static void appendState(String state){
+        log.i("writing " + state + " to " + fileName);
+
+        if (appFilesDir == null) {
+            log.e("ERROR: " + fileName + " is not initialized");
+            return;
+        }
+
+        String dtm = DateFormat.format("yyyy-MM-ddTHH:mm:ss", new Date()).toString();
+        String msg = dtm + " - " + state.trim() + "\n";
+
+        try {
+            File file = new File(appFilesDir, fileName);
+            FileOutputStream stream = new FileOutputStream(file, true);
+            stream.write(msg.getBytes());
+            stream.close();
+        } catch (IOException e){
+            log.e("ERROR: could not log to " + fileName);
+        }
+    }
+}

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -2422,7 +2422,9 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 				mActivity.initTTS(ttsacc -> BackgroundThread.instance().executeGUI(() -> {
 					log.i("TTS created: opening TTS toolbar");
 					ttsToolbar = TTSToolbarDlg.showDialog(mActivity, ReaderView.this, ttsacc);
-					ttsToolbar.setOnCloseListener(() -> ttsToolbar = null);
+					ttsToolbar.setOnCloseListener(() -> {
+						ttsToolbar = null;
+					});
 					ttsToolbar.setAppSettings(mSettings, null);
 					ttsToolbar.initAudiobookWordTimings(null);
 				}));

--- a/android/src/org/coolreader/crengine/ReaderView.java
+++ b/android/src/org/coolreader/crengine/ReaderView.java
@@ -58,6 +58,7 @@ import android.view.View.OnTouchListener;
 
 import org.coolreader.CoolReader;
 import org.coolreader.R;
+import org.coolreader.crengine.CRStateFileLogger;
 import org.coolreader.crengine.InputDialog.InputHandler;
 import org.koekak.android.ebookdownloader.SonyBookSelector;
 
@@ -2421,9 +2422,11 @@ public class ReaderView implements android.view.SurfaceHolder.Callback, Settings
 				log.i("DCMD_TTS_PLAY: initializing TTS");
 				mActivity.initTTS(ttsacc -> BackgroundThread.instance().executeGUI(() -> {
 					log.i("TTS created: opening TTS toolbar");
+					CRStateFileLogger.appendState("TTS_ON");
 					ttsToolbar = TTSToolbarDlg.showDialog(mActivity, ReaderView.this, ttsacc);
 					ttsToolbar.setOnCloseListener(() -> {
 						ttsToolbar = null;
+						CRStateFileLogger.appendState("TTS_OFF");
 					});
 					ttsToolbar.setAppSettings(mSettings, null);
 					ttsToolbar.initAudiobookWordTimings(null);

--- a/android/src/org/coolreader/tts/TTSControlService.java
+++ b/android/src/org/coolreader/tts/TTSControlService.java
@@ -51,7 +51,6 @@ import android.speech.tts.Voice;
 
 import org.coolreader.CoolReader;
 import org.coolreader.R;
-import org.coolreader.crengine.CRStateFileLogger;
 import org.coolreader.crengine.L;
 import org.coolreader.crengine.Logger;
 import org.coolreader.crengine.SentenceInfo;
@@ -311,7 +310,6 @@ public class TTSControlService extends BaseService {
 
 	@Override
 	public void onCreate() {
-		CRStateFileLogger.appendState("TTS_CREATE");
 		log.d("onCreate");
 		super.onCreate();
 		mState = State.STOPPED;
@@ -573,7 +571,6 @@ public class TTSControlService extends BaseService {
 
 	@Override
 	public void onDestroy() {
-		CRStateFileLogger.appendState("TTS_DESTROY");
 		log.d("onDestroy");
 		getApplicationContext().getContentResolver().unregisterContentObserver(mVolumeSettingsContentObserver);
 		synchronized (mLocker) {

--- a/android/src/org/coolreader/tts/TTSControlService.java
+++ b/android/src/org/coolreader/tts/TTSControlService.java
@@ -51,6 +51,7 @@ import android.speech.tts.Voice;
 
 import org.coolreader.CoolReader;
 import org.coolreader.R;
+import org.coolreader.crengine.CRStateFileLogger;
 import org.coolreader.crengine.L;
 import org.coolreader.crengine.Logger;
 import org.coolreader.crengine.SentenceInfo;
@@ -310,6 +311,7 @@ public class TTSControlService extends BaseService {
 
 	@Override
 	public void onCreate() {
+		CRStateFileLogger.appendState("TTS_CREATE");
 		log.d("onCreate");
 		super.onCreate();
 		mState = State.STOPPED;
@@ -571,6 +573,7 @@ public class TTSControlService extends BaseService {
 
 	@Override
 	public void onDestroy() {
+		CRStateFileLogger.appendState("TTS_DESTROY");
 		log.d("onDestroy");
 		getApplicationContext().getContentResolver().unregisterContentObserver(mVolumeSettingsContentObserver);
 		synchronized (mLocker) {


### PR DESCRIPTION
writes a single line at startup, shutdown, tts start, and tts stop. it currently writes to the coolreader app dir, but could write to external storage for interfacing with other apps.

i use this to control coolreader TTS audio using the volume up/down buttons while my phone is locked. (if coolreader is running and in TTS mode, play/pause coolreader. otherwise, play/pause my media player).

i have previously used a combination of querying the android media layer, pgrep to see if tts is running, and logcat, which worked a little less reliably and a lot less efficiently.