### PR TITLE
thirdparty[harfbuzz]: upgrade harfbuzz 2.8.2 => 14.2.1

### DIFF
--- a/android/app/thirdparty_libs/harfbuzz/Android.mk
+++ b/android/app/thirdparty_libs/harfbuzz/Android.mk
@@ -20,19 +20,26 @@ LOCAL_CFLAGS += -DHAVE_CONFIG_H=1
 LOCAL_CFLAGS += -funwind-tables -Wl,--no-merge-exidx-entries
 
 LOCAL_SRC_FILES := \
+    $(HARFBUZZ_SRC_DIR)/src/OT/Var/VARC/VARC.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-aat-layout.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-aat-map.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-blob.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-buffer.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-buffer-serialize.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-buffer-verify.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-common.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-draw.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-face.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-face-builder.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-fallback-shape.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-font.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-paint.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-paint-extents.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-paint-bounded.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ft.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-map.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-number.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-outline.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-cff1-table.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-cff2-table.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-color.cc \
@@ -44,18 +51,18 @@ LOCAL_SRC_FILES := \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-meta.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-metrics.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-name.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-arabic.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-default.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-hangul.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-hebrew.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-indic.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-indic-table.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-khmer.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-myanmar.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-syllabic.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-thai.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-use.cc \
-    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-complex-vowel-constraints.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-arabic.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-default.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-hangul.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-hebrew.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-indic.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-indic-table.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-khmer.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-myanmar.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-syllabic.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-thai.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-use.cc \
+    $(HARFBUZZ_SRC_DIR)/src/hb-ot-shaper-vowel-constraints.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-fallback.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape-normalize.cc \
     $(HARFBUZZ_SRC_DIR)/src/hb-ot-shape.cc \

--- a/android/app/thirdparty_libs/harfbuzz/CMakeLists.txt
+++ b/android/app/thirdparty_libs/harfbuzz/CMakeLists.txt
@@ -10,19 +10,26 @@ include_directories(${HARFBUZZ_CONFIG_DIR})
 add_definitions(-DHAVE_CONFIG_H=1)
 
 set(HARFBUZZ_SRC_FILES
+    ${HARFBUZZ_SRC_DIR}/src/OT/Var/VARC/VARC.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-aat-layout.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-aat-map.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-blob.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-buffer.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-buffer-serialize.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-buffer-verify.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-common.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-draw.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-face.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-face-builder.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-fallback-shape.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-font.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-paint.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-paint-extents.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-paint-bounded.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ft.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-map.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-number.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-outline.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-cff1-table.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-cff2-table.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-color.cc
@@ -34,18 +41,18 @@ set(HARFBUZZ_SRC_FILES
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-meta.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-metrics.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-name.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-arabic.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-default.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-hangul.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-hebrew.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-indic.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-indic-table.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-khmer.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-myanmar.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-syllabic.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-thai.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-use.cc
-    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-complex-vowel-constraints.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-arabic.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-default.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-hangul.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-hebrew.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-indic.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-indic-table.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-khmer.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-myanmar.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-syllabic.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-thai.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-use.cc
+    ${HARFBUZZ_SRC_DIR}/src/hb-ot-shaper-vowel-constraints.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-fallback.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape-normalize.cc
     ${HARFBUZZ_SRC_DIR}/src/hb-ot-shape.cc

--- a/android/app/thirdparty_libs/harfbuzz/config.h
+++ b/android/app/thirdparty_libs/harfbuzz/config.h
@@ -134,7 +134,7 @@
 #define PACKAGE_NAME "HarfBuzz"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "HarfBuzz 2.8.0"
+#define PACKAGE_STRING "HarfBuzz 14.2.1"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "harfbuzz"
@@ -143,7 +143,7 @@
 #define PACKAGE_URL "http://harfbuzz.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.8.0"
+#define PACKAGE_VERSION "14.2.1"
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */


### PR DESCRIPTION
updated dependency to fix build error in audiobook_in_tts
modern C++ prevents compiling any harfbuzz version < 9.0.0 for me
