### PR TITLE
Set CMake policy version lower bound to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(cr3)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5..4.0)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
 

--- a/android/app/CMakeLists.txt
+++ b/android/app/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.5..4.0)
 
 project(cr3engine)
 

--- a/android/app/thirdparty_libs/fribidi/CMakeLists.txt
+++ b/android/app/thirdparty_libs/fribidi/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(local_fribidi C)
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5..4.0)
 
 set(FRIBIDI_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../../../thirdparty/${REPO_FRIBIDI_SRCDIR}")
 set(FRIBIDI_CONFIG_DIR "${PROJECT_SOURCE_DIR}")

--- a/android/app/thirdparty_libs/libunibreak/CMakeLists.txt
+++ b/android/app/thirdparty_libs/libunibreak/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(local_unibreak C)
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5..4.0)
 
 set(LIBUNIBREAK_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../../../thirdparty/${REPO_LIBUNIBREAK_SRCDIR}/src")
 

--- a/crengine/Tools/blend-algo-test/CMakeLists.txt
+++ b/crengine/Tools/blend-algo-test/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(blend-algo-test C)
 
-cmake_minimum_required(VERSION 2.6.2)
+cmake_minimum_required(VERSION 3.5..4.0)
 
 include_directories(${CMAKE_BINARY_DIR})
 


### PR DESCRIPTION
Also specify upper bound as 4.0.

With CMake 4.0 policies before 3.5 will be dropped. CMake 4.0 also
requires the upper bound to be specified.
